### PR TITLE
Fix and refactor is valid topic check

### DIFF
--- a/control-plane/pkg/reconciler/base/receiver_condition_set.go
+++ b/control-plane/pkg/reconciler/base/receiver_condition_set.go
@@ -59,7 +59,7 @@ const (
 	ReasonDataPlaneNotAvailable  = "Data plane not available"
 	MessageDataPlaneNotAvailable = "Did you install the data plane for this component?"
 
-	ReasonTopicNotPresent = "Topic is not present"
+	ReasonTopicNotPresentOrInvalid = "Topic is not present or invalid"
 )
 
 type Object interface {
@@ -229,24 +229,24 @@ func (manager *StatusConditionManager) ConfigResolved() {
 	manager.Object.GetConditionSet().Manage(manager.Object.GetStatus()).MarkTrue(ConditionConfigParsed)
 }
 
-func (manager *StatusConditionManager) TopicNotPresentOrInvalidErr(err error) error {
+func (manager *StatusConditionManager) TopicsNotPresentOrInvalidErr(topics []string, err error) error {
 	manager.Object.GetConditionSet().Manage(manager.Object.GetStatus()).MarkFalse(
 		ConditionTopicReady,
-		ReasonTopicNotPresent,
+		ReasonTopicNotPresentOrInvalid,
+		"topics %v: %s",
+		topics,
 		err.Error(),
 	)
 
-	return fmt.Errorf("topic is not present: %w", err)
+	return fmt.Errorf("topics %v not present or invalid: %w", topics, err)
 }
 
-func (manager *StatusConditionManager) TopicNotPresentOrInvalid() error {
-
+func (manager *StatusConditionManager) TopicsNotPresentOrInvalid(topics []string) error {
 	manager.Object.GetConditionSet().Manage(manager.Object.GetStatus()).MarkFalse(
 		ConditionTopicReady,
-		ReasonTopicNotPresent,
-		"Check topic configuration",
+		ReasonTopicNotPresentOrInvalid,
+		"Check topics %v configuration",
+		topics,
 	)
-
-	return fmt.Errorf("topic is not present: check topic configuration")
-
+	return fmt.Errorf("topics %v not present or invalid: check topic configuration", topics)
 }

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -126,13 +126,13 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		// If the topic is externally managed, we need to make sure that the topic exists and it's valid.
 		ks.GetStatus().Annotations[base.TopicOwnerAnnotation] = ExternalTopicOwner
 
-		isPresentAndValid, err := kafka.IsTopicPresentAndValid(kafkaClusterAdmin, ks.Spec.Topic)
+		isPresentAndValid, err := kafka.AreTopicsPresentAndValid(kafkaClusterAdmin, ks.Spec.Topic)
 		if err != nil {
-			return statusConditionManager.TopicNotPresentOrInvalidErr(err)
+			return statusConditionManager.TopicsNotPresentOrInvalidErr([]string{ks.Spec.Topic}, err)
 		}
 		if !isPresentAndValid {
 			// The topic might be invalid.
-			return statusConditionManager.TopicNotPresentOrInvalid()
+			return statusConditionManager.TopicsNotPresentOrInvalid([]string{ks.Spec.Topic})
 		}
 	}
 	statusConditionManager.TopicReady(ks.Spec.Topic)

--- a/control-plane/pkg/reconciler/sink/kafka_sink_test.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink_test.go
@@ -295,8 +295,8 @@ func sinkReconciliation(t *testing.T, format string, configs broker.Configs) {
 				Eventf(
 					corev1.EventTypeWarning,
 					"InternalError",
-					"topic is not present: "+SinkNotPresentErrFormat,
-					SinkTopic(), io.EOF,
+					"topics %v not present or invalid: "+SinkNotPresentErrFormat,
+					[]string{SinkTopic()}, []string{SinkTopic()}, io.EOF,
 				),
 			},
 			WantErr: true,
@@ -1069,6 +1069,7 @@ func useTable(t *testing.T, table TableTest, configs *broker.Configs) {
 				metadata = append(metadata, &sarama.TopicMetadata{
 					Name:       topic,
 					IsInternal: false,
+					Partitions: []*sarama.PartitionMetadata{{}},
 				})
 			}
 		}
@@ -1097,8 +1098,8 @@ func useTable(t *testing.T, table TableTest, configs *broker.Configs) {
 					ErrorOnCreateTopic:                     onCreateTopicError,
 					ErrorOnDeleteTopic:                     onDeleteTopicError,
 					ExpectedTopics:                         expectedTopicsOnDescribeTopics,
-					ExpectedTopicsMetadataOnDescribeTopics: metadata,
 					ExpectedErrorOnDescribeTopics:          errorOnDescribeTopics,
+					ExpectedTopicsMetadataOnDescribeTopics: metadata,
 					T:                                      t,
 				}, nil
 			},

--- a/control-plane/pkg/reconciler/source/source_test.go
+++ b/control-plane/pkg/reconciler/source/source_test.go
@@ -434,6 +434,11 @@ func TestReconcileKind(t *testing.T) {
 func useTable(t *testing.T, table TableTest, configs broker.Configs) {
 	table.Test(t, NewFactory(&configs, func(ctx context.Context, listers *Listers, configs *broker.Configs, row *TableRow) controller.Reconciler {
 
+		var topicMetadata []*sarama.TopicMetadata
+		for _, t := range SourceTopics {
+			topicMetadata = append(topicMetadata, &sarama.TopicMetadata{Name: t, Partitions: []*sarama.PartitionMetadata{{}}})
+		}
+
 		reconciler := &Reconciler{
 			Reconciler: &base.Reconciler{
 				KubeClient:                  kubeclient.Get(ctx),
@@ -456,7 +461,7 @@ func useTable(t *testing.T, table TableTest, configs broker.Configs) {
 					ExpectedCloseError:                     nil,
 					ExpectedTopics:                         SourceTopics,
 					ExpectedErrorOnDescribeTopics:          nil,
-					ExpectedTopicsMetadataOnDescribeTopics: nil,
+					ExpectedTopicsMetadataOnDescribeTopics: topicMetadata,
 					T:                                      t,
 				}, nil
 			},

--- a/control-plane/pkg/reconciler/testing/objects_sink.go
+++ b/control-plane/pkg/reconciler/testing/objects_sink.go
@@ -45,7 +45,7 @@ const (
 	SinkNumPartitions     = 10
 	SinkReplicationFactor = 3
 
-	SinkNotPresentErrFormat = "failed to describe topic %s: %v"
+	SinkNotPresentErrFormat = "failed to describe topics %v: %v"
 
 	topicPrefix = "knative-sink-"
 )
@@ -149,8 +149,8 @@ func SinkTopicNotPresentErr(topic string, err error) func(sink *eventing.KafkaSi
 	return func(sink *eventing.KafkaSink) {
 		sink.GetConditionSet().Manage(sink.GetStatus()).MarkFalse(
 			base.ConditionTopicReady,
-			base.ReasonTopicNotPresent,
-			fmt.Sprintf(SinkNotPresentErrFormat, topic, err),
+			base.ReasonTopicNotPresentOrInvalid,
+			fmt.Sprintf("topics %v: "+SinkNotPresentErrFormat, []string{topic}, []string{topic}, err),
 		)
 	}
 }


### PR DESCRIPTION
- Topic is valid check wasn't working since sarama returns
  topic metadata even when there is no topic present.
- Remove unused parameters
- Support checking the validity of multiple topics in one
  request.

Signed-off-by: Pierangelo Di Pilato <pdipilat@redhat.com>

Part of #312 

## Proposed Changes

- Fix and refactor topic validity checks

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```