### PR TITLE
Fixing: `NullPointerException` occurring and it's discarding the records while tracing for Loom deployment

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -139,7 +139,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
         if (this.isPollInFlight.compareAndSet(false, true)) {
             logger.debug("Polling for records {}", getConsumerVerticleContext().getLoggingKeyValue());
 
-            this.consumer.poll(POLLING_TIMEOUT).onSuccess(this::recordsHandler).onFailure(t -> {
+            this.consumer.poll(POLLING_TIMEOUT).onSuccess(records -> vertx.runOnContext(v -> this.recordsHandler(records))).onFailure(t -> {
                 if (this.closed.get()) {
                     // The failure might have been caused by stopping the consumer, so we just ignore it
                     return;

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -139,14 +139,17 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
         if (this.isPollInFlight.compareAndSet(false, true)) {
             logger.debug("Polling for records {}", getConsumerVerticleContext().getLoggingKeyValue());
 
-            this.consumer.poll(POLLING_TIMEOUT).onSuccess(records -> vertx.runOnContext(v -> this.recordsHandler(records))).onFailure(t -> {
-                if (this.closed.get()) {
-                    // The failure might have been caused by stopping the consumer, so we just ignore it
-                    return;
-                }
-                isPollInFlight.set(false);
-                exceptionHandler(t);
-            });
+            this.consumer
+                    .poll(POLLING_TIMEOUT)
+                    .onSuccess(records -> vertx.runOnContext(v -> this.recordsHandler(records)))
+                    .onFailure(t -> {
+                        if (this.closed.get()) {
+                            // The failure might have been caused by stopping the consumer, so we just ignore it
+                            return;
+                        }
+                        isPollInFlight.set(false);
+                        exceptionHandler(t);
+                    });
         }
     }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -97,15 +97,18 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
             return;
         }
         if (this.isPollInFlight.compareAndSet(false, true)) {
-            this.consumer.poll(POLL_TIMEOUT).onSuccess(records -> vertx.runOnContext(v -> this.handleRecords(records))).onFailure(cause -> {
-                isPollInFlight.set(false);
-                logger.error(
-                        "Failed to poll messages {}",
-                        getConsumerVerticleContext().getLoggingKeyValue(),
-                        cause);
-                // Wait before retrying.
-                vertx.setTimer(BACKOFF_DELAY_MS, t -> poll());
-            });
+            this.consumer
+                    .poll(POLL_TIMEOUT)
+                    .onSuccess(records -> vertx.runOnContext(v -> this.handleRecords(records)))
+                    .onFailure(cause -> {
+                        isPollInFlight.set(false);
+                        logger.error(
+                                "Failed to poll messages {}",
+                                getConsumerVerticleContext().getLoggingKeyValue(),
+                                cause);
+                        // Wait before retrying.
+                        vertx.setTimer(BACKOFF_DELAY_MS, t -> poll());
+                    });
         }
     }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -97,7 +97,7 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
             return;
         }
         if (this.isPollInFlight.compareAndSet(false, true)) {
-            this.consumer.poll(POLL_TIMEOUT).onSuccess(this::handleRecords).onFailure(cause -> {
+            this.consumer.poll(POLL_TIMEOUT).onSuccess(records -> vertx.runOnContext(v -> this.handleRecords(records))).onFailure(cause -> {
                 isPollInFlight.set(false);
                 logger.error(
                         "Failed to poll messages {}",


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
### Problem

Current Loom Dispatcher was not working properly and there is no events retrieving on that side.

The Problem we find is that when we are using loom modules the ConsumerTracer (which is using vertx opentelemetry), is a `NullPointerException` occurring and it's discarding the records.
```sh
"stack_trace":"java.lang.NullPointerException": 
Cannot invoke "io.vertx.core.Context.getLocal(Object)" because "vertxCtx" is null
   at io.vertx.tracing.opentelemetry.VertxContextStorageProvider$VertxContextStorage.attach(VertxContextStorageProvider.java:27)
   at io.vertx.tracing.opentelemetry.OpenTelemetryTracer.receiveRequest(OpenTelemetryTracer.java:70)
   at io.vertx.tracing.opentelemetry.OpenTelemetryTracer.receiveRequest(OpenTelemetryTracer.java:31)
   at dev.knative.eventing.kafka.broker.core.tracing.kafka.ConsumerTracer.prepareMessageReceived(ConsumerTracer.java:88)
   at dev.knative.eventing.kafka.broker.dispatcher.impl.RecordDispatcherImpl.getStartedSpan(RecordDispatcherImpl.java:485)
```


## Proposed Changes

As for the Solution we have here is we handle the records inside the current Vertx Context. So that when for the tracing we try to get the currentContext we get the context instead of `null` https://github.com/knative-extensions/eventing-kafka-broker/blob/c6e8f3c4c5c74917f36b3d30fc8bc3ffbccce8e2/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java#L203-L205


/cc @pierDipi @matzew 
<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
