### PR TITLE
Add `.spec.subscribers[].name` field in KafkaChannel to align with eventing-core channel definition

### DIFF
--- a/control-plane/config/eventing-kafka-broker/100-channel/100-kafka-channel.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-channel/100-kafka-channel.yaml
@@ -147,6 +147,9 @@ spec:
                         description: Generation of the origin of the subscriber with uid:UID.
                         type: integer
                         format: int64
+                      name:
+                        description: The name of the subscription
+                        type: string
                       replyUri:
                         description: ReplyURI is the endpoint for the reply
                         type: string


### PR DESCRIPTION
In https://github.com/knative/eventing/pull/7733 we added the `.spec.subscribers[].name` field for Channels. This PR adjusts the KafkaChannel to support this field too.

This helps with tests issues from https://github.com/knative-extensions/eventing-kafka-broker/pull/3770