### PR TITLE
Run Filewatchers triggerfunction only once on changes on the watched file

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/file/FileWatcher.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/file/FileWatcher.java
@@ -155,6 +155,11 @@ public class FileWatcher implements AutoCloseable {
                 }
 
                 // We check if the event's context (the file) matches our target file
+                if (!event.context().toString().equals(this.toWatch.getName())) {
+                  logger.debug("Skipping event for " + file.getAbsolutePath() + " as we only watch " + this.toWatch.getAbsolutePath());
+                  continue;
+                }
+
                 if (kind != OVERFLOW) {
                     logger.debug("Calling trigger func as we got a " + kind.name() + " on " + file.getAbsolutePath());
                     triggerFunction.run();

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/file/FileWatcherTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/file/FileWatcherTest.java
@@ -42,7 +42,7 @@ public class FileWatcherTest {
         Files.deleteIfExists(tempFile.toPath());
     }
 
-    @Test
+    @RepeatedTest(20)
     public void testFileModification() throws Exception {
         // Set up a counter to track how many times the trigger function is called
         AtomicInteger counter = new AtomicInteger(0);

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/file/FileWatcherTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/file/FileWatcherTest.java
@@ -47,8 +47,8 @@ public class FileWatcherTest {
         // Set up a counter to track how many times the trigger function is called
         AtomicInteger counter = new AtomicInteger(0);
 
-        fileWatcher = new FileWatcher(tempFile, () -> {
-            counter.incrementAndGet();
+        fileWatcher = new FileWatcher(tempFile, file -> {
+          counter.incrementAndGet();
         });
         fileWatcher.start().await();
 
@@ -67,7 +67,7 @@ public class FileWatcherTest {
         // Set up a counter to track how many times the trigger function is called
         AtomicInteger counter = new AtomicInteger(0);
 
-        fileWatcher = new FileWatcher(tempFile, () -> {
+        fileWatcher = new FileWatcher(tempFile, file -> {
             counter.incrementAndGet();
         });
         fileWatcher.start().await();
@@ -82,7 +82,7 @@ public class FileWatcherTest {
       // Set up a counter to track how many times the trigger function is called
       AtomicInteger counter = new AtomicInteger(0);
 
-      fileWatcher = new FileWatcher(tempFile, () -> {
+      fileWatcher = new FileWatcher(tempFile, file -> {
         counter.incrementAndGet();
       });
       fileWatcher.start().await();

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
@@ -131,7 +131,7 @@ public class Main {
                     new ContractPublisher(vertx.eventBus(), ResourcesReconcilerMessageHandler.ADDRESS);
 
             File file = new File(env.getDataPlaneConfigFilePath());
-            FileWatcher fileWatcher = new FileWatcher(file, () -> publisher.updateContract(file));
+            FileWatcher fileWatcher = new FileWatcher(file, publisher::updateContract);
             fileWatcher.start();
 
             //     Register shutdown hook for graceful shutdown.

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/UnorderedConsumerTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/integration/UnorderedConsumerTest.java
@@ -103,7 +103,7 @@ public class UnorderedConsumerTest {
         final var file = Files.createTempFile("fw-", "-fw").toFile();
         final var contractPublisher =
                 new ContractPublisher(vertx.eventBus(), ResourcesReconcilerMessageHandler.ADDRESS);
-        final var fileWatcher = new FileWatcher(file, () -> contractPublisher.updateContract(file));
+        final var fileWatcher = new FileWatcher(file, contractPublisher::updateContract);
 
         fileWatcher.start();
 

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticle.java
@@ -184,7 +184,7 @@ public class ReceiverVerticle extends AbstractVerticle implements Handler<HttpSe
     // Set up the secret watcher
     private void setupSecretWatcher() {
         try {
-            this.secretWatcher = new FileWatcher(this.tlsCrtFile, this::updateServerConfig);
+            this.secretWatcher = new FileWatcher(this.tlsCrtFile, f -> this.updateServerConfig());
             this.secretWatcher.start();
         } catch (IOException e) {
             logger.error("Failed to start SecretWatcher", e);

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -160,7 +160,7 @@ public class Main {
             ContractPublisher publisher =
                     new ContractPublisher(vertx.eventBus(), ResourcesReconcilerMessageHandler.ADDRESS);
             File file = new File(env.getDataPlaneConfigFilePath());
-            FileWatcher fileWatcher = new FileWatcher(file, () -> publisher.updateContract(file));
+            FileWatcher fileWatcher = new FileWatcher(file,  publisher::updateContract);
             fileWatcher.start();
 
             var closeables =


### PR DESCRIPTION
We have seen the Filewatcher unit tests being flaky with:

```
09:56:39.778 [main] DEBUG dev.knative.eventing.kafka.broker.core.eventbus.ContractPublisher - Contract unchanged generation=0 lastGeneration=0
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.310 s -- in dev.knative.eventing.kafka.broker.core.eventbus.ContractPublisherTest
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   FileWatcherTest.testFileModification:62 » ConditionTimeout Condition dev.knative.eventing.kafka.broker.core.file.FileWatcherTest$$Lambda/0x00007fc8b318c7a0 was not fulfilled within 10 seconds.
[INFO] 
[ERROR] Tests run: 130, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
```

This is, as the MODIFY event can get send twice (once for update on the file content and once for update on the files modification date. See https://stackoverflow.com/a/25221600):
```
created file
15:53:06.445 [contract-file-watcher] INFO  dev.knative.eventing.kafka.broker.core.file.FileWatcher - Started watching /tmp/test10156420168117534422.txt
15:53:06.446 [contract-file-watcher] DEBUG dev.knative.eventing.kafka.broker.core.file.FileWatcher - running trigger func initialize
running trigger func
updating file
15:53:06.446 [contract-file-watcher] DEBUG dev.knative.eventing.kafka.broker.core.file.FileWatcher - Contract updates
15:53:06.446 [contract-file-watcher] DEBUG dev.knative.eventing.kafka.broker.core.file.FileWatcher - Got ENTRY_MODIFY on test10156420168117534422.txt
running trigger func
15:53:06.446 [contract-file-watcher] DEBUG dev.knative.eventing.kafka.broker.core.file.FileWatcher - Contract updates
15:53:06.447 [contract-file-watcher] DEBUG dev.knative.eventing.kafka.broker.core.file.FileWatcher - Got ENTRY_MODIFY on test10156420168117534422.txt
running trigger func
15:53:16.477 [contract-file-watcher] DEBUG dev.knative.eventing.kafka.broker.core.file.FileWatcher - Interrupted exception. Stopping filewatching thread
```

This can be fixed by either a `Thread.sleep()` right after the `watcher.take()`, or by checking the files modification date and only calling the trigger function if it got updated.

This is addressed in this PR. In addition, the trigger function is only called, when the watched file got updated (the filewatcher watches a directory and notifies on changes on all files): 94f32107b387be7722010a3246ecf38bb29cc5ca