### PR TITLE
Updated mockito to 5.3.1 to support JDK21 compilation

### DIFF
--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -218,7 +218,7 @@ Lists of 232 third-party dependencies.
      (Public Domain, per Creative Commons CC0) LatencyUtils (org.latencyutils:LatencyUtils:2.0.3 - http://latencyutils.github.io/LatencyUtils/)
      (The Apache Software License, Version 2.0) LZ4 and xxHash (org.lz4:lz4-java:1.8.0 - https://github.com/lz4/lz4-java)
      (The MIT License) mockito-core (org.mockito:mockito-core:5.3.1 - https://github.com/mockito/mockito)
-     (The MIT License) mockito-junit-jupiter (org.mockito:mockito-junit-jupiter:4.8.0 - https://github.com/mockito/mockito)
+     (The MIT License) mockito-junit-jupiter (org.mockito:mockito-junit-jupiter:5.3.1 - https://github.com/mockito/mockito)
      (Apache License, Version 2.0) Objenesis (org.objenesis:objenesis:3.3 - http://objenesis.org/objenesis)
      (GNU General Public License (GPL), version 2, with the Classpath exception) JMH Core (org.openjdk.jmh:jmh-core:1.35 - http://openjdk.java.net/projects/code-tools/jmh/jmh-core/)
      (GNU General Public License (GPL), version 2, with the Classpath exception) JMH Generators: Annotation Processors (org.openjdk.jmh:jmh-generator-annprocess:1.35 - http://openjdk.java.net/projects/code-tools/jmh/jmh-generator-annprocess/)

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -56,7 +56,7 @@
     <assertj.version>3.22.0</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <junit.jupiter.version>5.9.1</junit.jupiter.version>
-    <mokito.junit.jupiter.version>4.8.0</mokito.junit.jupiter.version>
+    <mokito.junit.jupiter.version>5.3.1</mokito.junit.jupiter.version>
     <fabric8.kubernetes.version>6.7.2</fabric8.kubernetes.version>
     <kafka.version>3.2.3</kafka.version>
     <debezium.version>1.9.6.Final</debezium.version>


### PR DESCRIPTION
Fixes #3350

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- bump mockito to 5.3.1

This change was tested successfully locally with:
```
openjdk version "21" 2023-09-19
OpenJDK Runtime Environment (Red_Hat-21.0.0.0.35-1.rolling.fc38) (fastdebug build 21+35)
OpenJDK 64-Bit Server VM (Red_Hat-21.0.0.0.35-1.rolling.fc38) (fastdebug build 21+35, mixed mode, sharing)
```
The compilation errors seem to be fixed.