### PR TITLE
Fix flaky test failures because of single partition configmaps having the same name

### DIFF
--- a/test/e2e_new/dls_extensions_test.go
+++ b/test/e2e_new/dls_extensions_test.go
@@ -72,11 +72,13 @@ func SubscriberUnreachable() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("install one partition configuration", single_partition_config.Install)
+	install, cmName := single_partition_config.MakeInstall()
+
+	f.Setup("install one partition configuration", install)
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(kafka.BrokerClass),
-		broker.WithConfig(single_partition_config.ConfigMapName),
+		broker.WithConfig(cmName),
 	))
 	f.Setup("broker is ready", broker.IsReady(brokerName))
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
@@ -122,7 +124,9 @@ func SubscriberReturnedErrorNoData() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("install one partition configuration", single_partition_config.Install)
+	install, _ := single_partition_config.MakeInstall()
+
+	f.Setup("install one partition configuration", install)
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(kafka.BrokerClass),
@@ -183,11 +187,13 @@ func SubscriberReturnedErrorSmallData() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("install one partition configuration", single_partition_config.Install)
+	install, cmName := single_partition_config.MakeInstall()
+
+	f.Setup("install one partition configuration", install)
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(kafka.BrokerClass),
-		broker.WithConfig(single_partition_config.ConfigMapName),
+		broker.WithConfig(cmName),
 	))
 	f.Setup("broker is ready", broker.IsReady(brokerName))
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
@@ -246,11 +252,13 @@ func SubscriberReturnedErrorLargeData() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("install one partition configuration", single_partition_config.Install)
+	install, cmName := single_partition_config.MakeInstall()
+
+	f.Setup("install one partition configuration", install)
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(kafka.BrokerClass),
-		broker.WithConfig(single_partition_config.ConfigMapName),
+		broker.WithConfig(cmName),
 	))
 	f.Setup("broker is ready", broker.IsReady(brokerName))
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
@@ -310,11 +318,13 @@ func SubscriberReturnedHtmlWebpage() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("install one partition configuration", single_partition_config.Install)
+	install, cmName := single_partition_config.MakeInstall()
+
+	f.Setup("install one partition configuration", install)
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(kafka.BrokerClass),
-		broker.WithConfig(single_partition_config.ConfigMapName),
+		broker.WithConfig(cmName),
 	))
 	f.Setup("broker is ready", broker.IsReady(brokerName))
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
@@ -373,11 +383,13 @@ func SubscriberReturnedCustomExtensionHeader() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("install one partition configuration", single_partition_config.Install)
+	install, cmName := single_partition_config.MakeInstall()
+
+	f.Setup("install one partition configuration", install)
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(kafka.BrokerClass),
-		broker.WithConfig(single_partition_config.ConfigMapName),
+		broker.WithConfig(cmName),
 	))
 	f.Setup("broker is ready", broker.IsReady(brokerName))
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))

--- a/test/e2e_new/new_trigger_filters_test.go
+++ b/test/e2e_new/new_trigger_filters_test.go
@@ -51,11 +51,13 @@ func TestNewTriggerFilters(t *testing.T) {
 func InstallKafkaBroker(f *feature.Feature) string {
 	brokerName := feature.MakeRandomK8sName("kafka-broker")
 
-	f.Setup("install one partition configuration", single_partition_config.Install)
+	install, cmName := single_partition_config.MakeInstall()
+
+	f.Setup("install one partition configuration", install)
 	f.Setup("install kafka broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(kafka.BrokerClass),
-		broker.WithConfig(single_partition_config.ConfigMapName),
+		broker.WithConfig(cmName),
 	))
 	f.Setup("kafka broker is ready", broker.IsReady(brokerName))
 	f.Setup("kafka broker is addressable", broker.IsAddressable(brokerName))

--- a/test/e2e_new/ordered_test.go
+++ b/test/e2e_new/ordered_test.go
@@ -73,11 +73,13 @@ func SinglePartitionOrderedDelivery() *feature.Feature {
 
 	ev := cetest.FullEvent()
 
-	f.Setup("install one partition configuration", single_partition_config.Install)
+	install, cmName := single_partition_config.MakeInstall()
+
+	f.Setup("install one partition configuration", install)
 	f.Setup("install broker", broker.Install(
 		brokerName,
 		broker.WithBrokerClass(broker.EnvCfg.BrokerClass),
-		broker.WithConfig(single_partition_config.ConfigMapName),
+		broker.WithConfig(cmName),
 	))
 	f.Setup("broker is ready", broker.IsReady(brokerName))
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))

--- a/test/e2e_new/single_partition_config/install.go
+++ b/test/e2e_new/single_partition_config/install.go
@@ -24,15 +24,19 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 )
 
-const ConfigMapName = "single-partition-kafka-broker-config"
+const configMapName = "single-partition-kafka-broker-config"
 
 //go:embed *.yaml
 var yamls embed.FS
 
-func Install(ctx context.Context, t feature.T) {
-	if _, err := manifest.InstallYamlFS(ctx, yamls, map[string]interface{}{
-		"name": ConfigMapName,
-	}); err != nil {
-		t.Fatal(err)
-	}
+func MakeInstall() (feature.StepFn, string) {
+	cmName := feature.MakeRandomK8sName(configMapName)
+
+	return func(ctx context.Context, t feature.T) {
+		if _, err := manifest.InstallYamlFS(ctx, yamls, map[string]interface{}{
+			"name": cmName,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}, cmName
 }


### PR DESCRIPTION
Some tests have recently been failing in a flaky manner with errors as follows:
```
    install.go:36: failed to create resource configmaps "single-partition-kafka-broker-config" already exists - Resource:
        apiVersion: v1
        data:
          bootstrap.servers: my-cluster-kafka-bootstrap.kafka:9092
          default.topic.partitions: "1"
          default.topic.replication.factor: "1"
        kind: ConfigMap
        metadata:
          name: single-partition-kafka-broker-config
          namespace: test-dsvwxqja
```
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->



<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use a randomized configmap name so that the names don't conflict


