### PR TITLE
feat: remove yaml merge tag

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-webhook/500-webhook.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/500-webhook.yaml
@@ -100,7 +100,7 @@ spec:
             - name: profiling
               containerPort: 8008
 
-          readinessProbe: &probe
+          readinessProbe:
             periodSeconds: 1
             httpGet:
               scheme: HTTPS
@@ -109,7 +109,13 @@ spec:
                 - name: k-kubelet-probe
                   value: "webhook"
           livenessProbe:
-            <<: *probe
+            periodSeconds: 1
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              httpHeaders:
+                - name: k-kubelet-probe
+                  value: "webhook"
             initialDelaySeconds: 20
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

Merge keys are not officially supported in YAML according to its specifications. These keys are associated with an older version of YAML (1.1), which is now considered obsolete. Additionally, these merge keys haven't been updated or included in the current YAML version (1.2), so there's no guarantee that they will function as expected or be supported. In summary, using merge keys in YAML might not work reliably and is not recommended due to these limitations and lack of support in the latest YAML version.

I attempted to install the YAML mentioned using Kustomize, but the installation failed because Kustomize couldn't properly interpret or render the YAML file.

## Proposed Changes

- I suggest that we avoid utilizing merge tags to ensure compliance with YAML specifications, particularly in the latest versions like 1.2.x.
