### PR TITLE
Get rid of `func (f NewClusterAdminFunc) IsTopicPresentAndValid(...)`

### DIFF
--- a/control-plane/pkg/reconciler/kafka/topic.go
+++ b/control-plane/pkg/reconciler/kafka/topic.go
@@ -103,14 +103,7 @@ func DeleteTopic(admin sarama.ClusterAdmin, topic string) (string, error) {
 	return topic, nil
 }
 
-func (f NewClusterAdminFunc) IsTopicPresentAndValid(topic string, bootstrapServers []string, secOptions security.ConfigOption) (bool, error) {
-
-	kafkaClusterAdmin, err := GetClusterAdmin(f, bootstrapServers, secOptions)
-	if err != nil {
-		return false, err
-	}
-	defer kafkaClusterAdmin.Close()
-
+func IsTopicPresentAndValid(kafkaClusterAdmin sarama.ClusterAdmin, topic string, bootstrapServers []string, secOptions security.ConfigOption) (bool, error) {
 	metadata, err := kafkaClusterAdmin.DescribeTopics([]string{topic})
 	if err != nil {
 		return false, fmt.Errorf("failed to describe topic %s: %w", topic, err)


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Same with https://github.com/knative-sandbox/eventing-kafka-broker/pull/1355, except this time I delete  `IsTopicPresentAndValid`
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
