### PR TITLE
Use error log level when contract parsing fails

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventbus/ContractPublisher.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventbus/ContractPublisher.java
@@ -98,7 +98,7 @@ public class ContractPublisher implements Consumer<DataPlaneContract.Contract>, 
             this.parser.merge(content, contract);
             return contract.build();
         } catch (final InvalidProtocolBufferException ex) {
-            logger.debug("failed to parse from JSON", ex);
+            logger.error("failed to parse from JSON", ex);
         }
         return null;
     }


### PR DESCRIPTION
As per title to have this issue not missed.