### PR TITLE
Remove sensitive logs from TokenVerifier

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/TokenVerifier.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/TokenVerifier.java
@@ -70,7 +70,6 @@ public class TokenVerifier {
         }
 
         String token = authHeader.substring("Bearer ".length());
-        logger.debug("Extracted token \"{}\" from request auth header \"{}\"", token, authHeader);
 
         return verify(token, expectedAudience);
     }


### PR DESCRIPTION
Currently we have a log line, which logs the JWT. This should not be logged.

/cc @pierDipi @Cali0707 @Leo6Leo 