### PR TITLE
Made the async prober private

### DIFF
--- a/control-plane/pkg/prober/composite_prober_test.go
+++ b/control-plane/pkg/prober/composite_prober_test.go
@@ -46,7 +46,7 @@ func TestCompositeProber(t *testing.T) {
 		name                     string
 		pods                     []*corev1.Pod
 		podsLabelsSelector       labels.Selector
-		addressable              NewAddressable
+		addressable              ProberAddressable
 		responseStatusCode       int
 		wantStatus               Status
 		wantRequeueCountMin      int
@@ -66,7 +66,7 @@ func TestCompositeProber(t *testing.T) {
 				},
 			},
 			podsLabelsSelector: labels.SelectorFromSet(map[string]string{"app": "p"}),
-			addressable: NewAddressable{
+			addressable: ProberAddressable{
 				AddressStatus: &duckv1.AddressStatus{
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{Scheme: "http", Path: "/b1/b1"},
@@ -97,7 +97,7 @@ func TestCompositeProber(t *testing.T) {
 				},
 			},
 			podsLabelsSelector: labels.SelectorFromSet(map[string]string{"app": "p"}),
-			addressable: NewAddressable{
+			addressable: ProberAddressable{
 				AddressStatus: &duckv1.AddressStatus{
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{Scheme: "https", Path: "/b1/b1"},
@@ -128,7 +128,7 @@ func TestCompositeProber(t *testing.T) {
 				},
 			},
 			podsLabelsSelector: labels.SelectorFromSet(map[string]string{"app": "p"}),
-			addressable: NewAddressable{
+			addressable: ProberAddressable{
 				AddressStatus: &duckv1.AddressStatus{
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{Scheme: "http", Path: "/b1/b1"},
@@ -197,7 +197,7 @@ func TestCompositeProber(t *testing.T) {
 				}
 			}
 
-			var IPsLister IPsLister = func(addressable Addressable) ([]string, error) {
+			var IPsLister IPsLister = func(addressable proberAddressable) ([]string, error) {
 				pods, err := podinformer.Get(ctx).Lister().List(tc.podsLabelsSelector)
 				if err != nil {
 					return nil, err
@@ -238,7 +238,7 @@ func TestCompositeProberNoTLS(t *testing.T) {
 		name                     string
 		pods                     []*corev1.Pod
 		podsLabelsSelector       labels.Selector
-		addressable              NewAddressable
+		addressable              ProberAddressable
 		responseStatusCode       int
 		wantStatus               Status
 		wantRequeueCountMin      int
@@ -258,7 +258,7 @@ func TestCompositeProberNoTLS(t *testing.T) {
 				},
 			},
 			podsLabelsSelector: labels.SelectorFromSet(map[string]string{"app": "p"}),
-			addressable: NewAddressable{
+			addressable: ProberAddressable{
 				AddressStatus: &duckv1.AddressStatus{
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{Scheme: "http", Path: "/b1/b1"},
@@ -289,7 +289,7 @@ func TestCompositeProberNoTLS(t *testing.T) {
 				},
 			},
 			podsLabelsSelector: labels.SelectorFromSet(map[string]string{"app": "p"}),
-			addressable: NewAddressable{
+			addressable: ProberAddressable{
 				AddressStatus: &duckv1.AddressStatus{
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{Scheme: "https", Path: "/b1/b1"},
@@ -320,7 +320,7 @@ func TestCompositeProberNoTLS(t *testing.T) {
 				},
 			},
 			podsLabelsSelector: labels.SelectorFromSet(map[string]string{"app": "p"}),
-			addressable: NewAddressable{
+			addressable: ProberAddressable{
 				AddressStatus: &duckv1.AddressStatus{
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{Scheme: "http", Path: "/b1/b1"},
@@ -389,7 +389,7 @@ func TestCompositeProberNoTLS(t *testing.T) {
 				}
 			}
 
-			var IPsLister IPsLister = func(addressable Addressable) ([]string, error) {
+			var IPsLister IPsLister = func(addressable proberAddressable) ([]string, error) {
 				pods, err := podinformer.Get(ctx).Lister().List(tc.podsLabelsSelector)
 				if err != nil {
 					return nil, err

--- a/control-plane/pkg/prober/prober_test.go
+++ b/control-plane/pkg/prober/prober_test.go
@@ -30,12 +30,12 @@ func TestFuncProbe(t *testing.T) {
 
 	calls := atomic.NewInt32(0)
 	status := StatusReady
-	p := Func(func(ctx context.Context, addressable Addressable, expected Status) Status {
+	p := Func(func(ctx context.Context, addressable proberAddressable, expected Status) Status {
 		calls.Inc()
 		return status
 	})
 
-	s := p.Probe(context.Background(), Addressable{}, status)
+	s := p.probe(context.Background(), proberAddressable{}, status)
 
 	require.Equal(t, status, s, s.String())
 	require.Equal(t, int32(1), calls.Load())
@@ -60,7 +60,7 @@ func TestIPsListerFromService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := IPsListerFromService(tt.svc)(Addressable{})
+			got, err := IPsListerFromService(tt.svc)(proberAddressable{})
 			if tt.wantErr != (err != nil) {
 				t.Errorf("Got err %v, wantErr %v", err, tt.wantErr)
 			}

--- a/control-plane/pkg/prober/probertesting/mock_prober.go
+++ b/control-plane/pkg/prober/probertesting/mock_prober.go
@@ -22,15 +22,8 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 )
 
-// MockProber returns a prober that always returns the provided status.
-func MockProber(status prober.Status) prober.Prober {
-	return prober.Func(func(ctx context.Context, addressable prober.Addressable, expected prober.Status) prober.Status {
-		return status
-	})
-}
-
 func MockNewProber(status prober.Status) prober.NewProber {
-	return prober.NewFunc(func(ctx context.Context, addressable prober.NewAddressable, expected prober.Status) prober.Status {
+	return prober.NewFunc(func(ctx context.Context, addressable prober.ProberAddressable, expected prober.Status) prober.Status {
 		return status
 	})
 }

--- a/control-plane/pkg/prober/probertesting/mock_prober_test.go
+++ b/control-plane/pkg/prober/probertesting/mock_prober_test.go
@@ -30,30 +30,30 @@ func TestMockProber(t *testing.T) {
 		name        string
 		status      prober.Status
 		ctx         context.Context
-		addressable prober.Addressable
+		addressable prober.ProberAddressable
 	}{
 		{
 			name:        "unknown",
 			status:      prober.StatusUnknown,
 			ctx:         context.Background(),
-			addressable: prober.Addressable{},
+			addressable: prober.ProberAddressable{},
 		},
 		{
 			name:        "ready",
 			status:      prober.StatusReady,
 			ctx:         context.Background(),
-			addressable: prober.Addressable{},
+			addressable: prober.ProberAddressable{},
 		},
 		{
 			name:        "notReady",
 			status:      prober.StatusNotReady,
 			ctx:         context.Background(),
-			addressable: prober.Addressable{},
+			addressable: prober.ProberAddressable{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := MockProber(tt.status).Probe(tt.ctx, tt.addressable, tt.status)
+			got := MockNewProber(tt.status).Probe(tt.ctx, tt.addressable, tt.status)
 			if diff := cmp.Diff(tt.status, got); diff != "" {
 				t.Error("(-want, got)", diff)
 			}

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -261,7 +261,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 		addressableStatus.Addresses = []duckv1.Addressable{httpAddress}
 	}
 
-	proberAddressable := prober.NewAddressable{
+	proberAddressable := prober.ProberAddressable{
 		AddressStatus: &addressableStatus,
 		ResourceKey: types.NamespacedName{
 			Namespace: broker.GetNamespace(),
@@ -356,7 +356,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 	// 	- https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181306446
 	// 	- https://cwiki.apache.org/confluence/display/KAFKA/KIP-286%3A+producer.send%28%29+should+not+block+on+metadata+update
 	address := receiver.HTTPAddress(ingressHost, broker)
-	proberAddressable := prober.NewAddressable{
+	proberAddressable := prober.ProberAddressable{
 		AddressStatus: &duckv1.AddressStatus{
 			Address:   &address,
 			Addresses: []duckv1.Addressable{address},

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -346,7 +346,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 		addressableStatus.Addresses = []duckv1.Addressable{httpAddress}
 	}
 
-	proberAddressable := prober.NewAddressable{
+	proberAddressable := prober.ProberAddressable{
 		AddressStatus: &addressableStatus,
 		ResourceKey: types.NamespacedName{
 			Namespace: channel.GetNamespace(),
@@ -429,7 +429,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	// 	- https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181306446
 	// 	- https://cwiki.apache.org/confluence/display/KAFKA/KIP-286%3A+producer.send%28%29+should+not+block+on+metadata+update
 	address := receiver.HTTPAddress(r.IngressHost, channel)
-	proberAddressable := prober.NewAddressable{
+	proberAddressable := prober.ProberAddressable{
 		AddressStatus: &duckv1.AddressStatus{
 			Address:   &address,
 			Addresses: []duckv1.Addressable{address},

--- a/control-plane/pkg/reconciler/channel/v2/channelv2.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2.go
@@ -313,7 +313,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta
 		addressableStatus.Addresses = []duckv1.Addressable{httpAddress}
 	}
 
-	proberAddressable := prober.NewAddressable{
+	proberAddressable := prober.ProberAddressable{
 		AddressStatus: &addressableStatus,
 		ResourceKey: types.NamespacedName{
 			Namespace: channel.GetNamespace(),
@@ -419,7 +419,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, channel *messagingv1beta1
 	// 	- https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181306446
 	// 	- https://cwiki.apache.org/confluence/display/KAFKA/KIP-286%3A+producer.send%28%29+should+not+block+on+metadata+update
 	address := receiver.HTTPAddress(r.IngressHost, channel)
-	proberAddressable := prober.NewAddressable{
+	proberAddressable := prober.ProberAddressable{
 		AddressStatus: &duckv1.AddressStatus{
 			Address:   &address,
 			Addresses: []duckv1.Addressable{address},

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -277,7 +277,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		addressableStatus.Addresses = []duckv1.Addressable{httpAddress}
 	}
 
-	proberAddressable := prober.NewAddressable{
+	proberAddressable := prober.ProberAddressable{
 		AddressStatus: &addressableStatus,
 		ResourceKey: types.NamespacedName{
 			Namespace: ks.GetNamespace(),
@@ -349,7 +349,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, ks *eventing.KafkaSink) e
 	// 	- https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=181306446
 	// 	- https://cwiki.apache.org/confluence/display/KAFKA/KIP-286%3A+producer.send%28%29+should+not+block+on+metadata+update
 	address := receiver.HTTPAddress(r.IngressHost, ks)
-	proberAddressable := prober.NewAddressable{
+	proberAddressable := prober.ProberAddressable{
 		AddressStatus: &duckv1.AddressStatus{
 			Address:   &address,
 			Addresses: []duckv1.Addressable{address},


### PR DESCRIPTION
Fixes #3190
Fixes #3141 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Make the async prober private, since we should only use the composite prober now that TLS is supported


