### PR TITLE
Improve KEDA installed check efficiency

### DIFF
--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -283,7 +283,7 @@ func IsEnabled(ctx context.Context, features *config.KafkaFeatureFlags, client v
 		 return true
 	 }*/
 
-	if _, err := client.KedaV1alpha1().ScaledObjects(object.GetNamespace()).List(ctx, metav1.ListOptions{}); err != nil {
+	if _, err := client.KedaV1alpha1().ScaledObjects(object.GetNamespace()).List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
 		logging.FromContext(ctx).Debug("KEDA not installed, failed to list ScaledObjects")
 		return false
 	}


### PR DESCRIPTION
Instead of listing a potentially large number of ScaledObjects, we can limit this number to the smallest number: 1.
