### PR TITLE
Revert embracing of JDK-21

### DIFF
--- a/.github/workflows/build-dependabot-pr.yaml
+++ b/.github/workflows/build-dependabot-pr.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1
         with:
-          java-version: 21
+          java-version: 17
 
       - run: mvn --no-transfer-progress -B --file data-plane/pom.xml -Dlicense.outputDirectory=. license:aggregate-add-third-party
       - run: mkdir ./dependabot-pr

--- a/.github/workflows/knative-java-test.yaml
+++ b/.github/workflows/knative-java-test.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Java Unit Tests
     strategy:
       matrix:
-        java-version: [ 21 ]
+        java-version: [ 20 ]
         platform: [ ubuntu-latest ]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/knative-profile-data-plane.yaml
+++ b/.github/workflows/knative-profile-data-plane.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         java-version:
-          - 21
+          - 20
         go-version:
           - 1.17.x
         platform: [ ubuntu-latest ]

--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -208,7 +208,7 @@ Lists of 230 third-party dependencies.
      (Apache License, version 2.0) JBoss Logging I18n Annotations (org.jboss.logging:jboss-logging-annotations:2.2.1.Final - http://www.jboss.org/jboss-logging-tools-parent/jboss-logging-annotations)
      (Apache License 2.0) JBoss Log Manager (Embedded) (org.jboss.logmanager:jboss-logmanager-embedded:1.1.1 - http://www.jboss.org/jboss-logmanager-embedded)
      (Apache License 2.0) JBoss Threads (org.jboss.threads:jboss-threads:3.5.0.Final - http://www.jboss.org/jboss-threads)
-     (Eclipse Public License v2.0) JUnit Jupiter (Aggregator) (org.junit.jupiter:junit-jupiter:5.10.1 - https://junit.org/junit5/)
+     (Eclipse Public License v2.0) JUnit Jupiter (Aggregator) (org.junit.jupiter:junit-jupiter:5.9.1 - https://junit.org/junit5/)
      (Eclipse Public License v2.0) JUnit Jupiter API (org.junit.jupiter:junit-jupiter-api:5.9.3 - https://junit.org/junit5/)
      (Eclipse Public License v2.0) JUnit Jupiter Engine (org.junit.jupiter:junit-jupiter-engine:5.9.3 - https://junit.org/junit5/)
      (Eclipse Public License v2.0) JUnit Jupiter Params (org.junit.jupiter:junit-jupiter-params:5.9.3 - https://junit.org/junit5/)

--- a/data-plane/dispatcher-loom/pom.xml
+++ b/data-plane/dispatcher-loom/pom.xml
@@ -29,7 +29,8 @@
   <name>dispatcher-loom</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>20</java.version>
+    <argLine>--enable-preview</argLine>
   </properties>
 
 
@@ -87,7 +88,7 @@
         <version>${jib.version}</version>
         <configuration>
           <from>
-            <image>docker.io/library/eclipse-temurin:21-jre</image>
+            <image>docker.io/library/eclipse-temurin:20-jre</image>
             <platforms>
               <platform>
                 <architecture>amd64</architecture>

--- a/data-plane/dispatcher-loom/pom.xml
+++ b/data-plane/dispatcher-loom/pom.xml
@@ -28,6 +28,11 @@
 
   <name>dispatcher-loom</name>
 
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+
   <dependencies>
     <dependency>
       <groupId>dev.knative.eventing.kafka.broker</groupId>
@@ -71,6 +76,9 @@
       <configuration>
         <source>${java.version}</source>
         <target>${java.version}</target>
+        <compilerArgs>
+          <arg>--enable-preview</arg>
+        </compilerArgs>
       </configuration>
       </plugin>
       <plugin>

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -56,7 +56,7 @@
     <net.logstash.logback.encoder.version>7.2</net.logstash.logback.encoder.version>
     <assertj.version>3.22.0</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
-    <junit.jupiter.version>5.10.1</junit.jupiter.version>
+    <junit.jupiter.version>5.9.1</junit.jupiter.version>
     <mokito.junit.jupiter.version>5.8.0</mokito.junit.jupiter.version>
     <fabric8.kubernetes.version>6.7.2</fabric8.kubernetes.version>
     <kafka.version>3.2.3</kafka.version>
@@ -444,7 +444,7 @@
             <!--  KinD e2e tests registry uses HTTP -->
             <allowInsecureRegistries>true</allowInsecureRegistries>
             <from>
-              <image>registry.access.redhat.com/ubi9/openjdk-21</image>
+              <image>registry.access.redhat.com/ubi9/openjdk-17</image>
               <platforms>
                 <platform>
                   <architecture>amd64</architecture>
@@ -488,9 +488,6 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven.surefire.plugin.version}</version>
           <configuration>
-            <systemPropertyVariables>
-                <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
-            </systemPropertyVariables>
             <!-- This is required for the jacoco maven plugin -->
             <argLine>${argLine}</argLine>
           </configuration>

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>21</java.version>
+    <java.version>15</java.version>
 
     <!-- Maven plugins -->
     <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>

--- a/data-plane/receiver-loom/pom.xml
+++ b/data-plane/receiver-loom/pom.xml
@@ -29,7 +29,8 @@
   <name>receiver-loom</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>20</java.version>
+    <argLine>--enable-preview</argLine>
   </properties>
 
 
@@ -104,7 +105,7 @@
         <version>${jib.version}</version>
         <configuration>
           <from>
-            <image>docker.io/library/eclipse-temurin:21-jre</image>
+            <image>docker.io/library/eclipse-temurin:20-jre</image>
             <platforms>
               <platform>
                 <architecture>amd64</architecture>

--- a/data-plane/receiver-loom/pom.xml
+++ b/data-plane/receiver-loom/pom.xml
@@ -28,6 +28,11 @@
 
   <name>receiver-loom</name>
 
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
+
   <dependencies>
     <dependency>
       <groupId>dev.knative.eventing.kafka.broker</groupId>
@@ -88,6 +93,9 @@
       <configuration>
         <source>${java.version}</source>
         <target>${java.version}</target>
+        <compilerArgs>
+          <arg>--enable-preview</arg>
+        </compilerArgs>
       </configuration>
       </plugin>
       <plugin>

--- a/data-plane/tests/pom.xml
+++ b/data-plane/tests/pom.xml
@@ -29,7 +29,9 @@
   <artifactId>tests</artifactId>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>20</java.version>
+    <!-- Used Loom Virtual Threads is still a preview feature in JDK20 -->
+    <argLine>--enable-preview</argLine>
   </properties>
 
   <dependencies>

--- a/data-plane/tests/pom.xml
+++ b/data-plane/tests/pom.xml
@@ -28,6 +28,10 @@
 
   <artifactId>tests</artifactId>
 
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+
   <dependencies>
 
     <!-- These are added as runtime deps, so jacoco can see these -->
@@ -123,6 +127,9 @@
       <configuration>
         <source>${java.version}</source>
         <target>${java.version}</target>
+        <compilerArgs>
+          <arg>--enable-preview</arg>
+        </compilerArgs>
       </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- there are flakes in CI, with the recent JDK-21 update. This PR is the base to revert fully embrace JDK_21 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
