### PR TITLE
Add OIDC TokenVerifier

### DIFF
--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -196,7 +196,7 @@ Lists of 230 third-party dependencies.
      (The Apache License, Version 2.0) org.apiguardian:apiguardian-api (org.apiguardian:apiguardian-api:1.1.2 - https://github.com/apiguardian-team/apiguardian)
      (Apache License, Version 2.0) AssertJ fluent assertions (org.assertj:assertj-core:3.22.0 - https://assertj.github.io/doc/assertj-core/)
      (Apache 2.0) Awaitility (org.awaitility:awaitility:4.2.0 - http://awaitility.org)
-     (The Apache Software License, Version 2.0) jose4j (org.bitbucket.b_c:jose4j:0.7.9 - https://bitbucket.org/b_c/jose4j/)
+     (The Apache Software License, Version 2.0) jose4j (org.bitbucket.b_c:jose4j:0.9.4 - https://bitbucket.org/b_c/jose4j/)
      (The MIT License) Checker Qual (org.checkerframework:checker-qual:3.34.0 - https://checkerframework.org/)
      (Apache License, Version 2.0) MicroProfile Config API (org.eclipse.microprofile.config:microprofile-config-api:3.0.3 - https://microprofile.io/project/eclipse/microprofile-config/microprofile-config-api)
      (Apache License, Version 2.0) MicroProfile Context Propagation (org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.3 - http://microprofile.io/microprofile-context-propagation-api)

--- a/data-plane/core/pom.xml
+++ b/data-plane/core/pom.xml
@@ -70,6 +70,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.bitbucket.b_c</groupId>
+      <artifactId>jose4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
     </dependency>

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCDiscoveryConfig.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCDiscoveryConfig.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.core.oidc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import org.jose4j.jwk.JsonWebKeySet;
+import org.jose4j.keys.resolvers.JwksVerificationKeyResolver;
+import org.jose4j.lang.JoseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OIDCDiscoveryConfig {
+
+  private static final Logger logger = LoggerFactory.getLogger(TokenVerifier.class);
+
+  private String issuer;
+
+  private JwksVerificationKeyResolver jwksVerificationKeyResolver;
+
+  private OIDCDiscoveryConfig() {}
+
+  public String getIssuer() {
+    return issuer;
+  }
+
+  public JwksVerificationKeyResolver getJwksVerificationKeyResolver() {
+    return jwksVerificationKeyResolver;
+  }
+
+  public static Future<OIDCDiscoveryConfig> build(Vertx vertx) {
+    Config kubeConfig = new ConfigBuilder().build();
+
+    WebClientOptions webClientOptions = new WebClientOptions()
+      .setPemTrustOptions(new PemTrustOptions().addCertPath(kubeConfig.getCaCertFile()));
+    WebClient webClient = WebClient.create(vertx, webClientOptions);
+
+    OIDCDiscoveryConfig oidcDiscoveryConfig = new OIDCDiscoveryConfig();
+
+    return webClient
+      .getAbs("https://kubernetes.default.svc/.well-known/openid-configuration")
+      .bearerTokenAuthentication(kubeConfig.getAutoOAuthToken())
+      .send()
+      .compose(res -> {
+        logger.debug("Got raw OIDC discovery info: " + res.bodyAsString());
+
+        try {
+          ObjectMapper mapper = new ObjectMapper();
+          OIDCInfo oidcInfo = mapper.readValue(res.bodyAsString(), OIDCInfo.class);
+
+          oidcDiscoveryConfig.issuer = oidcInfo.getIssuer();
+
+          return webClient
+            .getAbs(oidcInfo.getJwks().toString())
+            .bearerTokenAuthentication(kubeConfig.getAutoOAuthToken())
+            .send();
+
+        } catch (JsonProcessingException e) {
+          logger.error("Failed to parse OIDC discovery info", e);
+
+          return Future.failedFuture(e);
+        }
+      }).compose(res -> {
+        if (res.statusCode() >= 200 && res.statusCode() < 300) {
+          try {
+            JsonWebKeySet jsonWebKeySet = new JsonWebKeySet(res.bodyAsString());
+            logger.debug("Got JWKeys: " + jsonWebKeySet.toJson());
+
+            oidcDiscoveryConfig.jwksVerificationKeyResolver = new JwksVerificationKeyResolver(jsonWebKeySet.getJsonWebKeys());
+
+            return Future.succeededFuture(oidcDiscoveryConfig);
+          } catch (JoseException t) {
+            logger.error("Failed to parse JWKeys", t);
+
+            return Future.failedFuture(t);
+          }
+        }
+
+        logger.error("Got unexpected response code for JWKey URL: " + res.statusCode());
+
+        return Future.failedFuture("unexpected response code on JWKeys URL: " + res.statusCode());
+      });
+  }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCInfo.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCInfo.java
@@ -17,7 +17,6 @@ package dev.knative.eventing.kafka.broker.core.oidc;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.net.URL;
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCInfo.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.core.oidc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.net.URL;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class OIDCInfo {
+
+    private String issuer;
+
+    @JsonProperty("jwks_uri")
+    private URL jwks;
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public URL getJwks() {
+        return jwks;
+    }
+
+    public void setJwks(URL jwks) {
+        this.jwks = jwks;
+    }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/TokenVerifier.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/TokenVerifier.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.core.oidc;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.jose4j.jwt.consumer.JwtContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TokenVerifier {
+
+    private static final Logger logger = LoggerFactory.getLogger(TokenVerifier.class);
+
+    private final Vertx vertx;
+
+    private final OIDCDiscoveryConfig oidcDiscoveryConfig;
+
+    public TokenVerifier(Vertx vertx, OIDCDiscoveryConfig oidcDiscoveryConfig) {
+        this.vertx = vertx;
+        this.oidcDiscoveryConfig = oidcDiscoveryConfig;
+    }
+
+    public Future<JwtClaims> verify(String token, String expectedAudience) {
+        return this.vertx.<JwtClaims>executeBlocking(promise -> {
+            // execute blocking, as jose .process() is blocking
+
+            JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+                    .setVerificationKeyResolver(this.oidcDiscoveryConfig.getJwksVerificationKeyResolver())
+                    .setExpectedAudience(expectedAudience)
+                    .setExpectedIssuer(this.oidcDiscoveryConfig.getIssuer())
+                    .build();
+
+            try {
+                JwtContext jwtContext = jwtConsumer.process(token);
+
+                promise.complete(jwtContext.getJwtClaims());
+            } catch (InvalidJwtException e) {
+                promise.fail(e);
+            }
+        });
+    }
+
+    public Future<JwtClaims> verify(HttpServerRequest request, String expectedAudience) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader.isEmpty()) {
+            return Future.failedFuture("Request didn't contain Authorization header"); // change to exception
+        }
+
+        if (!authHeader.startsWith("Bearer ") && authHeader.length() <= "Bearer ".length()) {
+            return Future.failedFuture("Authorization header didn't contain Bearer token"); // change to exception
+        }
+
+        String token = authHeader.substring("Bearer ".length());
+        logger.debug("Extracted token \"{}\" from request auth header \"{}\"", token, authHeader);
+
+        return verify(token, expectedAudience);
+    }
+}

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -66,6 +66,7 @@
     <antlr.version>4.9.2
     </antlr.version> <!-- Overwritting quarkus's antlr version. Reminder: antlr4-maven-plugin,antlr4-runtime, antlr4 need to have the same version -->
     <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>
+    <jose4j.version>0.9.4</jose4j.version>
   </properties>
 
   <modules>
@@ -240,6 +241,12 @@
         <version>${jackson.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.bitbucket.b_c</groupId>
+        <artifactId>jose4j</artifactId>
+        <version>${jose4j.version}</version>
       </dependency>
 
       <!-- Logback -->


### PR DESCRIPTION
Fixes partially #3573

## Proposed Changes

- :gift: Adds a helper to verify JWT tokens and OIDC discovery.

An "in action example" of the setup and configuration can be seen at:
https://github.com/knative-extensions/eventing-kafka-broker/blob/9aafcece35118fb1290734dd9a98cb3557764d66/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java#L150-L153