### PR TITLE
Pass event type owner references to the data plane

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -617,9 +617,11 @@ func (r *Reconciler) reconcilerBrokerResource(ctx context.Context, topic string,
 		},
 		BootstrapServers: config.GetBootstrapServers(),
 		Reference: &contract.Reference{
-			Uuid:      string(broker.GetUID()),
-			Namespace: broker.GetNamespace(),
-			Name:      broker.GetName(),
+			Uuid:         string(broker.GetUID()),
+			Namespace:    broker.GetNamespace(),
+			Name:         broker.GetName(),
+			Kind:         "Broker",
+			GroupVersion: eventing.SchemeGroupVersion.String(),
 		},
 	}
 

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -676,9 +676,11 @@ func (r *Reconciler) getChannelContractResource(ctx context.Context, topic strin
 		},
 		BootstrapServers: config.GetBootstrapServers(),
 		Reference: &contract.Reference{
-			Uuid:      string(channel.GetUID()),
-			Namespace: channel.GetNamespace(),
-			Name:      channel.GetName(),
+			Uuid:         string(channel.GetUID()),
+			Namespace:    channel.GetNamespace(),
+			Name:         channel.GetName(),
+			Kind:         "KafkaChannel",
+			GroupVersion: messagingv1beta1.SchemeGroupVersion.String(),
 		},
 	}
 

--- a/control-plane/pkg/reconciler/channel/v2/channelv2.go
+++ b/control-plane/pkg/reconciler/channel/v2/channelv2.go
@@ -674,9 +674,11 @@ func (r *Reconciler) getChannelContractResource(ctx context.Context, topic strin
 		},
 		BootstrapServers: config.GetBootstrapServers(),
 		Reference: &contract.Reference{
-			Uuid:      string(channel.GetUID()),
-			Namespace: channel.GetNamespace(),
-			Name:      channel.GetName(),
+			Uuid:         string(channel.GetUID()),
+			Namespace:    channel.GetNamespace(),
+			Name:         channel.GetName(),
+			Kind:         "KafkaChannel",
+			GroupVersion: messagingv1beta1.SchemeGroupVersion.String(),
 		},
 	}
 

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -36,6 +36,7 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
 
+	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 	coreconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/core/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	kafkalogging "knative.dev/eventing-kafka-broker/control-plane/pkg/logging"
@@ -187,9 +188,11 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventing.KafkaSink) 
 		},
 		BootstrapServers: kafka.BootstrapServersCommaSeparated(ks.Spec.BootstrapServers),
 		Reference: &contract.Reference{
-			Uuid:      string(ks.GetUID()),
-			Namespace: ks.GetNamespace(),
-			Name:      ks.GetName(),
+			Uuid:         string(ks.GetUID()),
+			Namespace:    ks.GetNamespace(),
+			Name:         ks.GetName(),
+			Kind:         "KafkaSink",
+			GroupVersion: eventingv1alpha1.SchemeGroupVersion.String(),
 		},
 	}
 	if ks.Spec.HasAuthConfig() {

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -381,9 +381,11 @@ func brokerAddressable(broker *eventing.Broker, serviceName, serviceNamespace st
 
 func BrokerReference() *contract.Reference {
 	return &contract.Reference{
-		Uuid:      BrokerUUID,
-		Namespace: BrokerNamespace,
-		Name:      BrokerName,
+		Uuid:         BrokerUUID,
+		Namespace:    BrokerNamespace,
+		Name:         BrokerName,
+		Kind:         "Broker",
+		GroupVersion: eventing.SchemeGroupVersion.String(),
 	}
 }
 

--- a/control-plane/pkg/reconciler/testing/objects_channel.go
+++ b/control-plane/pkg/reconciler/testing/objects_channel.go
@@ -256,9 +256,11 @@ func WithChannelTopicStatusAnnotation(topicName string) func(obj duckv1.KRShaped
 
 func ChannelReference() *contract.Reference {
 	return &contract.Reference{
-		Uuid:      ChannelUUID,
-		Namespace: ChannelNamespace,
-		Name:      ChannelName,
+		Uuid:         ChannelUUID,
+		Namespace:    ChannelNamespace,
+		Name:         ChannelName,
+		Kind:         "KafkaChannel",
+		GroupVersion: messagingv1beta1.SchemeGroupVersion.String(),
 	}
 }
 

--- a/control-plane/pkg/reconciler/testing/objects_sink.go
+++ b/control-plane/pkg/reconciler/testing/objects_sink.go
@@ -131,9 +131,11 @@ func SinkAddressable(configs *config.Env) func(obj duckv1.KRShaped) {
 
 func SinkReference() *contract.Reference {
 	return &contract.Reference{
-		Uuid:      SinkUUID,
-		Namespace: SinkNamespace,
-		Name:      SinkName,
+		Uuid:         SinkUUID,
+		Namespace:    SinkNamespace,
+		Name:         SinkName,
+		Kind:         "KafkaSink",
+		GroupVersion: eventing.SchemeGroupVersion.String(),
 	}
 }
 


### PR DESCRIPTION
With the contract now including fields to ET owner references (needed for autocreate), we should pass those values to the data plane.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Pass the owner reference info to the data plane.