### PR TITLE
KafkaChannel and KafkaSource lease remappings

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-leader-election.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-leader-election.yaml
@@ -45,3 +45,5 @@ data:
   leaseDuration: "15s"
   renewDeadline: "10s"
   retryPeriod: "2s"
+  map-lease-prefix.kafka-broker-controller.knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.source.Reconciler: kafka-controller.knative.dev.eventing-kafka.pkg.source.reconciler.source.reconciler
+  map-lease-prefix.kafka-broker-controller.knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.channel.Reconciler: kafkachannel-controller.knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.reconciler

--- a/hack/control-plane.sh
+++ b/hack/control-plane.sh
@@ -21,6 +21,6 @@ readonly CONTROL_PLANE_POST_INSTALL_CONFIG_DIR=control-plane/config/post-install
 
 # Note: do not change this function name, it's used during releases.
 function control_plane_setup() {
-  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
-  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_POST_INSTALL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
+  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
+  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_POST_INSTALL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >"${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -108,6 +108,7 @@ function build_components_from_source() {
   [ -f "${EVENTING_KAFKA_BROKER_ARTIFACT}" ] && rm "${EVENTING_KAFKA_BROKER_ARTIFACT}"
   [ -f "${EVENTING_KAFKA_SINK_ARTIFACT}" ] && rm "${EVENTING_KAFKA_SINK_ARTIFACT}"
   [ -f "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" ] && rm "${EVENTING_KAFKA_CHANNEL_ARTIFACT}"
+  [ -f "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" ] && rm "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}"
 
   header "Data plane setup"
   data_plane_setup || fail_test "Failed to set up data plane components"

--- a/test/e2e_new/features/leases.go
+++ b/test/e2e_new/features/leases.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package features
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+func KafkaChannelLease() *feature.Feature {
+	f := feature.NewFeatureNamed("KafkaChannel lease")
+
+	f.Assert("verify lease name", verifyLeaseAcquired(
+		"kafkachannel-controller.knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.reconciler.00-of-01",
+	))
+
+	return f
+}
+
+func KafkaSourceLease() *feature.Feature {
+	f := feature.NewFeatureNamed("KafkaSource lease")
+
+	f.Assert("verify lease name", verifyLeaseAcquired(
+		"kafka-controller.knative.dev.eventing-kafka.pkg.source.reconciler.source.reconciler.00-of-01",
+	))
+
+	return f
+}
+
+func verifyLeaseAcquired(name string) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		err := wait.Poll(time.Second, time.Minute, func() (done bool, err error) {
+			lease, err := kubeclient.Get(ctx).
+				CoordinationV1().
+				Leases(system.Namespace()).
+				Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal("failed to get lease %s/%s: %v", system.Namespace(), name, err)
+			}
+
+			return lease.Spec.HolderIdentity != nil &&
+				strings.HasPrefix(*lease.Spec.HolderIdentity, "kafka-controller"), nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/test/e2e_new/lease_test.go
+++ b/test/e2e_new/lease_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_new
+
+import (
+	"testing"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing-kafka-broker/test/e2e_new/features"
+)
+
+func TestLeaseAcquired(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.KafkaChannelLease())
+	env.Test(ctx, t, features.KafkaSourceLease())
+}


### PR DESCRIPTION
Remap lease names to follow existing KafkaSource and
KafkaChannel leases.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>