### PR TITLE
fix selector path for cg scale subresource

### DIFF
--- a/control-plane/config/eventing-kafka-broker/100-kafka-internal/100-consumergroup.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-kafka-internal/100-consumergroup.yaml
@@ -34,7 +34,7 @@ spec:
           # statusReplicasPath defines the JSONPath inside a custom resource that corresponds to Scale.Status.Replicas.
           statusReplicasPath: .status.replicas
           # labelSelectorPath defines the JSONPath inside a custom resource that corresponds to Scale.Status.Selector
-          labelSelectorPath: .spec.selector
+          labelSelectorPath: .status.selector
       schema:
         openAPIV3Schema:
           type: object

--- a/control-plane/config/eventing-kafka-broker/100-kafka-internal/100-consumergroup.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-kafka-internal/100-consumergroup.yaml
@@ -34,7 +34,7 @@ spec:
           # statusReplicasPath defines the JSONPath inside a custom resource that corresponds to Scale.Status.Replicas.
           statusReplicasPath: .status.replicas
           # labelSelectorPath defines the JSONPath inside a custom resource that corresponds to Scale.Status.Selector
-          labelSelectorPath: .status.selector
+          labelSelectorPath: .spec.selector
       schema:
         openAPIV3Schema:
           type: object

--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
@@ -144,7 +144,7 @@ type ConsumerGroupStatus struct {
 
 	// Selector is the string serialized label selector needed for the scale subresource.
 	// Defaults to ""
-	Selector string `json:"selector"`
+	Selector string `json:"selector,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
@@ -141,6 +141,10 @@ type ConsumerGroupStatus struct {
 	// same Template, but individual replicas also have a consistent identity.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
+
+	// Selector is the string serialized label selector needed for the scale subresource.
+	// Defaults to ""
+	Selector string `json:"selector"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -178,6 +178,8 @@ type Reconciler struct {
 func (r *Reconciler) ReconcileKind(ctx context.Context, cg *kafkainternals.ConsumerGroup) reconciler.Event {
 	recordExpectedReplicasMetric(ctx, cg)
 
+	r.reconcileStatusSelector(cg)
+
 	if err := r.reconcileInitialOffset(ctx, cg); err != nil {
 		return cg.MarkInitializeOffsetFailed("InitializeOffset", err)
 	}
@@ -257,6 +259,10 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, cg *kafkainternals.Consum
 	r.InitOffsetLatestInitialOffsetCache.Expire(keyOf(cg))
 
 	return nil
+}
+
+func (r *Reconciler) reconcileStatusSelector(cg *kafkainternals.ConsumerGroup) {
+	cg.Status.Selector = labels.SelectorFromValidatedSet(cg.Spec.Selector).String()
 }
 
 func (r *Reconciler) deleteConsumerGroupMetadata(ctx context.Context, cg *kafkainternals.ConsumerGroup) error {

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
@@ -148,6 +148,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerGroupReplicas(2),
 							ConsumerGroupStatusReplicas(0),
 							ConsumerForTrigger(),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 						)
 						cg.Status.Placements = []eventingduckv1alpha1.Placement{
 							{PodName: "p1", VReplicas: 1},
@@ -234,6 +235,7 @@ func TestReconcileKind(t *testing.T) {
 								),
 							)),
 							ConsumerGroupReplicas(2),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerGroupStatusReplicas(0),
 							ConsumerForTrigger(),
 						)
@@ -340,6 +342,7 @@ func TestReconcileKind(t *testing.T) {
 								}),
 							)),
 							ConsumerGroupReplicas(2),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerForTrigger(),
 						)
 						cg.InitializeConditions()
@@ -448,6 +451,7 @@ func TestReconcileKind(t *testing.T) {
 								}),
 							)),
 							ConsumerGroupReplicas(2),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerGroupStatusReplicas(0),
 							ConsumerForTrigger(),
 						)
@@ -572,6 +576,7 @@ func TestReconcileKind(t *testing.T) {
 								}),
 							)),
 							ConsumerGroupReplicas(2),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerGroupStatusReplicas(1),
 							ConsumerForTrigger(),
 						)
@@ -758,6 +763,7 @@ func TestReconcileKind(t *testing.T) {
 								}),
 							)),
 							ConsumerGroupReplicas(2),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerForTrigger(),
 						)
 						cg.InitializeConditions()
@@ -974,6 +980,7 @@ func TestReconcileKind(t *testing.T) {
 							)),
 							ConsumerGroupReplicas(2),
 							ConsumerGroupStatusReplicas(1),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerForTrigger(),
 						)
 						cg.Status.Placements = []eventingduckv1alpha1.Placement{
@@ -1063,6 +1070,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerGroupReplicas(1),
 							ConsumerGroupStatusReplicas(0),
 							ConsumerForTrigger(),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 						)
 						cg.Status.Placements = []eventingduckv1alpha1.Placement{
 							{PodName: "p1", VReplicas: 1},
@@ -1144,6 +1152,7 @@ func TestReconcileKind(t *testing.T) {
 									ConsumerGroupIdConfig("my.group.id"),
 								),
 							)),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerGroupReplicas(2),
 							ConsumerGroupStatusReplicas(0),
 							ConsumerForTrigger(),
@@ -1230,6 +1239,7 @@ func TestReconcileKind(t *testing.T) {
 									ConsumerGroupIdConfig("my.group.id"),
 								),
 							)),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerGroupReplicas(2),
 							ConsumerGroupStatusReplicas(1),
 							ConsumerForTrigger(),
@@ -1358,6 +1368,7 @@ func TestReconcileKind(t *testing.T) {
 									ConsumerInitialOffset(sources.OffsetLatest),
 								)),
 							)),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerGroupReplicas(3),
 							ConsumerForTrigger(),
 						)
@@ -1468,6 +1479,7 @@ func TestReconcileKind(t *testing.T) {
 									ConsumerGroupIdConfig("my.group.id"),
 								),
 							)),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerGroupReplicas(3),
 							ConsumerForTrigger(),
 						)
@@ -1577,6 +1589,7 @@ func TestReconcileKind(t *testing.T) {
 									ConsumerGroupIdConfig("my.group.id"),
 								),
 							)),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerGroupReplicas(2),
 							ConsumerForTrigger(),
 						)
@@ -1640,6 +1653,7 @@ func TestReconcileKind(t *testing.T) {
 								),
 							)),
 							ConsumerGroupReplicas(2),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerForTrigger(),
 						)
 						cg.GetConditionSet().Manage(cg.GetStatus()).InitializeConditions()
@@ -1776,6 +1790,7 @@ func TestReconcileKindNoAutoscaler(t *testing.T) {
 								),
 							)),
 							ConsumerGroupReplicas(2),
+							ConsumerGroupStatusSelector(ConsumerLabels),
 							ConsumerGroupStatusReplicas(1),
 							ConsumerForTrigger(),
 						)

--- a/control-plane/pkg/reconciler/testing/objects_consumergroup.go
+++ b/control-plane/pkg/reconciler/testing/objects_consumergroup.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/pointer"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -186,6 +187,12 @@ func ConsumerGroupReplicas(replicas int32) ConsumerGroupOption {
 func ConsumerGroupStatusReplicas(replicas int32) ConsumerGroupOption {
 	return func(cg *kafkainternals.ConsumerGroup) {
 		cg.Status.Replicas = pointer.Int32(replicas)
+	}
+}
+
+func ConsumerGroupStatusSelector(label map[string]string) ConsumerGroupOption {
+	return func(cg *kafkainternals.ConsumerGroup) {
+		cg.Status.Selector = labels.SelectorFromSet(label).String()
 	}
 }
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Currently, we don't define the scale subresource correctly on the consumergroup, as we say that the `labelSelectorPath` is `.status.selector`, while we set `.spec.selector` instead. See the code here: https://github.com/knative-extensions/eventing-kafka-broker/blob/6012e1b19b407b20286c6b7c553f7acf4ec071a0/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_defaults.go#L41-L43

I believe this should fix the "SelectorRequired" warnings we see on the scaled objects reported in https://github.com/knative/eventing/issues/7655
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set the .status.selector json path with the required values
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug: the scale subresource is now correctly defined for consumergroups
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
