### PR TITLE
Add gc profiling to the benchmarks

### DIFF
--- a/data-plane/benchmarks/run.sh
+++ b/data-plane/benchmarks/run.sh
@@ -24,7 +24,7 @@ run_java_filter_benchmarks_for_class() {
   echo "Running benchmarks for ${CLASS}"
 
   java -Dlogback.configurationFile=${SCRIPT_DIR}/resources/config-logging.xml \
-    -jar "${SCRIPT_DIR}/target/benchmarks.jar" $CLASS 2>&1 | tee "${SCRIPT_DIR}/output/${CLASS}.${TIME}.out.txt"
+    -jar "${SCRIPT_DIR}/target/benchmarks.jar" -prof gc $CLASS 2>&1 | tee "${SCRIPT_DIR}/output/${CLASS}.${TIME}.out.txt"
 
   echo "Successfully ran benchmarks for ${CLASS}!\n\nThe results can be found at ${SCRIPT_DIR}/output/${CLASS}.${TIME}.out.txt"
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

To better measure filter benchmarks, we should also profile gc

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add gc profiling to the benchmarks so we can see how memory usage changes
