### PR TITLE
Expose reasons for BindInProgress by adding pod status summary

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_lifecycle.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_lifecycle.go
@@ -59,6 +59,10 @@ func (c *Consumer) MarkBindInProgress() {
 	c.GetConditionSet().Manage(c.GetStatus()).MarkFalse(ConsumerConditionBind, "BindInProgress", "")
 }
 
+func (c *Consumer) MarkBindInProgressWithMessage(messageFormat string, messageA ...interface{}) {
+	c.GetConditionSet().Manage(c.GetStatus()).MarkFalse(ConsumerConditionBind, "BindInProgress", messageFormat, messageA...)
+}
+
 func (c *Consumer) MarkBindSucceeded() {
 	c.GetConditionSet().Manage(c.GetStatus()).MarkTrue(ConsumerConditionBind)
 }

--- a/control-plane/pkg/reconciler/consumer/consumer.go
+++ b/control-plane/pkg/reconciler/consumer/consumer.go
@@ -18,7 +18,9 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -75,6 +77,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, c *kafkainternals.Consum
 	}
 
 	bound, err := r.schedule(ctx, logger, c, addResource(resourceCt), IsPodNotRunning)
+	var sErr *PodStatusSummary
+	if errors.As(err, &sErr) {
+		// Resource will get queued once we have all resources to schedule the Consumer.
+		c.MarkBindInProgressWithMessage(sErr.Error())
+		return nil
+	}
 	if err != nil {
 		return c.MarkBindFailed(err)
 	}
@@ -385,7 +393,7 @@ func (r *Reconciler) schedule(ctx context.Context, logger *zap.Logger, c *kafkai
 	// it won't become ready until we have created the
 	// ConfigMap
 	if shouldWait(p) {
-		return false, nil
+		return false, summarizePodStatus(p)
 	}
 
 	ct, err := b.GetDataPlaneConfigMapData(logger, cm)
@@ -464,4 +472,32 @@ func (r *Reconciler) setTrustBundles(ct *contract.Contract) error {
 	}
 	ct.TrustBundles = tb
 	return nil
+}
+
+type PodStatusSummary struct {
+	Pod *corev1.Pod
+}
+
+func (s *PodStatusSummary) Error() string {
+	return fmt.Sprintf("Pod %q is in phase %q with conditions %s", s.Pod.Name, string(s.Pod.Status.Phase), summarizePodConditions(s.Pod.Status.Conditions))
+}
+
+func summarizePodConditions(conditions []corev1.PodCondition) string {
+	sb := strings.Builder{}
+	sb.WriteRune('[')
+	for i, c := range conditions {
+		sb.WriteString(string(c.Type))
+		sb.WriteRune('=')
+		sb.WriteString(string(c.Status))
+		if len(conditions)-1 != i {
+			sb.WriteString(", ")
+		}
+	}
+	sb.WriteRune(']')
+
+	return sb.String()
+}
+
+func summarizePodStatus(p *corev1.Pod) *PodStatusSummary {
+	return &PodStatusSummary{Pod: p}
 }


### PR DESCRIPTION
This will make clear the reasons for BindInProgress status, especially when pods cannot be scheduled when there are not enough resources