### PR TITLE
Post install migration logic for triggerv2 and channelv2

### DIFF
--- a/control-plane/cmd/post-install/kafka_broker_deleter.go
+++ b/control-plane/cmd/post-install/kafka_broker_deleter.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+type kafkaBrokerDeleter struct {
+	k8s kubernetes.Interface
+}

--- a/control-plane/cmd/post-install/main.go
+++ b/control-plane/cmd/post-install/main.go
@@ -102,5 +102,19 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("channel post-deletion failed: %w", err)
 	}
 
+	channelDispatcherDeleter := &kafkaChannelPostMigrationDeleter{
+		k8s: kubernetes.NewForConfigOrDie(config),
+	}
+	if err := channelDispatcherDeleter.DeleteDispatcher(ctx); err != nil {
+		return fmt.Errorf("channel dispatcher deletion failed: %w", err)
+	}
+
+	brokerDispatcherDeleter := &kafkaBrokerDeleter{
+		k8s: kubernetes.NewForConfigOrDie(config),
+	}
+	if err := brokerDispatcherDeleter.DeleteDispatcher(ctx); err != nil {
+		return fmt.Errorf("broker dispatcher deletion failed: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Breaking down https://github.com/knative-sandbox/eventing-kafka-broker/pull/2437 into smaller PRs.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Added migration logic in post-install for deleting old dispatcher deployment

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Added migration logic in post-install for deleting old dispatcher deployments for broker and channel.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
