### PR TITLE
Sped up benchmarks

### DIFF
--- a/data-plane/benchmarks/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/filter/AllFilterBenchmark.java
+++ b/data-plane/benchmarks/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/filter/AllFilterBenchmark.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 public class AllFilterBenchmark {
     public static ExactFilter makeExactFilter() {
-        return new ExactFilter(Map.of("id", "com.github.pull.create"));
+        return new ExactFilter(Map.of("type", "com.github.pull.create"));
     }
 
     public static PrefixFilter makePrefixFilter() {

--- a/data-plane/benchmarks/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/filter/AnyFilterBenchmark.java
+++ b/data-plane/benchmarks/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/filter/AnyFilterBenchmark.java
@@ -33,7 +33,7 @@ public class AnyFilterBenchmark {
     }
 
     public static ExactFilter makeExactFilter() {
-        return new ExactFilter(Map.of("id", "com.github.pull.create"));
+        return new ExactFilter(Map.of("type", "com.github.pull.create"));
     }
 
     public static PrefixFilter makePrefixFilter() {

--- a/data-plane/benchmarks/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/filter/FilterBenchmark.java
+++ b/data-plane/benchmarks/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/filter/FilterBenchmark.java
@@ -22,20 +22,22 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
-@BenchmarkMode(Mode.All)
+@BenchmarkMode(Mode.Throughput)
 @Fork(1)
 @State(Scope.Thread)
+@Measurement(iterations = 3, time = 10)
+@Warmup(iterations = 3, time = 5)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public abstract class FilterBenchmark {
     Filter filter;
     CloudEvent cloudEvent;
 
-    @Setup
+    @Setup(Level.Trial)
     public void setupFilter() {
         this.filter = createFilter();
     }
 
-    @Setup
+    @Setup(Level.Trial)
     public void setupCloudEvent() {
         this.cloudEvent = createEvent();
     }


### PR DESCRIPTION
Fixes #3320 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Only benchmark throughput rather than all modes
- Reduce the number of warmup trials and their runtimes
- Reduce the number of measurement trials
- (bonus: small bugfix to the existing benchmarks for all filter and any filter)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->
