### PR TITLE
Execute update-cert-manager.sh by calling bash directly

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -90,6 +90,5 @@ fi
 "${REPO_ROOT_DIR}"/hack/update-deps.sh
 
 cert_manager_installer="${REPO_ROOT_DIR}/vendor/knative.dev/eventing/hack/update-cert-manager.sh"
-chmod +x "${cert_manager_installer}" # Allow executing cert-manager script
-"${cert_manager_installer}"
-chmod -x "${cert_manager_installer}" # Revert execute permissions
+
+bash "${cert_manager_installer}"


### PR DESCRIPTION
The script already starts with a shebang that requires "bash". It is more explicit to call "bash <script>" instead of just "<script>" and doesn't require the file to be executable.

Bash needs to be available in both cases otherwise calling the script will fail.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Call script by "bash <script>"
- Avoid calling chmod as this operation might not be allowed when running in a container with a specific non-root user

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
