### PR TITLE
feat: kafka broker now supports all kafka topic config options

### DIFF
--- a/control-plane/pkg/kafka/topic.go
+++ b/control-plane/pkg/kafka/topic.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"knative.dev/pkg/configmap"
 )
 
@@ -31,6 +32,7 @@ const (
 	DefaultTopicNumPartitionConfigMapKey      = "default.topic.partitions"
 	DefaultTopicReplicationFactorConfigMapKey = "default.topic.replication.factor"
 	BootstrapServersConfigMapKey              = "bootstrap.servers"
+	DefaultTopicConfigPrefix                  = "default.topic.config."
 
 	GroupIDConfigMapKey = "group.id"
 
@@ -95,6 +97,14 @@ func buildTopicConfigFromConfigMap(cm *corev1.ConfigMap) (*TopicConfig, error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config map %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+
+	topicDetail.ConfigEntries = make(map[string]*string)
+
+	for k, v := range cm.Data {
+		if s := strings.TrimPrefix(k, DefaultTopicConfigPrefix); s != k {
+			topicDetail.ConfigEntries[s] = pointer.String(v)
+		}
 	}
 
 	topicDetail.ReplicationFactor = int16(replicationFactor)

--- a/control-plane/pkg/kafka/topic.go
+++ b/control-plane/pkg/kafka/topic.go
@@ -99,10 +99,11 @@ func buildTopicConfigFromConfigMap(cm *corev1.ConfigMap) (*TopicConfig, error) {
 		return nil, fmt.Errorf("failed to parse config map %s/%s: %w", cm.Namespace, cm.Name, err)
 	}
 
-	topicDetail.ConfigEntries = make(map[string]*string)
-
 	for k, v := range cm.Data {
 		if s := strings.TrimPrefix(k, DefaultTopicConfigPrefix); s != k {
+			if topicDetail.ConfigEntries == nil {
+				topicDetail.ConfigEntries = make(map[string]*string)
+			}
 			topicDetail.ConfigEntries[s] = pointer.String(v)
 		}
 	}

--- a/control-plane/pkg/kafka/topic_test.go
+++ b/control-plane/pkg/kafka/topic_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 
 	kafkatesting "knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/testing"
@@ -437,6 +438,27 @@ func TestTopicConfigFromConfigMap(t *testing.T) {
 				TopicDetail: sarama.TopicDetail{
 					NumPartitions:     5,
 					ReplicationFactor: 8,
+				},
+				BootstrapServers: []string{"server1:9092", "server2:9092"},
+			},
+		},
+		{
+			name: "All valid, config options provided",
+			data: map[string]string{
+				"default.topic.partitions":               "5",
+				"default.topic.replication.factor":       "8",
+				"bootstrap.servers":                      "server1:9092, server2:9092",
+				"default.topic.config.retention.ms":      "3600",
+				"default.topic.config.max.message.bytes": "68000",
+			},
+			want: TopicConfig{
+				TopicDetail: sarama.TopicDetail{
+					NumPartitions:     5,
+					ReplicationFactor: 8,
+					ConfigEntries: map[string]*string{
+						"retention.ms":      pointer.String("3600"),
+						"max.message.bytes": pointer.String("68000"),
+					},
 				},
 				BootstrapServers: []string{"server1:9092", "server2:9092"},
 			},


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #1638 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Parse all configmap values with prefix `default.topic.config.` into the topic config entries

This approach allows us to support any future changes to the kafka topic config options automatically. The user will still get a message when they provide an incorrect config option as the kafka server will reject the create topic request telling them what went wrong:

```
lastTransitionTime: "2024-02-05T21:25:12Z"
    message: 'kafka server: Configuration is invalid - Unknown topic config name: unknown-config'
    reason: 'Failed to create topic: knative-broker-default-broker-3'
    status: "False"
    type: Ready
```

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Auto created topics by brokers now support the full set of topic config options, set them by using the prefix `default.topic.config.` in your kafka-broker-config configmap. 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

Will open a docs PR if this approach is accepted
