### PR TITLE
[WIP] Revert "[minor] Use Maven wrapper to run unit tests"

### DIFF
--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -146,7 +146,7 @@ function k8s() {
 
 function data_plane_unit_tests() {
   pushd ${DATA_PLANE_DIR} || fail_test
-  ./mvnw clean verify -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=6 --no-transfer-progress
+  mvn clean verify -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=6 --no-transfer-progress
   mvn_output=$?
 
   echo "Copy test reports in ${ARTIFACTS}"


### PR DESCRIPTION
I don't know if using the wrapper is the problem of CI flakiness.

Reverts knative-sandbox/eventing-kafka-broker#1281