### PR TITLE
only requeue consumergroups from appropriate statefulset on change

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/register.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/register.go
@@ -75,3 +75,15 @@ func IsKnownStatefulSet(name string) bool {
 		name == ChannelStatefulSetName ||
 		name == BrokerStatefulSetName
 }
+
+func GetOwnerKindFromStatefulSetName(name string) (string, bool) {
+	switch name {
+	case SourceStatefulSetName:
+		return "KafkaSource", true
+	case ChannelStatefulSetName:
+		return "KafkaChannel", true
+	case BrokerStatefulSetName:
+		return "Trigger", true
+	}
+	return "", false
+}

--- a/control-plane/pkg/reconciler/consumer/controller.go
+++ b/control-plane/pkg/reconciler/consumer/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/pkg/logging"
 

--- a/control-plane/pkg/reconciler/consumer/controller.go
+++ b/control-plane/pkg/reconciler/consumer/controller.go
@@ -90,7 +90,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher) *controller.I
 		impl.GlobalResync(consumerInformer.Informer())
 	}
 
-	cgreconciler.ResyncOnStatefulSetChange(ctx, globalResync)
+	cgreconciler.ResyncOnStatefulSetChange(ctx, impl.FilteredGlobalResync, consumerInformer.Informer())
 
 	trustBundleConfigMapInformer.Informer().AddEventHandler(controller.HandleAll(globalResync))
 

--- a/control-plane/pkg/reconciler/consumer/controller.go
+++ b/control-plane/pkg/reconciler/consumer/controller.go
@@ -97,14 +97,9 @@ func NewController(ctx context.Context, watcher configmap.Watcher) *controller.I
 			return nil, false
 		}
 
-		for _, ref := range c.GetOwnerReferences() {
-			if ref.Kind == "ConsumerGroup" {
-				cg, err := r.ConsumerGroupLister.ConsumerGroups(c.GetNamespace()).Get(ref.Name)
-				return cg, err == nil
-			}
-		}
-
-		return nil, false
+		cgRef := c.GetConsumerGroup()
+		cg, err := r.ConsumerGroupLister.ConsumerGroups(c.GetNamespace()).Get(cgRef.Name)
+		return cg, err == nil
 	})
 
 	trustBundleConfigMapInformer.Informer().AddEventHandler(controller.HandleAll(globalResync))

--- a/control-plane/pkg/reconciler/consumergroup/controller.go
+++ b/control-plane/pkg/reconciler/consumergroup/controller.go
@@ -220,7 +220,7 @@ func ResyncOnStatefulSetChange(ctx context.Context, filteredResync func(f func(i
 				return false
 			}
 			for _, owner := range cg.OwnerReferences {
-				if owner.Kind == kind {
+				if strings.EqualFold(owner.Kind, kind) {
 					return true
 				}
 			}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #3824 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Check the owner kind for the consumergroup and only requeue it if necessary for a given statefulset change
