### PR TITLE
Remove activationLagThreshold to fix 0->1 scaling

### DIFF
--- a/control-plane/pkg/autoscaler/config.go
+++ b/control-plane/pkg/autoscaler/config.go
@@ -38,7 +38,6 @@ func defaultConfig() *AutoscalerConfig {
 			AutoscalingPollingIntervalAnnotation: DefaultPollingInterval,
 			AutoscalingCooldownPeriodAnnotation:  DefaultCooldownPeriod,
 			AutoscalingLagThreshold:              DefaultLagThreshold,
-			AutoscalingActivationLagThreshold:    DefaultActivationLagThreshold,
 		},
 	}
 }

--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -62,11 +62,6 @@ func GenerateScaleTriggers(cg *kafkainternals.ConsumerGroup, triggerAuthenticati
 		return nil, err
 	}
 
-	activationLagThreshold, err := GetInt32ValueFromMap(cg.Annotations, autoscaler.AutoscalingActivationLagThreshold, aconfig.AutoscalerDefaults[autoscaler.AutoscalingActivationLagThreshold])
-	if err != nil {
-		return nil, err
-	}
-
 	allowIdleConsumers := "false"
 	if cg.Status.Placements != nil {
 		allowIdleConsumers = "true"
@@ -74,12 +69,11 @@ func GenerateScaleTriggers(cg *kafkainternals.ConsumerGroup, triggerAuthenticati
 
 	for _, topic := range cg.Spec.Template.Spec.Topics {
 		triggerMetadata := map[string]string{
-			"bootstrapServers":       bootstrapServers,
-			"consumerGroup":          consumerGroup,
-			"topic":                  topic,
-			"lagThreshold":           strconv.Itoa(int(*lagThreshold)),
-			"activationLagThreshold": strconv.Itoa(int(*activationLagThreshold)),
-			"allowIdleConsumers":     allowIdleConsumers,
+			"bootstrapServers":   bootstrapServers,
+			"consumerGroup":      consumerGroup,
+			"topic":              topic,
+			"lagThreshold":       strconv.Itoa(int(*lagThreshold)),
+			"allowIdleConsumers": allowIdleConsumers,
 		}
 
 		trigger := kedav1alpha1.ScaleTriggers{


### PR DESCRIPTION
Fixes Kafka source tests when KEDA is enabled (hopefully).

From discussion [here](https://github.com/kedacore/keda/discussions/4466), we shouldn't be using `activationLagThreshold` unless we want to initially scale form 0 to n>1. Hence, our scaling 0 -> 1 was not working.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove activationLagThreshold parameter (letting it default to 0)
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
