### PR TITLE
Create KafkaSources OIDC service account and expose in its status

### DIFF
--- a/control-plane/pkg/apis/sources/v1beta1/kafka_lifecycle.go
+++ b/control-plane/pkg/apis/sources/v1beta1/kafka_lifecycle.go
@@ -46,6 +46,9 @@ const (
 	// KafkaConditionInitialOffsetsCommitted is True when the KafkaSource has committed the
 	// initial offset of all claims
 	KafkaConditionInitialOffsetsCommitted apis.ConditionType = "InitialOffsetsCommitted"
+
+	// KafkaConditionOIDCIdentityCreated has status True when the KafkaSource has created an OIDC identity.
+	KafkaConditionOIDCIdentityCreated apis.ConditionType = "OIDCIdentityCreated"
 )
 
 var (
@@ -54,6 +57,7 @@ var (
 		KafkaConditionDeployed,
 		KafkaConditionConnectionEstablished,
 		KafkaConditionInitialOffsetsCommitted,
+		KafkaConditionOIDCIdentityCreated,
 	)
 
 	kafkaCondSetLock = sync.RWMutex{}
@@ -158,6 +162,22 @@ func (s *KafkaSourceStatus) MarkInitialOffsetCommitted() {
 
 func (s *KafkaSourceStatus) MarkInitialOffsetNotCommitted(reason, messageFormat string, messageA ...interface{}) {
 	KafkaSourceCondSet.Manage(s).MarkFalse(KafkaConditionInitialOffsetsCommitted, reason, messageFormat, messageA...)
+}
+
+func (s *KafkaSourceStatus) MarkOIDCIdentityCreatedSucceeded() {
+	KafkaSourceCondSet.Manage(s).MarkTrue(KafkaConditionOIDCIdentityCreated)
+}
+
+func (s *KafkaSourceStatus) MarkOIDCIdentityCreatedSucceededWithReason(reason, messageFormat string, messageA ...interface{}) {
+	KafkaSourceCondSet.Manage(s).MarkTrueWithReason(KafkaConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
+}
+
+func (s *KafkaSourceStatus) MarkOIDCIdentityCreatedFailed(reason, messageFormat string, messageA ...interface{}) {
+	KafkaSourceCondSet.Manage(s).MarkFalse(KafkaConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
+}
+
+func (s *KafkaSourceStatus) MarkOIDCIdentityCreatedUnknown(reason, messageFormat string, messageA ...interface{}) {
+	KafkaSourceCondSet.Manage(s).MarkUnknown(KafkaConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
 func (s *KafkaSourceStatus) UpdateConsumerGroupStatus(status string) {

--- a/control-plane/pkg/reconciler/source/controller.go
+++ b/control-plane/pkg/reconciler/source/controller.go
@@ -18,6 +18,8 @@ package source
 
 import (
 	"context"
+	"knative.dev/eventing/pkg/apis/feature"
+	"knative.dev/pkg/logging"
 
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
@@ -34,29 +36,51 @@ import (
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/consumergroup"
 	kedaclient "knative.dev/eventing-kafka-broker/third_party/pkg/client/injection/client"
+
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	serviceaccountinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 )
 
 func NewController(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
 
 	kafkaInformer := kafkainformer.Get(ctx)
 	consumerGroupInformer := consumergroupinformer.Get(ctx)
+	serviceaccountInformer := serviceaccountinformer.Get(ctx)
 
 	sources.RegisterAlternateKafkaConditionSet(conditionSet)
 
+	var globalResync func()
+	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"), func(name string, value interface{}) {
+		if globalResync != nil {
+			globalResync()
+		}
+	})
+	featureStore.WatchConfigs(watcher)
+
 	r := &Reconciler{
-		ConsumerGroupLister: consumerGroupInformer.Lister(),
-		InternalsClient:     consumergroupclient.Get(ctx),
-		KedaClient:          kedaclient.Get(ctx),
-		KafkaFeatureFlags:   config.DefaultFeaturesConfig(),
+		KubeClient:           kubeclient.Get(ctx),
+		ConsumerGroupLister:  consumerGroupInformer.Lister(),
+		InternalsClient:      consumergroupclient.Get(ctx),
+		KedaClient:           kedaclient.Get(ctx),
+		KafkaFeatureFlags:    config.DefaultFeaturesConfig(),
+		ServiceAccountLister: serviceaccountInformer.Lister(),
 	}
 
-	impl := kafkasource.NewImpl(ctx, r)
+	impl := kafkasource.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
+		return controller.Options{
+			ConfigStore: featureStore,
+		}
+	})
+
+	globalResync = func() {
+		impl.GlobalResync(kafkaInformer.Informer())
+	}
 
 	kafkaInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	configStore := config.NewStore(ctx, func(name string, value *config.KafkaFeatureFlags) {
 		r.KafkaFeatureFlags.Reset(value)
-		impl.GlobalResync(kafkaInformer.Informer())
+		globalResync()
 	})
 	configStore.WatchConfigs(watcher)
 
@@ -65,5 +89,12 @@ func NewController(ctx context.Context, watcher configmap.Watcher) *controller.I
 		FilterFunc: consumergroup.Filter("kafkasource"),
 		Handler:    controller.HandleAll(consumergroup.Enqueue("kafkasource", impl.EnqueueKey)),
 	})
+
+	// Reconcile KafkaSource when the OIDC service account changes
+	serviceaccountInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterController(&sources.KafkaSource{}),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
+
 	return impl
 }

--- a/control-plane/pkg/reconciler/source/controller.go
+++ b/control-plane/pkg/reconciler/source/controller.go
@@ -18,6 +18,7 @@ package source
 
 import (
 	"context"
+
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/pkg/logging"
 

--- a/control-plane/pkg/reconciler/source/controller_test.go
+++ b/control-plane/pkg/reconciler/source/controller_test.go
@@ -17,6 +17,7 @@
 package source
 
 import (
+	"knative.dev/eventing/pkg/apis/feature"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -40,6 +41,7 @@ import (
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	kedaclient "knative.dev/eventing-kafka-broker/third_party/pkg/client/injection/client/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 )
 
 func TestNewController(t *testing.T) {
@@ -68,6 +70,10 @@ func TestNewController(t *testing.T) {
 	controller := NewController(ctx, configmap.NewStaticWatcher(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "config-kafka-features",
+		},
+	}, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: feature.FlagsConfigName,
 		},
 	}))
 	if controller == nil {

--- a/control-plane/pkg/reconciler/source/controller_test.go
+++ b/control-plane/pkg/reconciler/source/controller_test.go
@@ -17,8 +17,9 @@
 package source
 
 import (
-	"knative.dev/eventing/pkg/apis/feature"
 	"testing"
+
+	"knative.dev/eventing/pkg/apis/feature"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -19,6 +19,10 @@ package source
 import (
 	"context"
 	"fmt"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"knative.dev/eventing/pkg/apis/feature"
+	"knative.dev/eventing/pkg/auth"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -57,10 +61,12 @@ var (
 )
 
 type Reconciler struct {
-	ConsumerGroupLister internalslst.ConsumerGroupLister
-	InternalsClient     internalsclient.Interface
-	KedaClient          kedaclientset.Interface
-	KafkaFeatureFlags   *config.KafkaFeatureFlags
+	KubeClient           kubernetes.Interface
+	ConsumerGroupLister  internalslst.ConsumerGroupLister
+	InternalsClient      internalsclient.Interface
+	KedaClient           kedaclientset.Interface
+	KafkaFeatureFlags    *config.KafkaFeatureFlags
+	ServiceAccountLister corelisters.ServiceAccountLister
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, ks *sources.KafkaSource) reconciler.Event {
@@ -70,6 +76,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *sources.KafkaSource)
 		return fmt.Errorf("getting labels as selector: %v", err)
 	}
 	ks.Status.Selector = selector.String()
+
+	err = auth.SetupOIDCServiceAccount(ctx, feature.FromContext(ctx), r.ServiceAccountLister, r.KubeClient, sources.SchemeGroupVersion.WithKind("KafkaSource"), ks.ObjectMeta, &ks.Status, func(as *duckv1.AuthStatus) {
+		ks.Status.Auth = as
+	})
+	if err != nil {
+		return fmt.Errorf("could not setup OIDC service account for KafkaSource %s/%s: %w", ks.Name, ks.Namespace, err)
+	}
 
 	cg, err := r.reconcileConsumerGroup(ctx, ks)
 	if err != nil {

--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -19,11 +19,12 @@ package source
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/auth"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/control-plane/pkg/reconciler/source/source_test.go
+++ b/control-plane/pkg/reconciler/source/source_test.go
@@ -19,6 +19,8 @@ package source
 import (
 	"context"
 	"fmt"
+	"knative.dev/eventing/pkg/apis/feature"
+	"knative.dev/eventing/pkg/auth"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -52,6 +54,8 @@ import (
 	. "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/testing"
 
 	kedaclient "knative.dev/eventing-kafka-broker/third_party/pkg/client/injection/client/fake"
+
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 )
 
 const (
@@ -148,6 +152,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -202,6 +207,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -256,6 +262,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -315,6 +322,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -370,6 +378,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -506,6 +515,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSinkResolved(""),
 						SourceNetSaslTls(true),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -626,6 +636,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSinkResolved(""),
 						SourceNetSaslTls(false),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -688,6 +699,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -743,6 +755,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
 						WithAutoscalingAnnotationsSource(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -832,6 +845,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroup(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -897,6 +911,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroup(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -963,6 +978,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
 						WithAutoscalingAnnotationsSource(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -1027,6 +1043,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -1080,6 +1097,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
 						WithAutoscalingAnnotationsSource(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -1131,6 +1149,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -1183,6 +1202,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupFailed("failed", "failed"),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -1237,6 +1257,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSinkResolved(""),
 						StatusSourceConsumerGroupReplicas(1),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -1325,6 +1346,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSinkResolved(""),
 						StatusSourceConsumerGroupReplicas(1),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -1385,6 +1407,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceSinkResolved(""),
 						StatusSourceConsumerGroupReplicas(1),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -1439,6 +1462,7 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 					),
 				},
 			},
@@ -1493,6 +1517,66 @@ func TestReconcileKind(t *testing.T) {
 						StatusSourceConsumerGroupUnknown(),
 						StatusSourceSinkResolved(""),
 						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+					),
+				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
+		},
+		{
+			Name: "Reconciled normal - with OIDC enabled",
+			Ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.OIDCAuthentication: feature.Enabled,
+			}),
+			Objects: []runtime.Object{
+				NewSource(),
+			},
+			Key: testKey,
+			WantCreates: []runtime.Object{
+				makeKafkaSourceOIDCServiceAccount(),
+				NewConsumerGroup(
+					WithConsumerGroupFinalizer(),
+					WithConsumerGroupName(SourceUUID),
+					WithConsumerGroupNamespace(SourceNamespace),
+					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewSource())),
+					WithConsumerGroupMetaLabels(OwnerAsSourceLabel),
+					WithConsumerGroupLabels(ConsumerSourceLabel),
+					ConsumerGroupConsumerSpec(NewConsumerSpec(
+						ConsumerTopics(SourceTopics[0], SourceTopics[1]),
+						ConsumerConfigs(
+							ConsumerGroupIdConfig(SourceConsumerGroup),
+							ConsumerBootstrapServersConfig(SourceBootstrapServers),
+						),
+						ConsumerAuth(NewConsumerSpecAuth()),
+						ConsumerDelivery(
+							NewConsumerSpecDelivery(
+								sources.Ordered,
+								NewConsumerTimeout("PT600S"),
+								NewConsumerRetry(10),
+								NewConsumerBackoffDelay("PT0.3S"),
+								NewConsumerBackoffPolicy(eventingduck.BackoffPolicyExponential),
+								ConsumerInitialOffset(sources.OffsetLatest),
+							),
+						),
+						ConsumerSubscriber(NewSourceSinkReference()),
+						ConsumerReply(ConsumerNoReply()),
+					)),
+					ConsumerGroupReplicas(1),
+				),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: NewSource(
+						StatusSourceConsumerGroupUnknown(),
+						StatusSourceSinkResolved(""),
+						StatusSourceSelector(),
+						StatusSourceOIDCIdentityCreatedSucceeded(),
+						StatusSourceOIDCIdentity(makeKafkaSourceOIDCServiceAccount().Name),
 					),
 				},
 			},
@@ -1523,10 +1607,12 @@ func TestReconcileKind(t *testing.T) {
 		}
 
 		reconciler := &Reconciler{
-			ConsumerGroupLister: listers.GetConsumerGroupLister(),
-			InternalsClient:     fakeconsumergroupinformer.Get(ctx),
-			KedaClient:          kedaclient.Get(ctx),
-			KafkaFeatureFlags:   configapis.DefaultFeaturesConfig(),
+			ConsumerGroupLister:  listers.GetConsumerGroupLister(),
+			InternalsClient:      fakeconsumergroupinformer.Get(ctx),
+			KedaClient:           kedaclient.Get(ctx),
+			KafkaFeatureFlags:    configapis.DefaultFeaturesConfig(),
+			ServiceAccountLister: listers.GetServiceAccountLister(),
+			KubeClient:           fakekubeclient.Get(ctx),
 		}
 
 		reconciler.KafkaFeatureFlags = configapis.FromContext(store.ToContext(ctx))
@@ -1633,4 +1719,12 @@ func patchFinalizers() clientgotesting.PatchActionImpl {
 	patch := `{"metadata":{"finalizers":["` + finalizerName + `"],"resourceVersion":""}}`
 	action.Patch = []byte(patch)
 	return action
+}
+
+func makeKafkaSourceOIDCServiceAccount() *corev1.ServiceAccount {
+	return auth.GetOIDCServiceAccountForResource(sources.SchemeGroupVersion.WithKind("KafkaSource"), metav1.ObjectMeta{
+		Name:      SourceName,
+		Namespace: SourceNamespace,
+		UID:       SourceUUID,
+	})
 }

--- a/control-plane/pkg/reconciler/source/source_test.go
+++ b/control-plane/pkg/reconciler/source/source_test.go
@@ -19,9 +19,10 @@ package source
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/auth"
-	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"

--- a/control-plane/pkg/reconciler/testing/objects_source.go
+++ b/control-plane/pkg/reconciler/testing/objects_source.go
@@ -17,6 +17,7 @@
 package testing
 
 import (
+	"fmt"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,6 +25,7 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/apis/bindings/v1beta1"
 	sources "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1beta1"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
+	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/eventingtls/eventingtlstesting"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -249,6 +251,29 @@ func StatusSourceSinkNotResolved(err string) KRShapedOption {
 			"FailedToResolveSink",
 			err,
 		)
+	}
+}
+
+func StatusSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled() KRShapedOption {
+	return func(obj duckv1.KRShaped) {
+		ks := obj.(*sources.KafkaSource)
+		ks.Status.MarkOIDCIdentityCreatedSucceededWithReason(fmt.Sprintf("%s feature disabled", feature.OIDCAuthentication), "")
+	}
+}
+
+func StatusSourceOIDCIdentityCreatedSucceeded() KRShapedOption {
+	return func(obj duckv1.KRShaped) {
+		ks := obj.(*sources.KafkaSource)
+		ks.Status.MarkOIDCIdentityCreatedSucceeded()
+	}
+}
+
+func StatusSourceOIDCIdentity(saName string) KRShapedOption {
+	return func(obj duckv1.KRShaped) {
+		ks := obj.(*sources.KafkaSource)
+		ks.Status.Auth = &duckv1.AuthStatus{
+			ServiceAccountName: &saName,
+		}
 	}
 }
 

--- a/control-plane/pkg/reconciler/testing/objects_source.go
+++ b/control-plane/pkg/reconciler/testing/objects_source.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Fixes #3658

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :gift: Create KafkaSources OIDC service account and expose in its status

**Release Note**

```release-note
Create KafkaSources OIDC service account and expose in its status
```