### PR TITLE
adding s390x and ppc64le platform for loom based builds

### DIFF
--- a/data-plane/dispatcher-loom/pom.xml
+++ b/data-plane/dispatcher-loom/pom.xml
@@ -89,6 +89,14 @@
                 <architecture>arm64</architecture>
                 <os>linux</os>
               </platform>
+              <platform>
+                  <architecture>s390x</architecture>
+                  <os>linux</os>
+                </platform>
+                <platform>
+                  <architecture>ppc64le</architecture>
+                  <os>linux</os>
+                </platform>
             </platforms>
           </from>
           <to>

--- a/data-plane/receiver-loom/pom.xml
+++ b/data-plane/receiver-loom/pom.xml
@@ -106,6 +106,14 @@
                 <architecture>arm64</architecture>
                 <os>linux</os>
               </platform>
+              <platform>
+                  <architecture>s390x</architecture>
+                  <os>linux</os>
+                </platform>
+                <platform>
+                  <architecture>ppc64le</architecture>
+                  <os>linux</os>
+                </platform>
             </platforms>
           </from>
           <to>


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #
#3776 

## Proposed Changes
This PR enables the Docker image build for the dataplane components receiver-loom and dispatcher-loom for the s390x and ppc64le architecture. For this it leverages jib's multi-arch Docker image build capabilities.
