### PR TITLE
feat: remove keda objects during reconciliation

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -864,7 +864,7 @@ func (r *Reconciler) deleteKedaObjects(ctx context.Context) error {
 		// delete scaled object
 		scaledObjects, err := r.KedaClient.KedaV1alpha1().ScaledObjects(namespace.Namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to list available scaled objects: %w", err)
+			return fmt.Errorf("failed to list available Keda scaled objects: %w", err)
 		}
 
 		for _, scaledObject := range scaledObjects.Items {
@@ -881,7 +881,7 @@ func (r *Reconciler) deleteKedaObjects(ctx context.Context) error {
 		// delete trigger authentication
 		triggerAuths, err := r.KedaClient.KedaV1alpha1().TriggerAuthentications(namespace.Namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to list available Keda trigger authentication objects: %w", err)
 		}
 
 		for _, triggerAuth := range triggerAuths.Items {

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -867,7 +867,7 @@ func (r *Reconciler) deleteKedaObjects(ctx context.Context, cg *kafkainternals.C
 		return nil
 	}
 
-	// if there is a trigger authentication tight to the consumer group, delete it
+	// if there is a trigger authentication tight to the consumer group, delete it! and then delete the scaled object
 	if metav1.IsControlledBy(scaledObject, cg) {
 		triggerAuthName := string(cg.ObjectMeta.OwnerReferences[0].UID)
 
@@ -877,15 +877,15 @@ func (r *Reconciler) deleteKedaObjects(ctx context.Context, cg *kafkainternals.C
 		}
 
 		logging.FromContext(ctx).Infoln("Keda trigger authentication deleted")
-	}
 
-	// delete scaled object
-	err = r.KedaClient.KedaV1alpha1().ScaledObjects(cg.Namespace).Delete(ctx, scaledObjectName, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete Keda scaled object: %w", err)
-	}
-	if err == nil {
-		logging.FromContext(ctx).Infoln("Keda scaled object deleted")
+		// delete scaled object
+		err = r.KedaClient.KedaV1alpha1().ScaledObjects(cg.Namespace).Delete(ctx, scaledObjectName, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete Keda scaled object: %w", err)
+		}
+		if err == nil {
+			logging.FromContext(ctx).Infoln("Keda scaled object deleted")
+		}
 	}
 
 	return nil

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -863,6 +863,10 @@ func (r *Reconciler) deleteKedaObjects(ctx context.Context, cg *kafkainternals.C
 		return fmt.Errorf("failed to get Keda scaled object: %w", err)
 	}
 
+	if scaledObject == nil {
+		return nil
+	}
+
 	// if there is a trigger authentication tight to the consumer group, delete it
 	if metav1.IsControlledBy(scaledObject, cg) {
 		triggerAuthName := string(cg.ObjectMeta.OwnerReferences[0].UID)

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -867,8 +867,11 @@ func (r *Reconciler) deleteKedaObjects(ctx context.Context, cg *kafkainternals.C
 		return nil
 	}
 
-	// if there is a trigger authentication tight to the consumer group, delete it! and then delete the scaled object
+	// if there is a trigger authentication tight to the consumer group, delete it, and then delete the scaled object
 	if metav1.IsControlledBy(scaledObject, cg) {
+		if len(cg.ObjectMeta.OwnerReferences) == 0 {
+			return fmt.Errorf("failed to delete Keda objects, missing owners reference: %w", err)
+		}
 		triggerAuthName := string(cg.ObjectMeta.OwnerReferences[0].UID)
 
 		err = r.KedaClient.KedaV1alpha1().TriggerAuthentications(cg.Namespace).Delete(ctx, triggerAuthName, metav1.DeleteOptions{})


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #3669 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

Remove Keda objects during reconciliation if [configmap] **config-kafka-features/controller-autoscaler-keda** is set to `disabled`.

```release-note
- remove Keda objects during reconciliation
```

* early feedback welcome / will add unit tests before marking it as ready