### PR TITLE
Dispatcher authenticate requests

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -140,6 +140,13 @@ rules:
       - update
       - create
       - delete
+  # To grant NamespacedBroker permissions to create OIDC tokens
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
 
   # Scheduler permissions
   - apiGroups:

--- a/data-plane/config/broker/200-broker-data-plane-cluster-role.yaml
+++ b/data-plane/config/broker/200-broker-data-plane-cluster-role.yaml
@@ -29,3 +29,9 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create

--- a/data-plane/config/channel/200-channel-data-plane-cluster-role.yaml
+++ b/data-plane/config/channel/200-channel-data-plane-cluster-role.yaml
@@ -29,3 +29,9 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create

--- a/data-plane/config/source/200-source-data-plane-cluster-role.yaml
+++ b/data-plane/config/source/200-source-data-plane-cluster-role.yaml
@@ -29,3 +29,9 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -18,6 +18,7 @@ package dev.knative.eventing.kafka.broker.dispatcher.main;
 import static dev.knative.eventing.kafka.broker.core.utils.Logging.keyValue;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.core.NamespacedName;
 import dev.knative.eventing.kafka.broker.core.ReactiveKafkaConsumer;
 import dev.knative.eventing.kafka.broker.core.ReactiveKafkaProducer;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
@@ -100,6 +101,7 @@ public class ConsumerVerticleBuilder {
         final var metricsCloser = Metrics.register(consumer.unwrap());
         consumerVerticle.setCloser(metricsCloser);
 
+        // setting up cloud events sender
         final var egressSubscriberSender = createConsumerRecordSender(vertx);
         final var egressDeadLetterSender = createDeadLetterSinkRecordSender(vertx);
         final var responseHandler = createResponseHandler(vertx);
@@ -232,6 +234,10 @@ public class ConsumerVerticleBuilder {
                             createWebClientOptionsFromCACerts(
                                     consumerVerticleContext.getEgress().getReplyUrlCACerts())),
                     consumerVerticleContext.getEgress().getReplyUrl(),
+                    consumerVerticleContext.getEgress().getReplyUrlAudience(),
+                    new NamespacedName(
+                            consumerVerticleContext.getResource().getReference().getNamespace(),
+                            consumerVerticleContext.getEgress().getOidcServiceAccountName()),
                     consumerVerticleContext,
                     Metrics.Tags.senderContext("reply")));
         }
@@ -257,6 +263,10 @@ public class ConsumerVerticleBuilder {
                         createWebClientOptionsFromCACerts(
                                 consumerVerticleContext.getEgress().getDestinationCACerts())),
                 consumerVerticleContext.getEgress().getDestination(),
+                consumerVerticleContext.getEgress().getDestinationAudience(),
+                new NamespacedName(
+                        consumerVerticleContext.getResource().getReference().getNamespace(),
+                        consumerVerticleContext.getEgress().getOidcServiceAccountName()),
                 consumerVerticleContext,
                 Metrics.Tags.senderContext("subscriber"));
     }
@@ -275,6 +285,10 @@ public class ConsumerVerticleBuilder {
                             createWebClientOptionsFromCACerts(
                                     consumerVerticleContext.getEgressConfig().getDeadLetterCACerts())),
                     consumerVerticleContext.getEgressConfig().getDeadLetter(),
+                    consumerVerticleContext.getEgressConfig().getDeadLetterAudience(),
+                    new NamespacedName(
+                            consumerVerticleContext.getResource().getReference().getNamespace(),
+                            consumerVerticleContext.getEgress().getOidcServiceAccountName()),
                     consumerVerticleContext,
                     Metrics.Tags.senderContext("deadlettersink"));
         }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSenderTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
+import dev.knative.eventing.kafka.broker.core.NamespacedName;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.dispatcher.main.FakeConsumerVerticleContext;
 import io.cloudevents.core.builder.CloudEventBuilder;
@@ -69,7 +70,13 @@ public class WebClientCloudEventSenderTest {
         doNothing().when(webClient).close();
 
         final var consumerRecordSender = new WebClientCloudEventSender(
-                vertx, webClient, "http://localhost:12345", FakeConsumerVerticleContext.get(), Tags.empty());
+                vertx,
+                webClient,
+                "http://localhost:12345",
+                "",
+                new NamespacedName("", ""),
+                FakeConsumerVerticleContext.get(),
+                Tags.empty());
 
         consumerRecordSender
                 .close()
@@ -115,6 +122,8 @@ public class WebClientCloudEventSenderTest {
                 vertx,
                 WebClient.create(vertx),
                 "http://localhost:" + port,
+                "",
+                new NamespacedName("", ""),
                 FakeConsumerVerticleContext.get(
                         FakeConsumerVerticleContext.get().getResource(),
                         DataPlaneContract.Egress.newBuilder(
@@ -174,6 +183,8 @@ public class WebClientCloudEventSenderTest {
                 vertx,
                 WebClient.create(vertx),
                 "http://localhost:" + port,
+                "",
+                new NamespacedName("", ""),
                 FakeConsumerVerticleContext.get(
                         FakeConsumerVerticleContext.get().getResource(),
                         DataPlaneContract.Egress.newBuilder(
@@ -236,6 +247,8 @@ public class WebClientCloudEventSenderTest {
                 vertx,
                 WebClient.create(vertx),
                 "http://localhost:" + port,
+                "",
+                new NamespacedName("", ""),
                 FakeConsumerVerticleContext.get(
                         FakeConsumerVerticleContext.get().getResource(),
                         DataPlaneContract.Egress.newBuilder(
@@ -292,6 +305,8 @@ public class WebClientCloudEventSenderTest {
                 vertx,
                 WebClient.create(vertx),
                 "http://localhost:" + port,
+                "",
+                new NamespacedName("", ""),
                 FakeConsumerVerticleContext.get(
                         FakeConsumerVerticleContext.get().getResource(),
                         DataPlaneContract.Egress.newBuilder(
@@ -357,6 +372,8 @@ public class WebClientCloudEventSenderTest {
                 vertx,
                 WebClient.create(vertx),
                 "http://localhost:" + port,
+                "",
+                new NamespacedName("", ""),
                 FakeConsumerVerticleContext.get(
                         FakeConsumerVerticleContext.get().getResource(),
                         DataPlaneContract.Egress.newBuilder(

--- a/test/e2e_new_channel/kafka_channel_test.go
+++ b/test/e2e_new_channel/kafka_channel_test.go
@@ -75,6 +75,21 @@ func TestKafkaChannelReadiness(t *testing.T) {
 	}
 }
 
+func TestKafkaChannelDispatcherAuthenticatesWithOIDC(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	env.Test(ctx, t, channel.DispatcherAuthenticatesRequestsWithOIDC())
+}
+
 func TestKafkaChannelOIDC(t *testing.T) {
 	// Run Test In Parallel With Others
 	t.Parallel()


### PR DESCRIPTION
Fixes #3578

## Proposed Changes

- :gift: Add OIDC token to requests, when target (subscriber/reply/DLS) has an audience set


**Release Note**
```release-note
Authenticate requests in case target has an OIDC audience set
```