### PR TITLE
Fix slow consumergroup reconciliation under load

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_lifecycle.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_lifecycle.go
@@ -61,7 +61,10 @@ func (cg *ConsumerGroup) MarkReconcileConsumersFailedCondition(condition *apis.C
 		condition.GetMessage(),
 	)
 
-	return fmt.Errorf("consumers aren't ready, %v: %v", condition.GetReason(), condition.GetMessage())
+	// It is "normal" to have non-ready consumers, and we will get notified when their status change,
+	// so we don't need to return an error here which causes the object to be queued with an
+	// exponentially increasing delay.
+	return nil
 }
 
 func (cg *ConsumerGroup) MarkReconcileConsumersSucceeded() {

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
@@ -399,7 +399,7 @@ func TestReconcileKind(t *testing.T) {
 					}, nil
 				}),
 			},
-			WantErr: true,
+			WantErr: false,
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
 					ConsumerSpec(NewConsumerSpec(
@@ -465,7 +465,6 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantEvents: []string{
 				finalizerUpdatedEvent,
-				"Warning InternalError consumers aren't ready, ConsumerBinding: failed to bind resource to pod: EOF",
 			},
 		},
 		{


### PR DESCRIPTION
In [1], we return an error, however, that method is called in the consumer group reconciler when a consumer is not ready which is a normal state at the beginning when consumers have been just created, so we shouldn't return an error because that causes the consumer group to be reconciled again with an exponentially increasing delay causing slow time to ready.

This is especially evident when scaling up with a high load = (therefore when dispatcher pod is slow to become ready).

[1] https://github.com/knative-sandbox/eventing-kafka-broker/blob/5cda5463aa2fa060179674fe7b3237abb836ee06/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_lifecycle.go#L57-L65

Fixes #3046 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix slow consumergroup reconciliation under load

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fix slow `ConsumerGroup` reconciliation under load
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
