### PR TITLE
fix: evictor no longer has NPE when called with nil pod

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/evictor.go
+++ b/control-plane/pkg/reconciler/consumergroup/evictor.go
@@ -60,12 +60,12 @@ func newEvictor(ctx context.Context, fields ...zap.Field) *evictor {
 	}
 }
 
-func (e *evictor) evict(pod *corev1.Pod, vpod scheduler.VPod, from *eventingduckv1alpha1.Placement) error {
+func (e *evictor) evict(_ *corev1.Pod, vpod scheduler.VPod, from *eventingduckv1alpha1.Placement) error {
 	key := vpod.GetKey()
 
 	logger := e.logger.
 		With(zap.String("consumergroup", key.String())).
-		With(zap.String("pod", fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName())))
+		With(zap.String("pod", from.PodName))
 
 	cgBefore, err := e.InternalsClient.
 		ConsumerGroups(key.Namespace).


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes bug where kafka controller panics due to the evictor accessing properties on a nil pod.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Don't use the pod variable, as we only use it to decorate the logger currently.
- Add a unit test to catch regressions


