### PR TITLE
Add cluster admin proxy

### DIFF
--- a/control-plane/pkg/kafka/clientpool/client_test.go
+++ b/control-plane/pkg/kafka/clientpool/client_test.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clientpool
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+	kafkatesting "knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/testing"
+)
+
+func setupTestClient(counter *int) *client {
+	mockClient := kafkatesting.MockKafkaClient{ShouldFailBrokenPipe: true}
+	return &client{
+		client: &mockClient,
+		isFatalError: func(err error) bool {
+			return err != nil && (strings.Contains(err.Error(), "broken pipe") || strings.Contains(err.Error(), "metadata is out of date"))
+		},
+		onFatalError: func(err error) {
+			*counter += 1
+		},
+	}
+}
+
+// TestProxyClientHandlesFatalErrors verifies that the cluster admin proxy identifies
+// and runs the provided function when it encounters a fatal error
+func TestProxyClientHandlesFatalErrors(t *testing.T) {
+	errorCount := ptr.To(0)
+
+	c := setupTestClient(errorCount)
+
+	c.Controller()
+	assert.Equal(t, 1, *errorCount)
+
+	c.RefreshController()
+	assert.Equal(t, 2, *errorCount)
+
+	c.Broker(0)
+	assert.Equal(t, 3, *errorCount)
+
+	c.Topics()
+	assert.Equal(t, 4, *errorCount)
+
+	c.Partitions("")
+	assert.Equal(t, 5, *errorCount)
+
+	c.WritablePartitions("")
+	assert.Equal(t, 6, *errorCount)
+
+	c.Leader("", 0)
+	assert.Equal(t, 7, *errorCount)
+
+	c.LeaderAndEpoch("", 0)
+	assert.Equal(t, 8, *errorCount)
+
+	c.Replicas("", 0)
+	assert.Equal(t, 9, *errorCount)
+
+	c.InSyncReplicas("", 0)
+	assert.Equal(t, 10, *errorCount)
+
+	c.OfflineReplicas("", 0)
+	assert.Equal(t, 11, *errorCount)
+
+	c.RefreshBrokers([]string{})
+	assert.Equal(t, 12, *errorCount)
+
+	c.RefreshMetadata()
+	assert.Equal(t, 13, *errorCount)
+
+	c.GetOffset("", 0, 0)
+	assert.Equal(t, 14, *errorCount)
+
+	c.Coordinator("")
+	assert.Equal(t, 15, *errorCount)
+
+	c.RefreshCoordinator("")
+	assert.Equal(t, 16, *errorCount)
+
+	c.TransactionCoordinator("")
+	assert.Equal(t, 17, *errorCount)
+
+	c.RefreshTransactionCoordinator("")
+	assert.Equal(t, 18, *errorCount)
+
+	c.InitProducerID()
+	assert.Equal(t, 19, *errorCount)
+}

--- a/control-plane/pkg/kafka/clientpool/clientpool.go
+++ b/control-plane/pkg/kafka/clientpool/clientpool.go
@@ -124,7 +124,7 @@ func (cp *ClientPool) GetClusterAdmin(ctx context.Context, bootstrapServers []st
 		return nil, err
 	}
 
-	ca, err := cp.newClusterAdminFromClient(c)
+	ca, err := clusterAdminFromClient(c, cp.newClusterAdminFromClient)
 	if err != nil {
 		c.Close()
 		return nil, err

--- a/control-plane/pkg/kafka/clientpool/clusteradmin.go
+++ b/control-plane/pkg/kafka/clientpool/clusteradmin.go
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clientpool
+
+import (
+	"fmt"
+
+	"github.com/IBM/sarama"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
+)
+
+// clusterAdmin is a proxy for sarama.ClusterAdmin
+//
+// It keeps track of callers that are actively using the cluster admin useing incrementCallers and Close()
+type clusterAdmin struct {
+	client       *client
+	clusterAdmin sarama.ClusterAdmin
+
+	isFatalError func(err error) bool
+	onFatalError func(err error)
+}
+
+func clusterAdminFromClient(saramaClient sarama.Client, makeClusterAdmin kafka.NewClusterAdminFromClientFunc) (*clusterAdmin, error) {
+	c, ok := saramaClient.(*client)
+	if !ok {
+		return nil, fmt.Errorf("failed to make clusterAdmin from client")
+	}
+
+	ca, err := makeClusterAdmin(c)
+	if err != nil {
+		return nil, err
+	}
+
+	c.incrementCallers()
+
+	return &clusterAdmin{
+		client:       c,
+		clusterAdmin: ca,
+		isFatalError: c.isFatalError,
+		onFatalError: c.onFatalError,
+	}, nil
+}
+
+var _ sarama.ClusterAdmin = &clusterAdmin{}
+
+func (a *clusterAdmin) CreateTopic(topic string, detail *sarama.TopicDetail, validateOnly bool) error {
+	err := a.clusterAdmin.CreateTopic(topic, detail, validateOnly)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) ListTopics() (map[string]sarama.TopicDetail, error) {
+	x, err := a.clusterAdmin.ListTopics()
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) DescribeTopics(topics []string) (metadata []*sarama.TopicMetadata, err error) {
+	x, err := a.clusterAdmin.DescribeTopics(topics)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) DeleteTopic(topic string) error {
+	err := a.clusterAdmin.DeleteTopic(topic)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) CreatePartitions(topic string, count int32, assignment [][]int32, validateOnly bool) error {
+	err := a.clusterAdmin.CreatePartitions(topic, count, assignment, validateOnly)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) AlterPartitionReassignments(topic string, assignment [][]int32) error {
+	err := a.clusterAdmin.AlterPartitionReassignments(topic, assignment)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) ListPartitionReassignments(topics string, partitions []int32) (topicStatus map[string]map[int32]*sarama.PartitionReplicaReassignmentsStatus, err error) {
+	x, err := a.clusterAdmin.ListPartitionReassignments(topics, partitions)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) DeleteRecords(topic string, partitionOffsets map[int32]int64) error {
+	err := a.clusterAdmin.DeleteRecords(topic, partitionOffsets)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error) {
+	x, err := a.clusterAdmin.DescribeConfig(resource)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) AlterConfig(resourceType sarama.ConfigResourceType, name string, entries map[string]*string, validateOnly bool) error {
+	err := a.clusterAdmin.AlterConfig(resourceType, name, entries, validateOnly)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) IncrementalAlterConfig(resourceType sarama.ConfigResourceType, name string, entries map[string]sarama.IncrementalAlterConfigsEntry, validateOnly bool) error {
+	err := a.clusterAdmin.IncrementalAlterConfig(resourceType, name, entries, validateOnly)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) CreateACL(resource sarama.Resource, acl sarama.Acl) error {
+	err := a.clusterAdmin.CreateACL(resource, acl)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) CreateACLs(resources []*sarama.ResourceAcls) error {
+	err := a.clusterAdmin.CreateACLs(resources)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) ListAcls(filter sarama.AclFilter) ([]sarama.ResourceAcls, error) {
+	x, err := a.clusterAdmin.ListAcls(filter)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) DeleteACL(filter sarama.AclFilter, validateOnly bool) ([]sarama.MatchingAcl, error) {
+	x, err := a.clusterAdmin.DeleteACL(filter, validateOnly)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) ListConsumerGroups() (map[string]string, error) {
+	x, err := a.clusterAdmin.ListConsumerGroups()
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) DescribeConsumerGroups(groups []string) ([]*sarama.GroupDescription, error) {
+	x, err := a.clusterAdmin.DescribeConsumerGroups(groups)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) ListConsumerGroupOffsets(group string, topicPartitions map[string][]int32) (*sarama.OffsetFetchResponse, error) {
+	x, err := a.clusterAdmin.ListConsumerGroupOffsets(group, topicPartitions)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) DeleteConsumerGroupOffset(group string, topic string, partition int32) error {
+	err := a.clusterAdmin.DeleteConsumerGroupOffset(group, topic, partition)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) DeleteConsumerGroup(group string) error {
+	err := a.clusterAdmin.DeleteConsumerGroup(group)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) DescribeCluster() (brokers []*sarama.Broker, controllerID int32, err error) {
+	x, y, err := a.clusterAdmin.DescribeCluster()
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, y, err
+}
+
+func (a *clusterAdmin) DescribeLogDirs(brokers []int32) (map[int32][]sarama.DescribeLogDirsResponseDirMetadata, error) {
+	x, err := a.clusterAdmin.DescribeLogDirs(brokers)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) DescribeUserScramCredentials(users []string) ([]*sarama.DescribeUserScramCredentialsResult, error) {
+	x, err := a.clusterAdmin.DescribeUserScramCredentials(users)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) DeleteUserScramCredentials(delete []sarama.AlterUserScramCredentialsDelete) ([]*sarama.AlterUserScramCredentialsResult, error) {
+	x, err := a.clusterAdmin.DeleteUserScramCredentials(delete)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) UpsertUserScramCredentials(upsert []sarama.AlterUserScramCredentialsUpsert) ([]*sarama.AlterUserScramCredentialsResult, error) {
+	x, err := a.clusterAdmin.UpsertUserScramCredentials(upsert)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) DescribeClientQuotas(components []sarama.QuotaFilterComponent, strict bool) ([]sarama.DescribeClientQuotasEntry, error) {
+	x, err := a.clusterAdmin.DescribeClientQuotas(components, strict)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) AlterClientQuotas(entity []sarama.QuotaEntityComponent, op sarama.ClientQuotasOp, validateOnly bool) error {
+	err := a.clusterAdmin.AlterClientQuotas(entity, op, validateOnly)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return err
+}
+
+func (a *clusterAdmin) Controller() (*sarama.Broker, error) {
+	x, err := a.clusterAdmin.Controller()
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) RemoveMemberFromConsumerGroup(groupId string, groupInstanceIds []string) (*sarama.LeaveGroupResponse, error) {
+	x, err := a.clusterAdmin.RemoveMemberFromConsumerGroup(groupId, groupInstanceIds)
+	if a.isFatalError(err) {
+		a.onFatalError(err)
+	}
+	return x, err
+}
+
+func (a *clusterAdmin) Close() error {
+	return a.client.Close()
+}

--- a/control-plane/pkg/kafka/clientpool/clusteradmin.go
+++ b/control-plane/pkg/kafka/clientpool/clusteradmin.go
@@ -26,7 +26,7 @@ import (
 
 // clusterAdmin is a proxy for sarama.ClusterAdmin
 //
-// It keeps track of callers that are actively using the cluster admin useing incrementCallers and Close()
+// It keeps track of callers that are actively using the cluster admin using incrementCallers and Close()
 type clusterAdmin struct {
 	client       *client
 	clusterAdmin sarama.ClusterAdmin

--- a/control-plane/pkg/kafka/clientpool/clusteradmin_test.go
+++ b/control-plane/pkg/kafka/clientpool/clusteradmin_test.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clientpool
+
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+	kafkatesting "knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/testing"
+)
+
+func makeMockClusterAdminFromClient(_ sarama.Client) (sarama.ClusterAdmin, error) {
+	return &kafkatesting.MockKafkaClusterAdmin{ErrorBrokenPipe: true}, nil
+}
+
+// TestProxyClusterAdminHandlesFatalErrors verifies that the cluster admin proxy identifies
+// and runs the provided function when it encounters a fatal error
+func TestProxyClusterAdminHandlesFatalErrors(t *testing.T) {
+	errorCount := ptr.To(0)
+
+	c := setupTestClient(errorCount)
+	a, err := clusterAdminFromClient(c, makeMockClusterAdminFromClient)
+	assert.NoError(t, err)
+
+	a.CreateTopic("", nil, false)
+	assert.Equal(t, 1, *errorCount)
+
+	a.ListTopics()
+	assert.Equal(t, 2, *errorCount)
+
+	a.DescribeTopics([]string{})
+	assert.Equal(t, 3, *errorCount)
+
+	a.DeleteTopic("")
+	assert.Equal(t, 4, *errorCount)
+
+	a.CreatePartitions("", 0, nil, false)
+	assert.Equal(t, 5, *errorCount)
+
+	a.AlterPartitionReassignments("", nil)
+	assert.Equal(t, 6, *errorCount)
+
+	a.ListPartitionReassignments("", nil)
+	assert.Equal(t, 7, *errorCount)
+
+	a.DeleteRecords("", nil)
+	assert.Equal(t, 8, *errorCount)
+
+	a.DescribeConfig(sarama.ConfigResource{})
+	assert.Equal(t, 9, *errorCount)
+
+	a.AlterConfig(0, "", nil, false)
+	assert.Equal(t, 10, *errorCount)
+
+	a.IncrementalAlterConfig(0, "", nil, false)
+	assert.Equal(t, 11, *errorCount)
+
+	a.CreateACL(sarama.Resource{}, sarama.Acl{})
+	assert.Equal(t, 12, *errorCount)
+
+	a.CreateACLs(nil)
+	assert.Equal(t, 13, *errorCount)
+
+	a.ListAcls(sarama.AclFilter{})
+	assert.Equal(t, 14, *errorCount)
+
+	a.DeleteACL(sarama.AclFilter{}, false)
+	assert.Equal(t, 15, *errorCount)
+
+	a.ListConsumerGroups()
+	assert.Equal(t, 16, *errorCount)
+
+	a.DescribeConsumerGroups(nil)
+	assert.Equal(t, 17, *errorCount)
+
+	a.ListConsumerGroupOffsets("", nil)
+	assert.Equal(t, 18, *errorCount)
+
+	a.DeleteConsumerGroupOffset("", "", 0)
+	assert.Equal(t, 19, *errorCount)
+
+	a.DeleteConsumerGroup("")
+	assert.Equal(t, 20, *errorCount)
+
+	a.DescribeCluster()
+	assert.Equal(t, 21, *errorCount)
+
+	a.DescribeLogDirs(nil)
+	assert.Equal(t, 22, *errorCount)
+
+	a.DescribeUserScramCredentials(nil)
+	assert.Equal(t, 23, *errorCount)
+
+	a.DeleteUserScramCredentials(nil)
+	assert.Equal(t, 24, *errorCount)
+
+	a.UpsertUserScramCredentials(nil)
+	assert.Equal(t, 25, *errorCount)
+
+	a.DescribeClientQuotas(nil, false)
+	assert.Equal(t, 26, *errorCount)
+
+	a.AlterClientQuotas(nil, sarama.ClientQuotasOp{}, false)
+	assert.Equal(t, 27, *errorCount)
+
+	a.Controller()
+	assert.Equal(t, 28, *errorCount)
+
+	a.RemoveMemberFromConsumerGroup("", nil)
+	assert.Equal(t, 29, *errorCount)
+}

--- a/control-plane/pkg/kafka/testing/admin_mock.go
+++ b/control-plane/pkg/kafka/testing/admin_mock.go
@@ -32,6 +32,7 @@ const (
 )
 
 type MockKafkaClusterAdmin struct {
+	ErrorBrokenPipe bool
 	// (Create|Delete)Topic
 	ExpectedTopicName string
 
@@ -61,38 +62,66 @@ type MockKafkaClusterAdmin struct {
 }
 
 func (m *MockKafkaClusterAdmin) CreateACLs(acls []*sarama.ResourceAcls) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) DeleteConsumerGroupOffset(group string, topic string, partition int32) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) DescribeClientQuotas(components []sarama.QuotaFilterComponent, strict bool) ([]sarama.DescribeClientQuotasEntry, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) AlterClientQuotas(entity []sarama.QuotaEntityComponent, op sarama.ClientQuotasOp, validateOnly bool) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) Controller() (*sarama.Broker, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) DescribeUserScramCredentials(users []string) ([]*sarama.DescribeUserScramCredentialsResult, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	return nil, nil
 }
 
 func (m *MockKafkaClusterAdmin) DeleteUserScramCredentials(delete []sarama.AlterUserScramCredentialsDelete) ([]*sarama.AlterUserScramCredentialsResult, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	return nil, nil
 }
 
 func (m *MockKafkaClusterAdmin) UpsertUserScramCredentials(upsert []sarama.AlterUserScramCredentialsUpsert) ([]*sarama.AlterUserScramCredentialsResult, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	return nil, nil
 }
 
 func (m *MockKafkaClusterAdmin) CreateTopic(topic string, detail *sarama.TopicDetail, validateOnly bool) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
+
 	if topic != m.ExpectedTopicName {
 		m.T.Errorf("expected topic %s got %s", m.ExpectedTopicName, topic)
 	}
@@ -105,6 +134,10 @@ func (m *MockKafkaClusterAdmin) CreateTopic(topic string, detail *sarama.TopicDe
 }
 
 func (m *MockKafkaClusterAdmin) ListTopics() (map[string]sarama.TopicDetail, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
+
 	if len(m.ExpectedTopics) == 0 {
 		return nil, fmt.Errorf("failed to list topics, no expected topics")
 	}
@@ -118,6 +151,9 @@ func (m *MockKafkaClusterAdmin) ListTopics() (map[string]sarama.TopicDetail, err
 }
 
 func (m *MockKafkaClusterAdmin) DescribeTopics(topics []string) (metadata []*sarama.TopicMetadata, err error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 
 	if !sets.NewString(m.ExpectedTopics...).HasAll(topics...) {
 		m.T.Errorf("unexpected topics %v, expected %v", topics, m.ExpectedTopics)
@@ -127,6 +163,10 @@ func (m *MockKafkaClusterAdmin) DescribeTopics(topics []string) (metadata []*sar
 }
 
 func (m *MockKafkaClusterAdmin) DeleteTopic(topic string) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
+
 	if topic != m.ExpectedTopicName {
 		m.T.Errorf("expected topic %s got %s", m.ExpectedTopicName, topic)
 	}
@@ -135,50 +175,88 @@ func (m *MockKafkaClusterAdmin) DeleteTopic(topic string) error {
 }
 
 func (m *MockKafkaClusterAdmin) CreatePartitions(topic string, count int32, assignment [][]int32, validateOnly bool) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
+
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) AlterPartitionReassignments(topic string, assignment [][]int32) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
+
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) ListPartitionReassignments(topics string, partitions []int32) (topicStatus map[string]map[int32]*sarama.PartitionReplicaReassignmentsStatus, err error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) DeleteRecords(topic string, partitionOffsets map[int32]int64) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) AlterConfig(resourceType sarama.ConfigResourceType, name string, entries map[string]*string, validateOnly bool) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) IncrementalAlterConfig(resourceType sarama.ConfigResourceType, name string, entries map[string]sarama.IncrementalAlterConfigsEntry, validateOnly bool) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) CreateACL(resource sarama.Resource, acl sarama.Acl) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) ListAcls(filter sarama.AclFilter) ([]sarama.ResourceAcls, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) DeleteACL(filter sarama.AclFilter, validateOnly bool) ([]sarama.MatchingAcl, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) ListConsumerGroups() (map[string]string, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) DescribeConsumerGroups(groups []string) ([]*sarama.GroupDescription, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	if !sets.NewString(m.ExpectedConsumerGroups...).HasAll(groups...) {
 		m.T.Errorf("unexpected consumer groups %v, expected %v", groups, m.ExpectedConsumerGroups)
 	}
@@ -187,22 +265,37 @@ func (m *MockKafkaClusterAdmin) DescribeConsumerGroups(groups []string) ([]*sara
 }
 
 func (m *MockKafkaClusterAdmin) ListConsumerGroupOffsets(group string, topicPartitions map[string][]int32) (*sarama.OffsetFetchResponse, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) DeleteConsumerGroup(group string) error {
+	if m.ErrorBrokenPipe {
+		return brokenPipeError{}
+	}
 	return m.ErrorOnDeleteConsumerGroup
 }
 
 func (m *MockKafkaClusterAdmin) DescribeCluster() (brokers []*sarama.Broker, controllerID int32, err error) {
+	if m.ErrorBrokenPipe {
+		return nil, 0, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) DescribeLogDirs(brokers []int32) (map[int32][]sarama.DescribeLogDirsResponseDirMetadata, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m *MockKafkaClusterAdmin) RemoveMemberFromConsumerGroup(groupId string, groupInstanceIds []string) (*sarama.LeaveGroupResponse, error) {
+	if m.ErrorBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 

--- a/control-plane/pkg/kafka/testing/client_mock.go
+++ b/control-plane/pkg/kafka/testing/client_mock.go
@@ -27,19 +27,33 @@ type MockKafkaClient struct {
 	IsClosed                  bool
 	ShouldFailRefreshMetadata bool
 	ShouldFailRefreshBrokers  bool
+	ShouldFailBrokenPipe      bool
 }
 
 var _ sarama.Client = &MockKafkaClient{}
+
+type brokenPipeError struct{}
+
+func (brokenPipeError) Error() string {
+	return "write: broken pipe"
+}
 
 func (m MockKafkaClient) Config() *sarama.Config {
 	return sarama.NewConfig()
 }
 
 func (m MockKafkaClient) Controller() (*sarama.Broker, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
+
 	return &sarama.Broker{}, nil
 }
 
 func (m MockKafkaClient) RefreshController() (*sarama.Broker, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
@@ -48,42 +62,72 @@ func (m MockKafkaClient) Brokers() []*sarama.Broker {
 }
 
 func (m MockKafkaClient) Broker(brokerID int32) (*sarama.Broker, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) Topics() ([]string, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) Partitions(topic string) ([]int32, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) WritablePartitions(topic string) ([]int32, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) Leader(topic string, partitionID int32) (*sarama.Broker, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) LeaderAndEpoch(topic string, partitionID int32) (*sarama.Broker, int32, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, 0, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) Replicas(topic string, partitionID int32) ([]int32, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) InSyncReplicas(topic string, partitionID int32) ([]int32, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) OfflineReplicas(topic string, partitionID int32) ([]int32, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) RefreshBrokers(addrs []string) error {
+	if m.ShouldFailBrokenPipe {
+		return brokenPipeError{}
+	}
 	if len(addrs) == 0 {
 		return fmt.Errorf("provide at least one broker to refresh them")
 	}
@@ -94,6 +138,9 @@ func (m MockKafkaClient) RefreshBrokers(addrs []string) error {
 }
 
 func (m MockKafkaClient) RefreshMetadata(topics ...string) error {
+	if m.ShouldFailBrokenPipe {
+		return brokenPipeError{}
+	}
 	if m.ShouldFailRefreshMetadata {
 		return fmt.Errorf("failed to refresh metadata")
 	}
@@ -101,26 +148,44 @@ func (m MockKafkaClient) RefreshMetadata(topics ...string) error {
 }
 
 func (m MockKafkaClient) GetOffset(topic string, partitionID int32, time int64) (int64, error) {
+	if m.ShouldFailBrokenPipe {
+		return 0, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) Coordinator(consumerGroup string) (*sarama.Broker, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) RefreshCoordinator(consumerGroup string) error {
+	if m.ShouldFailBrokenPipe {
+		return brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) TransactionCoordinator(transactionID string) (*sarama.Broker, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) RefreshTransactionCoordinator(transactionID string) error {
+	if m.ShouldFailBrokenPipe {
+		return brokenPipeError{}
+	}
 	panic("implement me")
 }
 
 func (m MockKafkaClient) InitProducerID() (*sarama.InitProducerIDResponse, error) {
+	if m.ShouldFailBrokenPipe {
+		return nil, brokenPipeError{}
+	}
 	panic("implement me")
 }
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #3780 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add a proxy for the cluster admin so that fatal errors are recovered from properly there too
- Add regression tests to make sure that the client and cluster admin proxies