### PR TITLE
Propagate ClusterConfiguration in kind correctly

### DIFF
--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -45,10 +45,7 @@ containerdConfigPatches:
 # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
-    metadata:
-      name: config
     apiServer:
       extraArgs:
         "service-account-issuer": "kubernetes.default.svc"


### PR DESCRIPTION
During https://github.com/knative/eventing/pull/7140 I saw, that the ClusterConfiguration is not used correctly (e.g. the cluster domain not set correctly). This is due to an old apiVersion field, which (according to https://github.com/kubernetes-sigs/kind/issues/1466#issuecomment-675664846) can be dropped.
Also the `metadata.name` field can be dropped ([kind docu: kubeadm-config-patches](https://kind.sigs.k8s.io/docs/user/configuration/#kubeadm-config-patches)).
With this fix, configs, like the CLUSTER_SUFFIX will be propagated correctly to kubeadm again.