### PR TITLE
TestBrokerWithConfig waits for Topic in Requirement phase

### DIFF
--- a/test/rekt/features/broker_config.go
+++ b/test/rekt/features/broker_config.go
@@ -55,7 +55,7 @@ func BrokerWithCustomReplicationFactorAndNumPartitions(env environment.Environme
 	if err != nil {
 		panic("failed to create broker topic name")
 	}
-	f.Setup("Topic is ready", kafkatopic.IsReady(topic))
+	f.Requirement("Topic is ready", kafkatopic.IsReady(topic))
 
 	f.Assert("Replication factor", kafkatopic.HasReplicationFactor(topic, replicationFactor))
 	f.Assert("Number of partitions", kafkatopic.HasNumPartitions(topic, numPartitions))


### PR DESCRIPTION
When running many tests in parallel, waiting for the Topic might start much earlier than creating the Broker/Topic and it can time out (see below). This change ensures that waiting for the topic starts later.
```
=== CONT
TestBrokerWithConfig/Broker_KafkaTopic_config_from_Broker_configmap/Setup/Topic_is_ready
wait.go:136: kafka knative-broker-test-msvvevxa-broker-dtbsqwrn not
found kafkatopics.kafka.strimzi.io
"knative-broker-test-msvvevxa-broker-dtbsqwrn" not found
topic.go:73: kafka.strimzi.io/v1beta2, Resource=kafkatopics did not
become ready, timed out waiting for the condition
```

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
