### PR TITLE
[Java 17] Changing some images

### DIFF
--- a/data-plane/docker/Dockerfile
+++ b/data-plane/docker/Dockerfile
@@ -24,9 +24,6 @@ ARG APP_JAR
 
 WORKDIR /build
 
-# https://github.com/AdoptOpenJDK/openjdk-docker/issues/260
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y binutils
-
 COPY pom.xml .
 COPY .editorconfig .
 COPY core/pom.xml core/pom.xml

--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -43,8 +43,8 @@ readonly dispatcher="${KNATIVE_KAFKA_BROKER_DISPATCHER:-knative-kafka-broker-dis
 
 # The BASE_IMAGE must have system libraries (libc, zlib, etc) compatible with the JAVA_IMAGE because
 # Jlink generates a jdk linked to the same system libraries available on the base images.
-readonly BASE_IMAGE=gcr.io/distroless/java-debian10:base-nonroot # Based on debian:buster
-readonly JAVA_IMAGE=docker.io/adoptopenjdk/openjdk16:debian      # Based on debian:buster
+readonly BASE_IMAGE=gcr.io/distroless/java-debian11:base-nonroot  # Based on debian:buster
+readonly JAVA_IMAGE=docker.io/eclipse-temurin:17-jdk-centos7      # Based on centos7
 
 readonly RECEIVER_JAR="receiver-1.0-SNAPSHOT.jar"
 readonly RECEIVER_DIRECTORY=receiver


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

`adoptopenjdk` is deprecated, and we now have `adoptium`:
* https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/

And images are now [here](https://hub.docker.com/_/eclipse-temurin)

There is no debian-based java image any more, hence I removed also the DEBIAN related `apt` calls.

NOTE: I'd like to also switch the base image to a distroless centos

/assign @pierDipi 