### PR TITLE
Change the name of the secretVolumePath

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -36,7 +36,7 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
     private final HttpServerOptions httpServerOptions;
     private final HttpServerOptions httpsServerOptions;
 
-    private final String secretVolumePath = "/etc/receiver-secret-volume";
+    private final String secretVolumePath = "/etc/receiver-tls-secret";
 
     private final IngressRequestHandler ingressRequestHandler;
 


### PR DESCRIPTION
Fixes #3302

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
The name should be etc/receiver-tls-secret instead of /etc/receiver-secret-volume
