### PR TITLE
[release-1.11] Enable receiver and dispatcher Docker images for ppc64le architecture

### DIFF
--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -452,6 +452,10 @@
                   <architecture>s390x</architecture>
                   <os>linux</os>
                 </platform>
+                <platform>
+                  <architecture>ppc64le</architecture>
+                  <os>linux</os>
+                </platform>
               </platforms>
             </from>
           </configuration>


### PR DESCRIPTION
Signed-off-by: Valen Mascarenhas [Valen.Mascarenhas@ibm.com](mailto:Valen.Mascarenhas@ibm.com)

Fixes 
https://github.com/knative-extensions/eventing-kafka-broker/issues/3643

**Proposed Changes**
This PR enables the Docker image build for the dataplane components (including receiver and dispatcher) for the ppc64le architecture. For this it leverages jib's multi-arch Docker image build capabilities.

**Release Note**
`Add support ppc64le architecture.`