### PR TITLE
Added AnyFilterBenchmark and AllFilterBenchmark

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -181,10 +181,16 @@ For example, if you want to run all of the Exact Filter Benchmarks, you could ru
 ./hack/run.sh benchmark-filter ExactFilterBenchmark
 ```
 
+To run benchmarks for any filter benchmark , you can use:
+
+```shell
+./hack/run.sh benchmark-filter AnyFilterBenchmark
+```
+
 Alternatively, if you want to run all of the benchmarks you can run:
 
 ```shell
-./hack/run.sh benchmark-filters
+./hack/run.sh benchmark-filter AllFilterBenchmark
 ```
 
 ## Code generation

--- a/data-plane/benchmarks/resources/filter-class-list.txt
+++ b/data-plane/benchmarks/resources/filter-class-list.txt
@@ -2,3 +2,5 @@ ExactFilterBenchmark
 NotFilterBenchmark
 PrefixFilterBenchmark
 SuffixFilterBenchmark
+AnyFilterBenchmark
+AllFilterBenchmark


### PR DESCRIPTION
feat: Add AnyFilterBenchmark and AllFilterBenchmark to benchmark filter list

Description:In this pr have added support for running benchmarks for AnyFilterBenchmark and AllFilterBenchmark by updating the filter-class-list.txt file. Now, users can run these benchmarks using the command ./hack/run.sh benchmark-filter AnyFilterBenchmark and ./hack/run.sh benchmark-filter AllFilterBenchmark. This enhancement enables performance testing for AnyFilter and AllFilter, providing valuable insights into their efficiency.

Persona:
This feature is essential for developers and performance testers who are working on optimizing the filter functionality within the system. By including AnyFilterBenchmark and AllFilterBenchmark in the benchmark filter list, they can assess the performance impact of changes made to these filters.

- Added AnyFilterBenchmark and AllFilterBenchmark to data-plane/benchmarks/resources/filter-class-list.txt.
 ./hack/run.sh benchmark-filter AnyFilterBenchmark and ./hack/run.sh benchmark-filter AllFilterBenchmark 
#3453 