### PR TITLE
Replace bash script log collector with a more resilient go based log collector

### DIFF
--- a/test/e2e_new/main_test.go
+++ b/test/e2e_new/main_test.go
@@ -20,9 +20,13 @@
 package e2e_new
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"os"
 	"testing"
+
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -31,6 +35,7 @@ import (
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/pkg/test/zipkin"
 
+	"knative.dev/eventing-kafka-broker/test/pkg/logging"
 	"knative.dev/reconciler-test/pkg/environment"
 )
 
@@ -52,6 +57,19 @@ func TestMain(m *testing.M) {
 		// place that cleans it up. If an individual test calls this instead, then it will break other
 		// tests that need the tracing in place.
 		defer zipkin.CleanupZipkinTracingSetup(log.Printf)
+		ctx, _ := global.Environment()
+		// make sure that this context only cancels after the tests finish running
+		ctx = context.WithoutCancel(ctx)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		client := kubeclient.Get(ctx)
+		logger := logging.NewLogger(ctx, client, map[string][]string{"knative-eventing": {"kafka-broker-dispatcher", "kafka-broker-receiver", "kafka-sink-receiver", "kafka-channel-receiver", "kafka-channel-dispatcher", "kafka-source-dispatcher", "kafka-webhook-eventing", "kafka-controller", "kafka-source-controller", "eventing-webhook"}})
+		err := logger.Start()
+		if err != nil {
+			fmt.Printf("failed to start logger: %s", err.Error())
+		}
+
 		return m.Run()
 	}())
 }

--- a/test/pkg/logging/logging.go
+++ b/test/pkg/logging/logging.go
@@ -116,12 +116,12 @@ func (l *logger) Start() error {
 	return nil
 }
 
-func (l *logger) startForPod(pod *corev1.Pod, artifactsDirt string) {
+func (l *logger) startForPod(pod *corev1.Pod, artifactsDir string) {
 	for _, container := range pod.Spec.Containers {
 		podNs, podName, containerName := pod.Namespace, pod.Name, container.Name
 
 		go func() {
-			f, err := os.OpenFile(fmt.Sprintf("%s/new-logs/%s-%s.log", artifactsDirt, podName, containerName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			f, err := os.OpenFile(fmt.Sprintf("%s/new-logs/%s-%s.log", artifactsDir, podName, containerName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				return
 			}

--- a/test/pkg/logging/logging.go
+++ b/test/pkg/logging/logging.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2024 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/ptr"
+)
+
+type Logger interface {
+	Start() error
+}
+
+type logger struct {
+	labelsByNamespace map[string][]string
+	kc                kubernetes.Interface
+	ctx               context.Context
+}
+
+func NewLogger(ctx context.Context, client kubernetes.Interface, labelsByNamespace map[string][]string) Logger {
+	return &logger{
+		ctx:               ctx,
+		kc:                client,
+		labelsByNamespace: labelsByNamespace,
+	}
+}
+
+func (l *logger) Start() error {
+	if len(l.labelsByNamespace) == 0 {
+		return fmt.Errorf("you need to have at least one namespace to get logs from")
+	}
+
+	artifacts := os.Getenv("ARTIFACTS")
+
+	if _, err := os.Stat(fmt.Sprintf("%s/new-logs", artifacts)); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(fmt.Sprintf("%s/new-logs", artifacts), os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+
+	for ns, ls := range l.labelsByNamespace {
+		requirement, err := labels.NewRequirement("app", selection.In, ls)
+		if err != nil {
+			return err
+		}
+
+		selector := labels.NewSelector().Add(*requirement)
+		watcher, err := l.kc.CoreV1().Pods(ns).Watch(l.ctx, metav1.ListOptions{LabelSelector: selector.String()})
+		if err != nil {
+			return err
+		}
+
+		go func() {
+			defer watcher.Stop()
+			watchedPods := sets.New[string]()
+			fileWriters := map[string]*os.File{}
+
+			for {
+				select {
+				case <-l.ctx.Done():
+					for _, writer := range fileWriters {
+						writer.Close()
+					}
+					return
+				case event := <-watcher.ResultChan():
+					if event.Object == nil || reflect.ValueOf(event.Object).IsNil() {
+						continue
+					}
+
+					pod, ok := event.Object.(*corev1.Pod)
+					if !ok {
+						continue
+					}
+
+					switch event.Type {
+					case watch.Deleted:
+						watchedPods.Delete(pod.Name)
+					case watch.Added, watch.Modified:
+						if !watchedPods.Has(pod.Name) && isPodReady(pod) {
+							label, ok := pod.Labels["app"]
+							if !ok {
+								continue
+							}
+							fileWriter, ok := fileWriters[label]
+							if !ok {
+								f, err := os.OpenFile(fmt.Sprintf("%s/new-logs/%s.log", artifacts, label), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+								if err != nil {
+									continue
+								}
+								fileWriter = f
+								fileWriters[label] = f
+							}
+							watchedPods.Insert(pod.Name)
+							l.startForPod(pod, fileWriter)
+						}
+					}
+				}
+			}
+		}()
+	}
+
+	return nil
+}
+
+func (l *logger) startForPod(pod *corev1.Pod, fileWriter io.Writer) {
+	for _, container := range pod.Spec.Containers {
+		podNs, podName, containerName := pod.Namespace, pod.Name, container.Name
+		fileWriter := fileWriter
+
+		go func() {
+			options := &corev1.PodLogOptions{
+				Container:    containerName,
+				Follow:       true,
+				SinceSeconds: ptr.Int64(1),
+			}
+
+			req := l.kc.CoreV1().Pods(podNs).GetLogs(podName, options)
+			stream, err := req.Stream(context.Background())
+			if err != nil {
+				return
+			}
+			defer stream.Close()
+
+			for scanner := bufio.NewScanner(stream); scanner.Scan(); {
+				fileWriter.Write(scanner.Bytes())
+			}
+		}()
+	}
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase == corev1.PodRunning && pod.DeletionTimestamp == nil {
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/test/pkg/logging/logging.go
+++ b/test/pkg/logging/logging.go
@@ -151,7 +151,7 @@ func (l *logger) startForPod(pod *corev1.Pod, fileWriter io.Writer) {
 			defer stream.Close()
 
 			for scanner := bufio.NewScanner(stream); scanner.Scan(); {
-				fileWriter.Write(scanner.Bytes())
+				fileWriter.Write(append(scanner.Bytes(), '\n'))
 			}
 		}()
 	}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Currently, the e2e tests just use `kubectl logs -f ...` to collect logs. This leads to issues if the pod goes away, as no more logs are collected. We have been seeing this in CI recently with the logs from the kafka-controller only including about 5 minutes worth of logs.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use a go based logging solution that picks up on any new pods and starts gathering those logs too.
- Put this into a separate directory so that we can ensure that this works before fully switching the logging solution used in CI
