### PR TITLE
Add timestamp to filename for logs

### DIFF
--- a/test/pkg/logging/logging.go
+++ b/test/pkg/logging/logging.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,7 +122,7 @@ func (l *logger) startForPod(pod *corev1.Pod, artifactsDir string) {
 		podNs, podName, containerName := pod.Namespace, pod.Name, container.Name
 
 		go func() {
-			f, err := os.OpenFile(fmt.Sprintf("%s/new-logs/%s-%s.log", artifactsDir, podName, containerName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			f, err := os.OpenFile(fmt.Sprintf("%s/new-logs/%s-%s-%s.log", artifactsDir, podName, containerName, time.Now().String()), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

On #3735 we discussed adding timestamps to the names for log files so that it is easy to see when the log collection started

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add timestamp to the log file names
