### PR TITLE
Add missing addresses field to broker finalizer

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -358,7 +358,8 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	address := receiver.HTTPAddress(ingressHost, broker)
 	proberAddressable := prober.NewAddressable{
 		AddressStatus: &duckv1.AddressStatus{
-			Address: &address,
+			Address:   &address,
+			Addresses: []duckv1.Addressable{address},
 		},
 		ResourceKey: types.NamespacedName{
 			Namespace: broker.GetNamespace(),


### PR DESCRIPTION
The broker finalizeKind probe should have the address in the `NewProber.Addresses` field as well, because the composite prober only probes addresses in that list.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add the address to the `Addresses` field
