### PR TITLE
[release-1.13] Bump CloudEvents GO-SDK to 2.15.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/IBM/sarama v1.41.2
 	github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.3.1-0.20230918062809-28780a762825
-	github.com/cloudevents/sdk-go/v2 v2.13.0
+	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.3.1-0.20230918062809-2
 github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.3.1-0.20230918062809-28780a762825/go.mod h1:hh+AlY88cpaWzAJXrcTer/IEqOjZoHc/nQOYmnRZgqE=
 github.com/cloudevents/sdk-go/sql/v2 v2.13.0 h1:gMJvQ3XFkygY9JmrusgK80d9yRAb8+J3X8IA1OC+oc0=
 github.com/cloudevents/sdk-go/sql/v2 v2.13.0/go.mod h1:XZRQBCgRreddIpQrdjBJQUrRg3BCs3aikplJQkHrK44=
-github.com/cloudevents/sdk-go/v2 v2.13.0 h1:2zxDS8RyY1/wVPULGGbdgniGXSzLaRJVl136fLXGsYw=
-github.com/cloudevents/sdk-go/v2 v2.13.0/go.mod h1:xDmKfzNjM8gBvjaF8ijFjM1VYOVUEeUfapHMUX1T5To=
+github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=
+github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+gqO04wryn5h75LSazbRlnya1k=
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=

--- a/vendor/github.com/cloudevents/sdk-go/v2/alias.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/alias.go
@@ -135,8 +135,14 @@ var (
 	ToMessage = binding.ToMessage
 
 	// Event Creation
-	NewEventFromHTTPRequest  = http.NewEventFromHTTPRequest
-	NewEventFromHTTPResponse = http.NewEventFromHTTPResponse
+
+	NewEventFromHTTPRequest   = http.NewEventFromHTTPRequest
+	NewEventFromHTTPResponse  = http.NewEventFromHTTPResponse
+	NewEventsFromHTTPRequest  = http.NewEventsFromHTTPRequest
+	NewEventsFromHTTPResponse = http.NewEventsFromHTTPResponse
+	NewHTTPRequestFromEvent   = http.NewHTTPRequestFromEvent
+	NewHTTPRequestFromEvents  = http.NewHTTPRequestFromEvents
+	IsHTTPBatch               = http.IsHTTPBatch
 
 	// HTTP Messages
 

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/doc.go
@@ -4,7 +4,6 @@
 */
 
 /*
-
 Package binding defines interfaces for protocol bindings.
 
 NOTE: Most applications that emit or consume events should use the ../client
@@ -16,11 +15,11 @@ Receiver and a Sender belonging to different bindings. This is useful for
 intermediary applications that route or forward events, but not necessary for
 most "endpoint" applications that emit or consume events.
 
-Protocol Bindings
+# Protocol Bindings
 
 A protocol binding usually implements a Message, a Sender and Receiver, a StructuredWriter and a BinaryWriter (depending on the supported encodings of the protocol) and an Write[ProtocolMessage] method.
 
-Read and write events
+# Read and write events
 
 The core of this package is the binding.Message interface.
 Through binding.MessageReader It defines how to read a protocol specific message for an
@@ -49,7 +48,7 @@ The binding.Write method tries to preserve the structured/binary encoding, in or
 Messages can be eventually wrapped to change their behaviours and binding their lifecycle, like the binding.FinishMessage.
 Every Message wrapper implements the MessageWrapper interface
 
-Sender and Receiver
+# Sender and Receiver
 
 A Receiver receives protocol specific messages and wraps them to into binding.Message implementations.
 
@@ -60,9 +59,8 @@ Message and ExactlyOnceMessage provide methods to allow acknowledgments to
 propagate when a reliable messages is forwarded from a Receiver to a Sender.
 QoS 0 (unreliable), 1 (at-least-once) and 2 (exactly-once) are supported.
 
-Transport
+# Transport
 
 A binding implementation providing Sender and Receiver implementations can be used as a Transport through the BindingTransport adapter.
-
 */
 package binding

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/encoding.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/encoding.go
@@ -11,14 +11,17 @@ import "errors"
 type Encoding int
 
 const (
-	// Binary encoding as specified in https://github.com/cloudevents/spec/blob/master/spec.md#message
+	// Binary encoding as specified in https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message
 	EncodingBinary Encoding = iota
-	// Structured encoding as specified in https://github.com/cloudevents/spec/blob/master/spec.md#message
+	// Structured encoding as specified in https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message
 	EncodingStructured
 	// Message is an instance of EventMessage or it contains EventMessage nested (through MessageWrapper)
 	EncodingEvent
 	// When the encoding is unknown (which means that the message is a non-event)
 	EncodingUnknown
+
+	// EncodingBatch is an instance of JSON Batched Events
+	EncodingBatch
 )
 
 func (e Encoding) String() string {
@@ -29,6 +32,8 @@ func (e Encoding) String() string {
 		return "structured"
 	case EncodingEvent:
 		return "event"
+	case EncodingBatch:
+		return "batch"
 	case EncodingUnknown:
 		return "unknown"
 	}

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/event_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/event_message.go
@@ -22,7 +22,9 @@ const (
 
 // EventMessage type-converts a event.Event object to implement Message.
 // This allows local event.Event objects to be sent directly via Sender.Send()
-//     s.Send(ctx, binding.EventMessage(e))
+//
+//	s.Send(ctx, binding.EventMessage(e))
+//
 // When an event is wrapped into a EventMessage, the original event could be
 // potentially mutated. If you need to use the Event again, after wrapping it into
 // an Event message, you should copy it before

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/format/format.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/format/format.go
@@ -7,6 +7,7 @@ package format
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -41,12 +42,33 @@ func (jsonFmt) Unmarshal(b []byte, e *event.Event) error {
 	return json.Unmarshal(b, e)
 }
 
+// JSONBatch is the built-in "application/cloudevents-batch+json" format.
+var JSONBatch = jsonBatchFmt{}
+
+type jsonBatchFmt struct{}
+
+func (jb jsonBatchFmt) MediaType() string {
+	return event.ApplicationCloudEventsBatchJSON
+}
+
+// Marshal will return an error for jsonBatchFmt since the Format interface doesn't support batch Marshalling, and we
+// know it's structured batch json, we'll go direct to the json.UnMarshall() (see `ToEvents()`) since that is the best
+// way to support batch operations for now.
+func (jb jsonBatchFmt) Marshal(e *event.Event) ([]byte, error) {
+	return nil, errors.New("not supported for batch events")
+}
+
+func (jb jsonBatchFmt) Unmarshal(b []byte, e *event.Event) error {
+	return errors.New("not supported for batch events")
+}
+
 // built-in formats
 var formats map[string]Format
 
 func init() {
 	formats = map[string]Format{}
 	Add(JSON)
+	Add(JSONBatch)
 }
 
 // Lookup returns the format for contentType, or nil if not found.

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/message.go
@@ -66,7 +66,7 @@ type MessageMetadataReader interface {
 
 // Message is the interface to a binding-specific message containing an event.
 //
-// Reliable Delivery
+// # Reliable Delivery
 //
 // There are 3 reliable qualities of service for messages:
 //

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/spec/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/spec/doc.go
@@ -8,6 +8,5 @@ Package spec provides spec-version metadata.
 
 For use by code that maps events using (prefixed) attribute name strings.
 Supports handling multiple spec versions uniformly.
-
 */
 package spec

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/client.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/client.go
@@ -98,6 +98,7 @@ type ceClient struct {
 	eventDefaulterFns         []EventDefaulter
 	pollGoroutines            int
 	blockingCallback          bool
+	ackMalformedEvent         bool
 }
 
 func (c *ceClient) applyOptions(opts ...Option) error {
@@ -202,7 +203,13 @@ func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
 		return fmt.Errorf("client already has a receiver")
 	}
 
-	invoker, err := newReceiveInvoker(fn, c.observabilityService, c.inboundContextDecorators, c.eventDefaulterFns...)
+	invoker, err := newReceiveInvoker(
+		fn,
+		c.observabilityService,
+		c.inboundContextDecorators,
+		c.eventDefaulterFns,
+		c.ackMalformedEvent,
+	)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/http_receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/http_receiver.go
@@ -14,7 +14,7 @@ import (
 )
 
 func NewHTTPReceiveHandler(ctx context.Context, p *thttp.Protocol, fn interface{}) (*EventReceiver, error) {
-	invoker, err := newReceiveInvoker(fn, noopObservabilityService{}, nil) //TODO(slinkydeveloper) maybe not nil?
+	invoker, err := newReceiveInvoker(fn, noopObservabilityService{}, nil, nil, false) //TODO(slinkydeveloper) maybe not nil?
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/options.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/options.go
@@ -126,3 +126,16 @@ func WithBlockingCallback() Option {
 		return nil
 	}
 }
+
+// WithAckMalformedevents causes malformed events received within StartReceiver to be acknowledged
+// rather than being permanently not-acknowledged. This can be useful when a protocol does not
+// provide a responder implementation and would otherwise cause the receiver to be partially or
+// fully stuck.
+func WithAckMalformedEvent() Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*ceClient); ok {
+			c.ackMalformedEvent = true
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/receiver.go
@@ -57,7 +57,6 @@ var (
 // * func(event.Event) (*event.Event, protocol.Result)
 // * func(context.Context, event.Event) *event.Event
 // * func(context.Context, event.Event) (*event.Event, protocol.Result)
-//
 func receiver(fn interface{}) (*receiverFn, error) {
 	fnType := reflect.TypeOf(fn)
 	if fnType.Kind() != reflect.Func {

--- a/vendor/github.com/cloudevents/sdk-go/v2/event/event.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/event/event.go
@@ -55,13 +55,12 @@ func New(version ...string) Event {
 // Use functions in the types package to convert extension values.
 // For example replace this:
 //
-//     var i int
-//     err := e.ExtensionAs("foo", &i)
+//	var i int
+//	err := e.ExtensionAs("foo", &i)
 //
 // With this:
 //
-//     i, err := types.ToInteger(e.Extensions["foo"])
-//
+//	i, err := types.ToInteger(e.Extensions["foo"])
 func (e Event) ExtensionAs(name string, obj interface{}) error {
 	return e.Context.ExtensionAs(name, obj)
 }

--- a/vendor/github.com/cloudevents/sdk-go/v2/event/eventcontext_v03.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/event/eventcontext_v03.go
@@ -179,7 +179,8 @@ func (ec EventContextV03) AsV1() *EventContextV1 {
 }
 
 // Validate returns errors based on requirements from the CloudEvents spec.
-// For more details, see https://github.com/cloudevents/spec/blob/master/spec.md
+// For more details, see
+// https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md
 // As of Feb 26, 2019, commit 17c32ea26baf7714ad027d9917d03d2fff79fc7e
 // + https://github.com/cloudevents/spec/pull/387 -> datacontentencoding
 // + https://github.com/cloudevents/spec/pull/406 -> subject

--- a/vendor/github.com/cloudevents/sdk-go/v2/event/extensions.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/event/extensions.go
@@ -50,7 +50,7 @@ func validateExtensionName(key string) error {
 
 	for _, c := range key {
 		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
-			return errors.New("bad key, CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the ASCII character set")
+			return errors.New("bad key, CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z'), upper-case letters ('A' to 'Z') or digits ('0' to '9') from the ASCII character set")
 		}
 	}
 	return nil

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/doc.go
@@ -21,6 +21,5 @@ Available protocols:
 * Nats
 * Nats Streaming (stan)
 * Google PubSub
-
 */
 package protocol

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/context.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/context.go
@@ -24,7 +24,7 @@ type RequestData struct {
 }
 
 // WithRequestDataAtContext uses the http.Request to add RequestData
-//  information to the Context.
+// information to the Context.
 func WithRequestDataAtContext(ctx context.Context, r *nethttp.Request) context.Context {
 	if r == nil {
 		return ctx

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/message.go
@@ -92,6 +92,9 @@ func (m *Message) ReadEncoding() binding.Encoding {
 		return binding.EncodingBinary
 	}
 	if m.format != nil {
+		if m.format == format.JSONBatch {
+			return binding.EncodingBatch
+		}
 		return binding.EncodingStructured
 	}
 	return binding.EncodingUnknown

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/options.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/options.go
@@ -158,7 +158,6 @@ func WithMethod(method string) Option {
 	}
 }
 
-//
 // Middleware is a function that takes an existing http.Handler and wraps it in middleware,
 // returning the wrapped http.Handler.
 type Middleware func(next nethttp.Handler) nethttp.Handler

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/protocol.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/protocol.go
@@ -102,7 +102,10 @@ func New(opts ...Option) (*Protocol, error) {
 	}
 
 	if p.Client == nil {
-		p.Client = http.DefaultClient
+		// This is how http.DefaultClient is initialized. We do not just use
+		// that because when WithRoundTripper is used, it will change the client's
+		// transport, which would cause that transport to be used process-wide.
+		p.Client = &http.Client{}
 	}
 
 	if p.roundTripper != nil {

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/utility.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/utility.go
@@ -6,7 +6,9 @@
 package http
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	nethttp "net/http"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -23,4 +25,65 @@ func NewEventFromHTTPRequest(req *nethttp.Request) (*event.Event, error) {
 func NewEventFromHTTPResponse(resp *nethttp.Response) (*event.Event, error) {
 	msg := NewMessageFromHttpResponse(resp)
 	return binding.ToEvent(context.Background(), msg)
+}
+
+// NewEventsFromHTTPRequest returns a batched set of Events from a HTTP Request
+func NewEventsFromHTTPRequest(req *nethttp.Request) ([]event.Event, error) {
+	msg := NewMessageFromHttpRequest(req)
+	return binding.ToEvents(context.Background(), msg, msg.BodyReader)
+}
+
+// NewEventsFromHTTPResponse returns a batched set of Events from a HTTP Response
+func NewEventsFromHTTPResponse(resp *nethttp.Response) ([]event.Event, error) {
+	msg := NewMessageFromHttpResponse(resp)
+	return binding.ToEvents(context.Background(), msg, msg.BodyReader)
+}
+
+// NewHTTPRequestFromEvent creates a http.Request object that can be used with any http.Client for a singular event.
+// This is an HTTP POST action to the provided url.
+func NewHTTPRequestFromEvent(ctx context.Context, url string, event event.Event) (*nethttp.Request, error) {
+	if err := event.Validate(); err != nil {
+		return nil, err
+	}
+
+	req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := WriteRequest(ctx, (*binding.EventMessage)(&event), req); err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewHTTPRequestFromEvents creates a http.Request object that can be used with any http.Client for sending
+// a batched set of events. This is an HTTP POST action to the provided url.
+func NewHTTPRequestFromEvents(ctx context.Context, url string, events []event.Event) (*nethttp.Request, error) {
+	// Sending batch events is quite straightforward, as there is only JSON format, so a simple implementation.
+	for _, e := range events {
+		if err := e.Validate(); err != nil {
+			return nil, err
+		}
+	}
+	var buffer bytes.Buffer
+	err := json.NewEncoder(&buffer).Encode(events)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, &buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set(ContentType, event.ApplicationCloudEventsBatchJSON)
+
+	return request, nil
+}
+
+// IsHTTPBatch returns if the current http.Request or http.Response is a batch event operation, by checking the
+// header `Content-Type` value.
+func IsHTTPBatch(header nethttp.Header) bool {
+	return header.Get(ContentType) == event.ApplicationCloudEventsBatchJSON
 }

--- a/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/write_request.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/protocol/http/write_request.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -58,7 +57,7 @@ func (b *httpRequestWriter) SetData(data io.Reader) error {
 func (b *httpRequestWriter) setBody(body io.Reader) error {
 	rc, ok := body.(io.ReadCloser)
 	if !ok && body != nil {
-		rc = ioutil.NopCloser(body)
+		rc = io.NopCloser(body)
 	}
 	b.Body = rc
 	if body != nil {
@@ -68,21 +67,21 @@ func (b *httpRequestWriter) setBody(body io.Reader) error {
 			buf := v.Bytes()
 			b.GetBody = func() (io.ReadCloser, error) {
 				r := bytes.NewReader(buf)
-				return ioutil.NopCloser(r), nil
+				return io.NopCloser(r), nil
 			}
 		case *bytes.Reader:
 			b.ContentLength = int64(v.Len())
 			snapshot := *v
 			b.GetBody = func() (io.ReadCloser, error) {
 				r := snapshot
-				return ioutil.NopCloser(&r), nil
+				return io.NopCloser(&r), nil
 			}
 		case *strings.Reader:
 			b.ContentLength = int64(v.Len())
 			snapshot := *v
 			b.GetBody = func() (io.ReadCloser, error) {
 				r := snapshot
-				return ioutil.NopCloser(&r), nil
+				return io.NopCloser(&r), nil
 			}
 		default:
 			// This is where we'd set it to -1 (at least
@@ -137,5 +136,7 @@ func (b *httpRequestWriter) SetExtension(name string, value interface{}) error {
 	return nil
 }
 
-var _ binding.StructuredWriter = (*httpRequestWriter)(nil) // Test it conforms to the interface
-var _ binding.BinaryWriter = (*httpRequestWriter)(nil)     // Test it conforms to the interface
+var (
+	_ binding.StructuredWriter = (*httpRequestWriter)(nil) // Test it conforms to the interface
+	_ binding.BinaryWriter     = (*httpRequestWriter)(nil) // Test it conforms to the interface
+)

--- a/vendor/github.com/cloudevents/sdk-go/v2/test/event_matchers.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/test/event_matchers.go
@@ -184,6 +184,18 @@ func HasExtensions(ext map[string]interface{}) EventMatcher {
 	}
 }
 
+// HasExtensionKeys checks if the event contains the provided keys from its extensions
+func HasExtensionKeys(keys []string) EventMatcher {
+	return func(have event.Event) error {
+		for _, k := range keys {
+			if _, ok := have.Extensions()[k]; !ok {
+				return fmt.Errorf("expecting extension key %q", k)
+			}
+		}
+		return nil
+	}
+}
+
 // HasExtension checks if the event contains the provided extension
 func HasExtension(key string, value interface{}) EventMatcher {
 	return HasExtensions(map[string]interface{}{key: value})
@@ -277,7 +289,6 @@ func HasAttributeKind(kind spec.Kind, value interface{}) EventMatcher {
 // LICENSE: MIT License
 
 func isEmpty(object interface{}) bool {
-
 	// get nil case out of the way
 	if object == nil {
 		return true

--- a/vendor/github.com/cloudevents/sdk-go/v2/types/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/types/doc.go
@@ -11,25 +11,25 @@ type has a corresponding native Go type and a canonical string encoding.  The
 native Go types used to represent the CloudEvents types are:
 bool, int32, string, []byte, *url.URL, time.Time
 
- +----------------+----------------+-----------------------------------+
- |CloudEvents Type|Native Type     |Convertible From                   |
- +================+================+===================================+
- |Bool            |bool            |bool                               |
- +----------------+----------------+-----------------------------------+
- |Integer         |int32           |Any numeric type with value in     |
- |                |                |range of int32                     |
- +----------------+----------------+-----------------------------------+
- |String          |string          |string                             |
- +----------------+----------------+-----------------------------------+
- |Binary          |[]byte          |[]byte                             |
- +----------------+----------------+-----------------------------------+
- |URI-Reference   |*url.URL        |url.URL, types.URIRef, types.URI   |
- +----------------+----------------+-----------------------------------+
- |URI             |*url.URL        |url.URL, types.URIRef, types.URI   |
- |                |                |Must be an absolute URI.           |
- +----------------+----------------+-----------------------------------+
- |Timestamp       |time.Time       |time.Time, types.Timestamp         |
- +----------------+----------------+-----------------------------------+
+	+----------------+----------------+-----------------------------------+
+	|CloudEvents Type|Native Type     |Convertible From                   |
+	+================+================+===================================+
+	|Bool            |bool            |bool                               |
+	+----------------+----------------+-----------------------------------+
+	|Integer         |int32           |Any numeric type with value in     |
+	|                |                |range of int32                     |
+	+----------------+----------------+-----------------------------------+
+	|String          |string          |string                             |
+	+----------------+----------------+-----------------------------------+
+	|Binary          |[]byte          |[]byte                             |
+	+----------------+----------------+-----------------------------------+
+	|URI-Reference   |*url.URL        |url.URL, types.URIRef, types.URI   |
+	+----------------+----------------+-----------------------------------+
+	|URI             |*url.URL        |url.URL, types.URIRef, types.URI   |
+	|                |                |Must be an absolute URI.           |
+	+----------------+----------------+-----------------------------------+
+	|Timestamp       |time.Time       |time.Time, types.Timestamp         |
+	+----------------+----------------+-----------------------------------+
 
 Extension attributes may be stored as a native type or a canonical string.  The
 To<Type> functions will convert to the desired <Type> from any convertible type
@@ -41,6 +41,5 @@ canonical strings.
 Note are no Parse or Format functions for URL or string. For URL use the
 standard url.Parse() and url.URL.String(). The canonical string format of a
 string is the string itself.
-
 */
 package types

--- a/vendor/github.com/cloudevents/sdk-go/v2/types/value.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/types/value.go
@@ -86,7 +86,7 @@ func Format(v interface{}) (string, error) {
 }
 
 // Validate v is a valid CloudEvents attribute value, convert it to one of:
-//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+// bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
 func Validate(v interface{}) (interface{}, error) {
 	switch v := v.(type) {
 	case bool, int32, string, []byte:
@@ -151,7 +151,9 @@ func Validate(v interface{}) (interface{}, error) {
 }
 
 // Clone v clones a CloudEvents attribute value, which is one of the valid types:
-//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
+//	bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
 // Returns the same type
 // Panics if the type is not valid
 func Clone(v interface{}) interface{} {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -79,8 +79,8 @@ github.com/cloudevents/sdk-go/sql/v2/gen
 github.com/cloudevents/sdk-go/sql/v2/parser
 github.com/cloudevents/sdk-go/sql/v2/runtime
 github.com/cloudevents/sdk-go/sql/v2/utils
-# github.com/cloudevents/sdk-go/v2 v2.13.0
-## explicit; go 1.17
+# github.com/cloudevents/sdk-go/v2 v2.15.2
+## explicit; go 1.18
 github.com/cloudevents/sdk-go/v2
 github.com/cloudevents/sdk-go/v2/binding
 github.com/cloudevents/sdk-go/v2/binding/format


### PR DESCRIPTION
## Proposed Changes

- lastest of Go-Sdk

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Using 2.15.2 of Go-sdk for CloudEvents
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
