### PR TITLE
docs: add gnu sed requirement on contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ You need to install:
     - check
       [java.version](https://github.com/knative-extensions/eventing-kafka-broker/blob/master/data-plane/pom.xml)
       maven property for the required Java version used in this project
+- [`GNU sed`](https://www.gnu.org/software/sed/) - (_required_)
+    - To install on a macOS, you can run `brew install gnu-sed` to replace macOS default sed with GNU sed.
 - [`protoc`](https://github.com/protocolbuffers/protobuf)
      - To install protoc, you can follow https://grpc.io/docs/protoc-installation/
 - `protoc-gen-go`


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- `sed` fail to deploy using the command `./hack/run.sh deploy` since default macOS sed works differently than the GNU sed that is used by this repo.
- I have initially made a change in the run.sh script, but it sounds better to tell the macOS users to use a common(gnu-sed) sed version to avoid increasing the code base to check what OS the user is running, and run different parameters to achieve the same result.