### PR TITLE
Fix channel finalizer logic

### DIFF
--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -68,6 +68,9 @@ const (
 	NewChannelIngressServiceName = "kafka-channel-ingress"
 	kafkaChannelTLSSecretName    = "kafka-channel-ingress-server-tls" //nolint:gosec // This is not a hardcoded credential
 	caCertsSecretKey             = "ca.crt"
+	// TopicPrefix is the old Kafka Channel topic prefix - we keep this constant so that deleting channels shortly after upgrading
+	// does not have issues. See https://github.com/knative-extensions/eventing-kafka-broker/issues/3289 for more info
+	TopicPrefix = "knative-messaging-kafka"
 )
 
 type Reconciler struct {
@@ -494,7 +497,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 
 	topicName, ok := channel.Status.Annotations[kafka.TopicAnnotation]
 	if !ok {
-		return fmt.Errorf("no topic annotated on channel")
+		topicName = kafka.ChannelTopic(TopicPrefix, channel)
 	}
 	topic, err := kafka.DeleteTopic(kafkaClusterAdminClient, topicName)
 	if err != nil {


### PR DESCRIPTION
Fixes #3289 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use the old channel topic name function to figure out which topic to delete when no topic is annotated


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug: Fixed bug where deleting channels shortly after upgrading from pre 1.10 Knative threw an error.
```

