### PR TITLE
Change error checking logic for consumergroup

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/IBM/sarama"
@@ -770,7 +771,7 @@ func (r *Reconciler) ensureContractConfigMapExists(ctx context.Context, p *corev
 
 func errorIsOneOf(err error, errs ...error) bool {
 	for _, e := range errs {
-		if errors.Is(err, e) {
+		if strings.Contains(err.Error(), e.Error()) {
 			return true
 		}
 	}


### PR DESCRIPTION
Hopefully fixes consumergroup error checking logic. There were errors such as:
```
failed to initialize consumer group offset: failed to initialize offset: failed to get partitions for topic topic-nxugepfo: kafka server: Request was for a topic or partition that does not exist on this broker
```
These errors were created with `fmt.Errorf` embedding multiple errors into each other. To handle that, this changes the logic from checking error equality to checking if the error string contains the allowable underlying kafka error strings.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use strings.Contains rather than err.Is()


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fix error checking logic in consumergroups, improving deletion times when consumergroup has errors and is deleted
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
