### PR TITLE
Stash only relevant broker config keys on the broker status

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -576,6 +576,7 @@ func storeConfigMapAsStatusAnnotation(broker *eventing.Broker, cm *corev1.Config
 		kafka.DefaultTopicNumPartitionConfigMapKey:      true,
 		kafka.DefaultTopicReplicationFactorConfigMapKey: true,
 		kafka.BootstrapServersConfigMapKey:              true,
+		security.AuthSecretNameKey:                      true,
 	}
 
 	for k, v := range cm.Data {

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -572,8 +572,16 @@ func storeConfigMapAsStatusAnnotation(broker *eventing.Broker, cm *corev1.Config
 		broker.Status.Annotations = make(map[string]string, len(cm.Data))
 	}
 
+	keysToStore := map[string]bool{
+		kafka.DefaultTopicNumPartitionConfigMapKey:      true,
+		kafka.DefaultTopicReplicationFactorConfigMapKey: true,
+		kafka.BootstrapServersConfigMapKey:              true,
+	}
+
 	for k, v := range cm.Data {
-		broker.Status.Annotations[k] = v
+		if keysToStore[k] {
+			broker.Status.Annotations[k] = v
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #2914

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Stash only relevant broker config keys on the broker status
- 
<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
