### PR TITLE
replaced error to stop consumer from reconciling with exponentially delay

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_lifecycle.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_lifecycle.go
@@ -61,7 +61,10 @@ func (cg *ConsumerGroup) MarkReconcileConsumersFailedCondition(condition *apis.C
 		condition.GetMessage(),
 	)
 
-	return fmt.Errorf("consumers aren't ready, %v: %v", condition.GetReason(), condition.GetMessage())
+	// It is "normal" to have non-ready consumers, and we will get notified when their status change,
+	// so we don't need to return an error here which causes the object to be queued with an
+	// exponentially increasing delay.
+	return nil
 }
 
 func (cg *ConsumerGroup) MarkReconcileConsumersSucceeded() {


### PR DESCRIPTION
Fixes #3046

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- I replaced the returned error, which prevents the consumer group from being reconciled again, with an exponentially increasing delay which eventually caused a slow time to ready.