### PR TITLE
 Rename config-kafka-features feature flags to be consistent with eventing core feature flag names

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
@@ -4,7 +4,7 @@ metadata:
   name: config-kafka-features
   namespace: knative-eventing
   annotations:
-    knative.dev/example-checksum: "1192895d"
+    knative.dev/example-checksum: "cf3393de"
 data:
   _example: |-
     ################################
@@ -24,27 +24,27 @@ data:
     # Controls whether the dispatcher should use the rate limiter based on the number of virtual replicas.
     # 1. Enabled: The rate limiter is applied.
     # 2. Disabled: The rate limiter is not applied.
-    dispatcher.rate-limiter: "disabled"
+    dispatcher-rate-limiter: "disabled"
     # Controls whether the dispatcher should record additional metrics.
     # 1. Enabled: The metrics are recorded.
     # 2. Disabled: The metrics are not recorded.
-    dispatcher.ordered-executor-metrics: "disabled"
+    dispatcher-ordered-executor-metrics: "disabled"
     # Controls whether the controller should autoscale consumer resources with KEDA
     # 1. Enabled: KEDA autoscaling of consumers will be setup.
     # 2. Disabled: KEDA autoscaling of consumers will not be setup.
-    controller.autoscaler: "disabled"
+    controller-autoscaler-keda: "disabled"
     # The Go text/template used to generate consumergroup ID for triggers.
     # The template can reference the trigger Kubernetes metadata only.
-    triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+    triggers-consumergroup-template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
     # The Go text/template used to generate topics for Brokers.
     # The template can reference the broker Kubernetes metadata only.
-    brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+    brokers-topic-template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
     # The Go text/template used to generate topics for Channels.
     # The template can reference the channel Kubernetes metadata only.
-    channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
-  dispatcher.rate-limiter: "disabled"
-  dispatcher.ordered-executor-metrics: "disabled"
-  controller.autoscaler: "disabled"
-  triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
-  brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
-  channels.topic.template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"
+    channels-topic-template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
+  dispatcher-rate-limiter: "disabled"
+  dispatcher-ordered-executor-metrics: "disabled"
+  controller-autoscaler-keda: "disabled"
+  triggers-consumergroup-template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+  brokers-topic-template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+  channels-topic-template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"

--- a/control-plane/pkg/apis/config/features.go
+++ b/control-plane/pkg/apis/config/features.go
@@ -80,11 +80,17 @@ func NewFeaturesConfigFromMap(cm *corev1.ConfigMap) (*KafkaFeatureFlags, error) 
 	nc := DefaultFeaturesConfig()
 	err := configmap.Parse(cm.Data,
 		asFlag("dispatcher.rate-limiter", &nc.features.DispatcherRateLimiter),
+		asFlag("dispatcher-rate-limiter", &nc.features.DispatcherRateLimiter),
 		asFlag("dispatcher.ordered-executor-metrics", &nc.features.DispatcherOrderedExecutorMetrics),
+		asFlag("dispatcher-ordered-executor-metrics", &nc.features.DispatcherOrderedExecutorMetrics),
 		asFlag("controller.autoscaler", &nc.features.ControllerAutoscaler),
+		asFlag("controller-autoscaler-keda", &nc.features.ControllerAutoscaler),
 		asTemplate("triggers.consumergroup.template", &nc.features.TriggersConsumerGroupTemplate),
+		asTemplate("triggers-consumergroup-template", &nc.features.TriggersConsumerGroupTemplate),
 		asTemplate("brokers.topic.template", &nc.features.BrokersTopicTemplate),
+		asTemplate("brokers-topic-template", &nc.features.BrokersTopicTemplate),
 		asTemplate("channels.topic.template", &nc.features.ChannelsTopicTemplate),
+		asTemplate("channels-topic-template", &nc.features.ChannelsTopicTemplate),
 	)
 	return nc, err
 }


### PR DESCRIPTION
Fixes #3509 

## Proposed Changes

- Rename config-kafka-features feature flags to be consistent with eventing core feature flag names
 
```release-note 
Align config-kafka-features flags to eventing core feature flags.  
``` 
