### PR TITLE
Check status code of OIDC discovery response

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCDiscoveryConfig.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCDiscoveryConfig.java
@@ -68,7 +68,8 @@ public class OIDCDiscoveryConfig {
 
                     try {
                         if (res.statusCode() >= 400) {
-                          return Future.failedFuture("Unexpected status (" + res.statusCode() + ") on OIDC discovery endpoint: " + res.bodyAsString());
+                            return Future.failedFuture("Unexpected status (" + res.statusCode()
+                                    + ") on OIDC discovery endpoint: " + res.bodyAsString());
                         }
 
                         ObjectMapper mapper = new ObjectMapper();

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCDiscoveryConfig.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCDiscoveryConfig.java
@@ -67,7 +67,7 @@ public class OIDCDiscoveryConfig {
                     logger.debug("Got raw OIDC discovery info: " + res.bodyAsString());
 
                     try {
-                        if (res.statusCode() >= 400) {
+                        if (res.statusCode() != 200) {
                             return Future.failedFuture("Unexpected status (" + res.statusCode()
                                     + ") on OIDC discovery endpoint: " + res.bodyAsString());
                         }

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCDiscoveryConfig.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/oidc/OIDCDiscoveryConfig.java
@@ -34,6 +34,8 @@ public class OIDCDiscoveryConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(TokenVerifier.class);
 
+    private static final String OIDC_DISCOVERY_URL = "https://kubernetes.default.svc/.well-known/openid-configuration";
+
     private String issuer;
 
     private JwksVerificationKeyResolver jwksVerificationKeyResolver;
@@ -58,13 +60,17 @@ public class OIDCDiscoveryConfig {
         OIDCDiscoveryConfig oidcDiscoveryConfig = new OIDCDiscoveryConfig();
 
         return webClient
-                .getAbs("https://kubernetes.default.svc/.well-known/openid-configuration")
+                .getAbs(OIDC_DISCOVERY_URL)
                 .bearerTokenAuthentication(kubeConfig.getAutoOAuthToken())
                 .send()
                 .compose(res -> {
                     logger.debug("Got raw OIDC discovery info: " + res.bodyAsString());
 
                     try {
+                        if (res.statusCode() >= 400) {
+                          return Future.failedFuture("Unexpected status (" + res.statusCode() + ") on OIDC discovery endpoint: " + res.bodyAsString());
+                        }
+
                         ObjectMapper mapper = new ObjectMapper();
                         OIDCInfo oidcInfo = mapper.readValue(res.bodyAsString(), OIDCInfo.class);
 


### PR DESCRIPTION
Fixes #3674 

## Proposed Changes

- :bug: Check status code of response of OIDC discovery before setting up OIDC info to prevent JSON parse exception