### PR TITLE
chore: added eventing-controller to the normal logging labels used

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			log.Printf("Failed to create kube client: %v\n", err)
 		}
-		e2elogger := logging.NewLogger(ctx, kubeClient, map[string][]string{"knative-eventing": {"kafka-broker-dispatcher", "kafka-broker-receiver", "kafka-sink-receiver", "kafka-channel-receiver", "kafka-channel-dispatcher", "kafka-source-dispatcher", "kafka-webhook-eventing", "kafka-controller", "kafka-source-controller", "eventing-webhook"}})
+		e2elogger := logging.NewLogger(ctx, kubeClient, logging.CommonLoggingLabels)
 		erre2e := e2elogger.Start()
 		if erre2e != nil {
 			fmt.Printf("failed to start logger: %s", erre2e.Error())

--- a/test/e2e_channel/main_test.go
+++ b/test/e2e_channel/main_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			log.Printf("Failed to create kube client: %v\n", err)
 		}
-		logger := logging.NewLogger(ctx, kubeClient, map[string][]string{"knative-eventing": {"kafka-broker-dispatcher", "kafka-broker-receiver", "kafka-sink-receiver", "kafka-channel-receiver", "kafka-channel-dispatcher", "kafka-source-dispatcher", "kafka-webhook-eventing", "kafka-controller", "kafka-source-controller", "eventing-webhook"}})
+		logger := logging.NewLogger(ctx, kubeClient, logging.CommonLoggingLabels)
 		e2e_channel_err := logger.Start()
 		if err != nil {
 			fmt.Printf("failed to start logger: %s", e2e_channel_err.Error())

--- a/test/e2e_new/main_test.go
+++ b/test/e2e_new/main_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 		defer cancel()
 
 		client := kubeclient.Get(ctx)
-		logger := logging.NewLogger(ctx, client, map[string][]string{"knative-eventing": {"kafka-broker-dispatcher", "kafka-broker-receiver", "kafka-sink-receiver", "kafka-channel-receiver", "kafka-channel-dispatcher", "kafka-source-dispatcher", "kafka-webhook-eventing", "kafka-controller", "kafka-source-controller", "eventing-webhook"}})
+		logger := logging.NewLogger(ctx, client, logging.CommonLoggingLabels)
 		err := logger.Start()
 		if err != nil {
 			fmt.Printf("failed to start logger: %s", err.Error())

--- a/test/e2e_new_channel/main_test.go
+++ b/test/e2e_new_channel/main_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 		defer cancel()
 
 		client := kubeclient.Get(ctx)
-		logger := logging.NewLogger(ctx, client, map[string][]string{"knative-eventing": {"kafka-broker-dispatcher", "kafka-broker-receiver", "kafka-sink-receiver", "kafka-channel-receiver", "kafka-channel-dispatcher", "kafka-source-dispatcher", "kafka-webhook-eventing", "kafka-controller", "kafka-source-controller", "eventing-webhook"}})
+		logger := logging.NewLogger(ctx, client, logging.CommonLoggingLabels)
 		err := logger.Start()
 		if err != nil {
 			fmt.Printf("failed to start logger: %s", err.Error())

--- a/test/e2e_sink/main_test.go
+++ b/test/e2e_sink/main_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			log.Printf("Failed to create kube client: %v\n", err)
 		}
-		logger := logging.NewLogger(ctx, kubeClient, map[string][]string{"knative-eventing": {"kafka-broker-dispatcher", "kafka-broker-receiver", "kafka-sink-receiver", "kafka-channel-receiver", "kafka-channel-dispatcher", "kafka-source-dispatcher", "kafka-webhook-eventing", "kafka-controller", "kafka-source-controller", "eventing-webhook"}})
+		logger := logging.NewLogger(ctx, kubeClient, logging.CommonLoggingLabels)
 		e2e_sink_err := logger.Start()
 		if err != nil {
 			fmt.Printf("failed to start logger: %s", e2e_sink_err.Error())

--- a/test/e2e_source/main_test.go
+++ b/test/e2e_source/main_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			log.Printf("Failed to create kube client: %v\n", err)
 		}
-		logger := logging.NewLogger(ctx, kubeClient, map[string][]string{"knative-eventing": {"kafka-broker-dispatcher", "kafka-broker-receiver", "kafka-sink-receiver", "kafka-channel-receiver", "kafka-channel-dispatcher", "kafka-source-dispatcher", "kafka-webhook-eventing", "kafka-controller", "kafka-source-controller", "eventing-webhook"}})
+		logger := logging.NewLogger(ctx, kubeClient, logging.CommonLoggingLabels)
 		e2e_source_err := logger.Start()
 		if err != nil {
 			fmt.Printf("failed to start logger: %s", e2e_source_err.Error())

--- a/test/pkg/logging/logging.go
+++ b/test/pkg/logging/logging.go
@@ -34,6 +34,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+var CommonLoggingLabels = map[string][]string{"knative-eventing": {"kafka-broker-dispatcher", "kafka-broker-receiver", "kafka-sink-receiver", "kafka-channel-receiver", "kafka-channel-dispatcher", "kafka-source-dispatcher", "kafka-webhook-eventing", "kafka-controller", "kafka-source-controller", "eventing-webhook", "eventing-controller"}}
+
 type Logger interface {
 	Start() error
 }

--- a/test/upgrade/main_test.go
+++ b/test/upgrade/main_test.go
@@ -52,7 +52,7 @@ func TestMain(m *testing.M) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	logger := logging.NewLogger(ctx, kubeClient, map[string][]string{"knative-eventing": {"kafka-broker-dispatcher", "kafka-broker-receiver", "kafka-sink-receiver", "kafka-channel-receiver", "kafka-channel-dispatcher", "kafka-source-dispatcher", "kafka-webhook-eventing", "kafka-controller", "kafka-source-controller", "eventing-webhook"}})
+	logger := logging.NewLogger(ctx, kubeClient, logging.CommonLoggingLabels)
 
 	err = logger.Start()
 	if err != nil {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Helps debugging PRs by adding the eventing-controller logs to those captured in CI

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Capture logs from eventing-controller pods too
