### PR TITLE
Remove reference for consolidated KafkaChannel and distributed KafkaChannel in README

### DIFF
--- a/docs/channel/README.md
+++ b/docs/channel/README.md
@@ -4,7 +4,6 @@
 
 This repository contains another KafkaChannel implementation, which we believe is more flexible and scalable.
 
-.
 
 While working on other KafkaChannel implementations we realized we could reuse the dataplane for other Knative Kafka
 components, namely Knative KafkaBroker and the Knative KafkaSink.
@@ -16,6 +15,14 @@ The dataplane is designed in a way that it only communicates the control plane v
 
 ## Comparison with other KafkaChannel implementations
 
+> [!NOTE]
+> Consolidated and Distributed Kafka channel are deprecated.
+
+You may find a comparison of this new KafkaChannel implementation with
+the [consolidated KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/75310cc459911463d4885d662ce3789996075142/pkg/channel/consolidated/README.md)
+and
+the [distributed KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/75310cc459911463d4885d662ce3789996075142/pkg/channel/distributed/README.md)
+implementations.
 
 |                         | New KafkaChannel                                        | Consolidated KafkaChannel (Not supported anymore)                               | Distributed KafkaChannel (Not supported anymore)                                                             |
 |-------------------------|---------------------------------------------------------|---------------------------------------------------------|--------------------------------------------------------------------------------------|

--- a/docs/channel/README.md
+++ b/docs/channel/README.md
@@ -16,7 +16,7 @@ The dataplane is designed in a way that it only communicates the control plane v
 ## Comparison with other KafkaChannel implementations
 
 > [!NOTE]
-> Consolidated and Distributed Kafka channel are deprecated.
+> Consolidated and Distributed channel are deprecated.
 
 You may find a comparison of this new KafkaChannel implementation with
 the [consolidated KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/75310cc459911463d4885d662ce3789996075142/pkg/channel/consolidated/README.md)

--- a/docs/channel/README.md
+++ b/docs/channel/README.md
@@ -19,9 +19,9 @@ The dataplane is designed in a way that it only communicates the control plane v
 > Consolidated and Distributed channel are deprecated.
 
 You may find a comparison of this new KafkaChannel implementation with
-the [consolidated KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/75310cc459911463d4885d662ce3789996075142/pkg/channel/consolidated/README.md)
+the [deprecated consolidated KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/75310cc459911463d4885d662ce3789996075142/pkg/channel/consolidated/README.md)
 and
-the [distributed KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/75310cc459911463d4885d662ce3789996075142/pkg/channel/distributed/README.md)
+the [deprecated distributed KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/75310cc459911463d4885d662ce3789996075142/pkg/channel/distributed/README.md)
 implementations.
 
 |                         | New KafkaChannel                                        | Consolidated KafkaChannel (Not supported anymore)                               | Distributed KafkaChannel (Not supported anymore)                                                             |

--- a/docs/channel/README.md
+++ b/docs/channel/README.md
@@ -4,13 +4,9 @@
 
 This repository contains another KafkaChannel implementation, which we believe is more flexible and scalable.
 
-There are already 2 other KafkaChannel implementations:
-the [consolidated KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/main/pkg/channel/consolidated/README.md)
-and
-the [distributed KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/main/pkg/channel/distributed/README.md)
 .
 
-While working on these 2 channel implementations, we realized we could reuse the dataplane for other Knative Kafka
+While working on other KafkaChannel implementations we realized we could reuse the dataplane for other Knative Kafka
 components, namely Knative KafkaBroker and the Knative KafkaSink.
 
 The dataplane is designed in a way that it only communicates the control plane via a configmap and thus it is:
@@ -20,13 +16,8 @@ The dataplane is designed in a way that it only communicates the control plane v
 
 ## Comparison with other KafkaChannel implementations
 
-You may find a comparison of this new KafkaChannel implementation with
-the [consolidated KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/main/pkg/channel/consolidated/README.md)
-and
-the [distributed KafkaChannel](https://github.com/knative-extensions/eventing-kafka/blob/main/pkg/channel/distributed/README.md)
-implementations.
 
-|                         | New KafkaChannel                                        | Consolidated KafkaChannel                               | Distributed KafkaChannel                                                             |
+|                         | New KafkaChannel                                        | Consolidated KafkaChannel (Not supported anymore)                               | Distributed KafkaChannel (Not supported anymore)                                                             |
 |-------------------------|---------------------------------------------------------|---------------------------------------------------------|--------------------------------------------------------------------------------------|
 | Delivery Guarantees     | At least once                                           | At least once                                           | At least once                                                                        |
 | Scalability             | Ingress and egress are in different pods and scalable** | Ingress and egress are in the same pod and not scalable | Ingress and egress are in different pods but not scalable                            |
@@ -156,8 +147,7 @@ implementations.
 
 ## Usage
 
-The API for the new KafkaChannel implementation is the same with the consolidated KafkaChannel. You can use your existing
-KafkaChannel custom objects as is, or you can create the `KafkaChannel` custom objects just like before:
+You can create the `KafkaChannel` custom objects just like:
 
    ```yaml
    apiVersion: messaging.knative.dev/v1beta1
@@ -370,7 +360,7 @@ or the whole Knative Kafka suite (`eventing-kafka.yaml`).
 
 You may find an example run of the automated migration below.
 
-Please note that the commands are run on a cluster that has Knative eventing and consolidated KafkaChannel already installed.
+Please note that the commands are run on a cluster that has Knative eventing already installed.
 
 ```sh
 

--- a/docs/channel/README.md
+++ b/docs/channel/README.md
@@ -167,6 +167,8 @@ the WebHook to `1`, `1`, and `PT168H` respectively.
 
 ## Migration
 
+> [!NOTE]
+> Consolidated and Distributed KafkaChannel are not supported anymore, please migrate to the new implementation.
 ### Breaking changes from consolidated channel
 
 There are a few breaking changes however automated migration is possible for migrations from the consolidated channel


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #3525

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Update README to remove references of old (consolidated and distributed) KafkaChannels that are not supported anymore by knative.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic


