### PR TITLE
Set consumer and consumergroups finalizers when creating them

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
@@ -156,12 +156,13 @@ func (c *ConsumerGroup) GetStatus() *duckv1.Status {
 func (cg *ConsumerGroup) ConsumerFromTemplate(options ...ConsumerOption) *Consumer {
 	// TODO figure out naming strategy, is generateName enough?
 	c := &Consumer{
-		ObjectMeta: cg.Spec.Template.ObjectMeta,
-		Spec:       cg.Spec.Template.Spec,
+		ObjectMeta: *cg.Spec.Template.ObjectMeta.DeepCopy(),
+		Spec:       *cg.Spec.Template.Spec.DeepCopy(),
 	}
 
 	ownerRef := metav1.NewControllerRef(cg, ConsumerGroupGroupVersionKind)
 	c.OwnerReferences = append(c.OwnerReferences, *ownerRef)
+	c.Finalizers = []string{"consumers.internal.kafka.eventing.knative.dev"}
 
 	for _, opt := range options {
 		opt(c)

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
@@ -108,6 +108,7 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -119,6 +120,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 				),
 				NewConsumer(2,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -194,6 +196,7 @@ func TestReconcileKind(t *testing.T) {
 				NewConfigMapWithBinaryData(systemNamespace, "p1", nil, DispatcherPodAsOwnerReference("p1")),
 				NewConfigMapWithBinaryData(systemNamespace, "p2", nil, DispatcherPodAsOwnerReference("p2")),
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -205,6 +208,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 				),
 				NewConsumer(2,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -402,6 +406,7 @@ func TestReconcileKind(t *testing.T) {
 			WantErr: false,
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -525,6 +530,7 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -871,6 +877,7 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -1112,6 +1119,7 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -1197,6 +1205,7 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -1290,6 +1299,7 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -1411,6 +1421,7 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -1529,6 +1540,7 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -1540,6 +1552,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 				),
 				NewConsumer(2,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(
@@ -1735,6 +1748,7 @@ func TestReconcileKindNoAutoscaler(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
+					ConsumerFinalizer(),
 					ConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
 						ConsumerConfigs(

--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -138,6 +138,9 @@ func (r Reconciler) reconcileConsumerGroup(ctx context.Context, ks *sources.Kafk
 			Labels: map[string]string{
 				internalscg.UserFacingResourceLabelSelector: strings.ToLower(ks.GetGroupVersionKind().Kind),
 			},
+			Finalizers: []string{
+				"consumergroups.internal.kafka.eventing.knative.dev",
+			},
 		},
 		Spec: internalscg.ConsumerGroupSpec{
 			Replicas: ks.Spec.Consumers,

--- a/control-plane/pkg/reconciler/source/source_test.go
+++ b/control-plane/pkg/reconciler/source/source_test.go
@@ -111,6 +111,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -163,6 +164,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -216,6 +218,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -272,6 +275,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -327,6 +331,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -430,6 +435,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -557,6 +563,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -638,6 +645,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -696,6 +704,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -1389,6 +1398,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
@@ -1442,6 +1452,7 @@ func TestReconcileKind(t *testing.T) {
 			Key: testKey,
 			WantCreates: []runtime.Object{
 				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
 					WithConsumerGroupName(SourceUUID),
 					WithConsumerGroupNamespace(SourceNamespace),
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),

--- a/control-plane/pkg/reconciler/testing/objects_consumer.go
+++ b/control-plane/pkg/reconciler/testing/objects_consumer.go
@@ -353,3 +353,9 @@ func ConsumerDeletedTimeStamp() ConsumerOption {
 		WithDeletedTimeStamp(c)
 	}
 }
+
+func ConsumerFinalizer() ConsumerOption {
+	return func(c *kafkainternals.Consumer) {
+		c.Finalizers = []string{"consumers.internal.kafka.eventing.knative.dev"}
+	}
+}

--- a/control-plane/pkg/reconciler/testing/objects_consumergroup.go
+++ b/control-plane/pkg/reconciler/testing/objects_consumergroup.go
@@ -173,6 +173,12 @@ func WithConsumerGroupLabels(labels map[string]string) ConsumerGroupOption {
 	}
 }
 
+func WithConsumerGroupFinalizer() ConsumerGroupOption {
+	return func(cg *kafkainternals.ConsumerGroup) {
+		cg.Finalizers = []string{"consumergroups.internal.kafka.eventing.knative.dev"}
+	}
+}
+
 func ConsumerGroupReplicas(replicas int32) ConsumerGroupOption {
 	return func(cg *kafkainternals.ConsumerGroup) {
 		cg.Spec.Replicas = pointer.Int32(replicas)


### PR DESCRIPTION
This is a mitigation for https://github.com/knative/pkg/issues/2828

Before this patch, it was possible that a deleted consumer or 
consumergroup might be reconciled and never finalized when
they are deleted before the finalizer is set.

This happens because the Knative generated reconciler uses
patch (as opposed to using update) for setting the finalizer
and patch doesn't have any optimistic concurrency controls.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set consumer and consumergroups finalizers when creating them

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Before this patch, it was possible that a deleted consumer or 
consumergroup might be reconciled and never finalized when
they are deleted before the finalizer is set.

This happens because the Knative generated reconciler uses
patch (as opposed to using update) for setting the finalizer
and patch doesn't have any optimistic concurrency controls.
```