### PR TITLE
Add broker OIDC e2e tests

### DIFF
--- a/test/e2e_new/templates/kafka-broker/broker.yaml
+++ b/test/e2e_new/templates/kafka-broker/broker.yaml
@@ -64,6 +64,13 @@ spec:
       {{ if .delivery.deadLetterSink.uri }}
       uri: {{ .delivery.deadLetterSink.uri }}
       {{ end }}
+      {{ if .delivery.deadLetterSink.CACerts }}
+      CACerts: |-
+        {{ .delivery.deadLetterSink.CACerts }}
+      {{ end }}
+      {{ if .delivery.deadLetterSink.audience }}
+      audience: {{ .delivery.deadLetterSink.audience }}
+      {{ end }}
     {{ end }}
     {{ if .delivery.retry }}
     retry: {{ .delivery.retry}}


### PR DESCRIPTION
Fixes #3684

## Proposed Changes

- :gift: Add OIDC e2e tests for Broker

The call in reconciler-tests.sh to run the OIDC tests was added in #3675 already:
https://github.com/knative-extensions/eventing-kafka-broker/blob/d6a383fff58047078c232f83bdcbe9e88d402891/test/reconciler-tests.sh#L57-L61