### PR TITLE
add egress uuid and name to span

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/tracing/TracingSpan.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/tracing/TracingSpan.java
@@ -17,6 +17,7 @@ package dev.knative.eventing.kafka.broker.core.tracing;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
+import dev.knative.eventing.kafka.broker.contract.DataPlaneContract.Egress;
 import io.cloudevents.CloudEvent;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
@@ -26,6 +27,8 @@ public class TracingSpan {
     private static final AttributeKey<String> MESSAGING_MESSAGE_ID = stringKey("messaging.message_id");
     private static final AttributeKey<String> MESSAGING_MESSAGE_SOURCE = stringKey("messaging.message_source");
     private static final AttributeKey<String> MESSAGING_MESSAGE_TYPE = stringKey("messaging.message_type");
+    private static final AttributeKey<String> EGRESS_UUID = stringKey("egress.uuid");
+    private static final AttributeKey<String> EGRESS_NAME = stringKey("egress.name");
 
     public static void decorateCurrentWithEvent(final CloudEvent event) {
         Span span = Span.fromContextOrNull(Context.current());
@@ -35,5 +38,14 @@ public class TracingSpan {
         span.setAttribute(MESSAGING_MESSAGE_ID, event.getId());
         span.setAttribute(MESSAGING_MESSAGE_SOURCE, event.getSource().toString());
         span.setAttribute(MESSAGING_MESSAGE_TYPE, event.getType());
+    }
+
+    public static void decorateCurrentWithEgress(final Egress egress) {
+        Span span = Span.fromContextOrNull(Context.current());
+        if (span == null) {
+            return;
+        }
+        span.setAttribute(EGRESS_UUID, egress.getReference().getUuid());
+        span.setAttribute(EGRESS_NAME, egress.getReference().getName());
     }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
@@ -123,6 +123,7 @@ public final class WebClientCloudEventSender implements CloudEventSender {
         } else {
             try {
                 TracingSpan.decorateCurrentWithEvent(event);
+                TracingSpan.decorateCurrentWithEgress(consumerVerticleContext.getEgress());
                 requestEmitted();
                 // here we send the event
                 send(event, promise).onComplete(v -> requestCompleted());


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #3720 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- decorate current span with egress name and uuid, when we are sending event to the sink.
