### PR TITLE
Fix multiple logger binding error

### DIFF
--- a/data-plane/benchmarks/pom.xml
+++ b/data-plane/benchmarks/pom.xml
@@ -54,25 +54,6 @@
       <groupId>dev.knative.eventing.kafka.broker</groupId>
       <artifactId>dispatcher-vertx</artifactId>
       <version>${project.version}</version>
-      <exclusions> <!-- Exclude logging and noop -->
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.logstash.logback</groupId>
-          <artifactId>logstash-logback-encoder</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
   </dependencies>
 
@@ -97,15 +78,6 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <filters>
-                <filter>
-                  <artifact>dev.knative.eventing.kafka.broker:dispatcher</artifact>
-                  <excludes>
-                    <!-- Exclude logging, we add slf4j-nop as dep -->
-                    <exclude>ch/qos/logback/**</exclude>
-                    <exclude>net/logstash/logback/**</exclude>
-                    <exclude>org/slf4j/**</exclude>
-                  </excludes>
-                </filter>
                 <filter>
                   <!--
                       Shading signed JARs will fail without this.


### PR DESCRIPTION
Fixes #3452

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Instead of swapping out the "real" logger for a nop logger, just use the real logger in benchmarks. Bonus: this is a better measure of the real performance!

Testing locally, the benchmarks work now. To verify for yourself, run `./hack/run.sh benchmark-filters` and wait until the first benchmark runs, then verify that you don't get a message along the lines of:
```
SLF4J: Class path contains multiple SLF4J providers.
SLF4J: Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@66202ab4]
SLF4J: Found provider [org.slf4j.nop.NOPServiceProvider@5f731a2f]
SLF4J: See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual provider is of type [ch.qos.logback.classic.spi.LogbackServiceProvider@66202ab4]
```