### PR TITLE
changed '>>' to '>' in order to avoid duplicated k8s resources in yamls

### DIFF
--- a/hack/control-plane.sh
+++ b/hack/control-plane.sh
@@ -23,10 +23,10 @@ readonly CONTROL_PLANE_SOURCE_CONFIG_DIR=control-plane/config/eventing-kafka-sou
 # Note: do not change this function name, it's used during releases.
 function control_plane_setup() {
   ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
-  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_POST_INSTALL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
+  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_POST_INSTALL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >"${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
 }
 
 function control_plane_source_setup() {
-  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_POST_INSTALL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
+  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_POST_INSTALL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >"${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
   ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_SOURCE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}" || return $?
 }


### PR DESCRIPTION
Fixes #3316

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- The provided [yaml](https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v1.12.1/eventing-kafka-post-install.yaml) on the release page has all k8s resources twice. Terraform does not like that. This PR fixes that.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
