### PR TITLE
Remove Trigger finalizer when Broker is removed

### DIFF
--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -119,6 +119,10 @@ func filterTriggers(lister eventinglisters.BrokerLister) func(interface{}) bool 
 			return false
 		}
 
+		if hasKafkaBrokerTriggerFinalizer(trigger.Finalizers, FinalizerName) {
+			return true
+		}
+
 		broker, err := lister.Brokers(trigger.Namespace).Get(trigger.Spec.Broker)
 		if err != nil {
 			return false
@@ -127,6 +131,15 @@ func filterTriggers(lister eventinglisters.BrokerLister) func(interface{}) bool 
 		value, ok := broker.GetAnnotations()[apiseventing.BrokerClassKey]
 		return ok && value == kafka.BrokerClass
 	}
+}
+
+func hasKafkaBrokerTriggerFinalizer(finalizers []string, finalizerName string) bool {
+	for _, f := range finalizers {
+		if f == finalizerName {
+			return true
+		}
+	}
+	return false
 }
 
 func enqueueTriggers(


### PR DESCRIPTION
This bug is reproducible in this situation:

- Create Kafka Broker `b1`
- Create a trigger `t1` associated with `b1`
- Remove Kafka Broker `b1`
- Remove Trigger `t1`

`t1` will be in `Terminating` state forever since our
reconciler will not reconcile it since we can't know
if Trigger is our trigger given that there is not `b1`.

## Proposed Changes

- Remove Trigger finalizer when Broker is removed

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```
