### PR TITLE
Ignore lint for generated contract code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,7 @@
 /pkg/**/testing/** coverage-excluded=true
 /vendor/** coverage-excluded=true
 /test/** coverage-excluded=true
+
+# ignore-lint is an attribute to explicitly exclude a patch from being linted.
+/control-plane/pkg/contract/*.pb.go ignore-lint=true
+/data-plane/contract/src/main/java/** ignore-lint=true


### PR DESCRIPTION
When we change the contract the linter complains about the generated code,
this is an attempt to fix it.

It's using a new feature of the linter action
https://github.com/knative-sandbox/.github/pull/142.

## Proposed Changes

- Ignore lint for generated contract code
