### PR TITLE
Use filtered global resync for triggers

### DIFF
--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -121,7 +121,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *conf
 	})
 
 	globalResync := func(_ interface{}) {
-		impl.GlobalResync(triggerInformer.Informer())
+		impl.FilteredGlobalResync(filterTriggers(reconciler.BrokerLister, kafka.BrokerClass, FinalizerName), triggerInformer.Informer())
 	}
 
 	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"), func(name string, value interface{}) {


### PR DESCRIPTION
The current global resync accidently queues triggers that aren't associated with our brokers.

This fixes flakes like 
```
TestTriggerNoFinalizer/0/Unknown_Broker_Class_-_Unknown/Assert/eventually_trigger_has_no_finalizer
```

in https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative-extensions_eventing-kafka-broker/3671/reconciler-tests_eventing-kafka-broker_main/1755226033222586368