### PR TITLE
Skip KafkaSource TLS tests on Istio

### DIFF
--- a/test/rekt/features/kafka_source.go
+++ b/test/rekt/features/kafka_source.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"knative.dev/eventing/test/rekt/features/featureflags"
 	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -556,6 +557,9 @@ func KafkaSourceTLSSink() *feature.Feature {
 	event.SetID(uuid.NewString())
 
 	f := feature.NewFeature()
+
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
+
 	f.Setup("install kafka topic", kafkatopic.Install(topic))
 	f.Setup("topic is ready", kafkatopic.IsReady(topic))
 
@@ -603,6 +607,9 @@ func KafkaSourceTLSSinkTrustBundle() *feature.Feature {
 	event.SetID(uuid.NewString())
 
 	f := feature.NewFeature()
+
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
+
 	f.Setup("install kafka topic", kafkatopic.Install(topic))
 	f.Setup("topic is ready", kafkatopic.IsReady(topic))
 

--- a/test/rekt/features/kafka_source.go
+++ b/test/rekt/features/kafka_source.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"knative.dev/eventing/test/rekt/features/featureflags"
 	"strings"
+
+	"knative.dev/eventing/test/rekt/features/featureflags"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/test"


### PR DESCRIPTION
As per title. Otherwise we have issues with eventing-istio e2e tests

/cc @pierDipi 