### PR TITLE
skip TestBrokerWithConfig

### DIFF
--- a/test/e2e_new/broker_config_test.go
+++ b/test/e2e_new/broker_config_test.go
@@ -31,6 +31,7 @@ import (
 // TestBrokerWithConfig tests a brokers values for ReplicationFactor and number
 // of partitions if set in the broker configmap.
 func TestBrokerWithConfig(t *testing.T) {
+	t.Skip("Skipping due to https://github.com/knative-extensions/eventing-kafka-broker/issues/3592")
 
 	t.Parallel()
 


### PR DESCRIPTION
skips TestBrokerWithConfig because of  https://github.com/knative-extensions/eventing-kafka-broker/issues/3592
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- :broom: skip TestBrokerWithConfig to not rely on the obsolete Strimzi "Bidirectional Topic Operator"