### PR TITLE
Make SecretSpec field of consumers Auth omitempty

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_types.go
@@ -127,7 +127,7 @@ type Auth struct {
 	NetSpec *bindings.KafkaNetSpec
 	// Deprecated, use secret spec
 	AuthSpec   *eventingv1alpha1.Auth `json:"AuthSpec,omitempty"`
-	SecretSpec *SecretSpec
+	SecretSpec *SecretSpec            `json:"SecretSpec,omitempty"`
 }
 
 type SecretSpec struct {


### PR DESCRIPTION
This will prevent writing SecretSpec with null value and the webhook will rather omit the element. 
```
 spec:
        auth:
          SecretSpec: null
```
Having the element there with null value can also caus problems during downgrades when the element was not there yet (it's a few versions back though)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
