### PR TITLE
Fix KinD setup with valid service account issuer

### DIFF
--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -48,7 +48,7 @@ kubeadmConfigPatches:
     kind: ClusterConfiguration
     apiServer:
       extraArgs:
-        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-issuer": "https://kubernetes.default.svc"
         "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
     networking:
       dnsDomain: "${CLUSTER_SUFFIX}"


### PR DESCRIPTION
Similar to https://github.com/knative/eventing/pull/7315/commits/243c52e6cb2f6819e51b35ed45ca7d8d86489117 to use a valid service account issuer.