### PR TITLE
Added Spotless Script to hack/run.sh

### DIFF
--- a/hack/run.sh
+++ b/hack/run.sh
@@ -95,8 +95,9 @@ elif [[ "${action}" == "benchmark-filter" ]]; then
   "${ROOT_DIR}/data-plane/benchmarks/run.sh" "$2"
 elif [[ "${action}" == "benchmark-filters" ]]; then
   "${ROOT_DIR}/data-plane/benchmarks/run.sh"
-elif [[ "${action}" == "./hack/update-codegen.sh" || "${action}" == "./hack/run.sh format-java" ]]; then
-    "${ROOT_DIR}"/mvnw spotless:apply
+elif [[ "${action}" == "format-java" ]]; then
+  cd "${ROOT_DIR}/data-plane"
+  ./mvnw spotless:apply
 else
   echo "Unrecognized action ${action}"
   usage "$0"

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -39,7 +39,6 @@ function usage() {
   echo "   benchmark-filters                                       Run all the filter benchmarks"
   echo ""
 }
-
 if [[ "$action" == "deploy-infra" ]]; then
   source "${ROOT_DIR}"/test/e2e-common.sh && knative_setup
 elif [[ "${action}" == "teardown-infra" ]]; then
@@ -96,6 +95,8 @@ elif [[ "${action}" == "benchmark-filter" ]]; then
   "${ROOT_DIR}/data-plane/benchmarks/run.sh" "$2"
 elif [[ "${action}" == "benchmark-filters" ]]; then
   "${ROOT_DIR}/data-plane/benchmarks/run.sh"
+elif [[ "${action}" == "./hack/update-codegen.sh" || "${action}" == "./hack/run.sh format-java" ]]; then
+    "${ROOT_DIR}"/mvnw spotless:apply
 else
   echo "Unrecognized action ${action}"
   usage "$0"


### PR DESCRIPTION
Currently, spotless formatting is triggered either when someone runs ./hack/update-codegen.sh or manually uses spotless. To simplify the process for contributors, this commit abstracts the formatting step away from contributors and enables them to run ./hack/run.sh format-java to automatically format all Java code.

#3331 