### PR TITLE
Don't ignore Context from TableRow in `NewFactory()`

### DIFF
--- a/control-plane/pkg/reconciler/testing/factory.go
+++ b/control-plane/pkg/reconciler/testing/factory.go
@@ -55,7 +55,12 @@ func NewFactory(env *config.Env, ctor Ctor) Factory {
 	return func(t *testing.T, row *TableRow) (pkgcontroller.Reconciler, ActionRecorderList, EventList) {
 
 		listers := newListers(row.Objects)
-		ctx := context.Background()
+		var ctx context.Context
+		if row.Ctx != nil {
+			ctx = row.Ctx
+		} else {
+			ctx = context.Background()
+		}
 
 		ctx, eventingClient := fakeeventingclient.With(ctx, listers.GetEventingObjects()...)
 		ctx, eventingKafkaBrokerClient := fakeeventingkafkabrokerclient.With(ctx, listers.GetEventingKafkaBrokerObjects()...)

--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -2948,6 +2948,10 @@ func useTableWithFlags(t *testing.T, table TableTest, env *config.Env, flags fea
 	table.Test(t, NewFactory(env, func(ctx context.Context, listers *Listers, env *config.Env, row *TableRow) controller.Reconciler {
 
 		logger := logging.FromContext(ctx)
+		ctxFlags := feature.FromContextOrDefaults(ctx)
+		for k, v := range flags {
+			ctxFlags[k] = v
+		}
 
 		reconciler := &Reconciler{
 			Reconciler: &base.Reconciler{
@@ -2963,7 +2967,7 @@ func useTableWithFlags(t *testing.T, table TableTest, env *config.Env, flags fea
 				ReceiverLabel:                base.BrokerReceiverLabel,
 			},
 			FlagsHolder: &FlagsHolder{
-				Flags: flags,
+				Flags: ctxFlags,
 			},
 			BrokerLister:              listers.GetBrokerLister(),
 			ConfigMapLister:           listers.GetConfigMapLister(),


### PR DESCRIPTION
Currently we ignore a TableTests row.Ctx value in `NewFactory`.
This PR addresses it and takes a `Ctx` from a TableRow into account, when setting up the constructor via `NewFactory`