### PR TITLE
Increase test timeout for TestKafkaSourceDeletedFromContractConfigMaps

### DIFF
--- a/test/e2e_new/kafka_source_test.go
+++ b/test/e2e_new/kafka_source_test.go
@@ -58,7 +58,7 @@ func TestKafkaSourceDeletedFromContractConfigMaps(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
-		environment.WithPollTimings(PollInterval, PollTimeout),
+		environment.WithPollTimings(PollInterval, time.Minute*10),
 		environment.Managed(t),
 	)
 	t.Cleanup(env.Finish)


### PR DESCRIPTION
The TestKafkaSourceDeletedFromContractConfigMaps e2e test creates a lot of resources and regularly times out by cleaning up them again. This PR increases the timeout for this test to 10 minutes.

/cc @pierDipi 

