### PR TITLE
Fix multiple time Promise complete problem

### DIFF
--- a/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
+++ b/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
@@ -55,6 +55,7 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
     private void addTask(Runnable task, Promise<?> promise) {
         if (isClosed.get()) {
             promise.fail("Consumer is closed");
+            return;
         }
         taskQueue.add(task);
     }
@@ -65,6 +66,7 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
                 taskQueue.take().run();
             } catch (InterruptedException e) {
                 logger.debug("Interrupted while waiting for task", e);
+                break;
             }
         }
     }
@@ -105,10 +107,10 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
                 }
                 taskRunnerThread.interrupt();
                 taskRunnerThread.join();
-                promise.complete();
+                promise.tryComplete();
             } catch (InterruptedException e) {
                 logger.debug("Interrupted while waiting for taskRunnerThread to finish", e);
-                promise.fail(e);
+                promise.tryFail(e);
             }
         });
         return promise.future();


### PR DESCRIPTION
Fixes #3309

From my inspection what might happening here is that After we are close the consumer, though we are failing the corresponding task promise still taskRunnerThread is still taking the task as we are not returning from the function.
https://github.com/knative-extensions/eventing-kafka-broker/blob/1e369784b4161dfb9a35eabe96b0db618991213b/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java#L55-L59

Other than that I also saw a exception while we are trying close the consumer. Though it is the Interrupted exception that is expected, but there is a possibility that the `consumer.close()` method fail. and we try to complete it again while we stop taskRunnerThread here
https://github.com/knative-extensions/eventing-kafka-broker/blob/1e369784b4161dfb9a35eabe96b0db618991213b/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java#L106-L112


/cc @pierDipi 