### PR TITLE
Update the updateServerConfig function to pass in the cert value diectly

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
@@ -238,7 +238,7 @@ public class ReceiverVerticle extends AbstractVerticle implements Handler<HttpSe
             try {
                 // Update SSL configuration by passing the new value of the certificate and key
                 // Have to use value instead of path here otherwise the changes won't be applied
-                PemKeyCertOptions keyCertOptions = new PemKeyCertOptions()
+                final var keyCertOptions = new PemKeyCertOptions()
                         .setCertValue(Buffer.buffer(java.nio.file.Files.readString(tlsCrtFile.toPath())))
                         .setKeyValue(Buffer.buffer(java.nio.file.Files.readString(tlsKeyFile.toPath())));
 


### PR DESCRIPTION
Fixes #3336 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
Now:
```
PemKeyCertOptions keyCertOptions = new PemKeyCertOptions()
            .setCertValue(Buffer.buffer(java.nio.file.Files.readString(tlsCrtFile.toPath())))
            .setKeyValue(Buffer.buffer(java.nio.file.Files.readString(tlsKeyFile.toPath())));
```
Past:
```
PemKeyCertOptions keyCertOptions =
                        new PemKeyCertOptions().setKeyPath(tlsKeyFile.getPath()).setCertPath(tlsCrtFile.getPath());
```

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
