### PR TITLE
Upgrade tests install eventing core from release

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -168,6 +168,13 @@ function build_source_components_from_source() {
 }
 
 function install_latest_release() {
+  echo "Installing previous eventing core release"
+
+  eventing_version=$(echo ${LATEST_RELEASE_VERSION} | sed 's/knative-v\(.*\)/\1/')
+
+  # Hack - need to find a way to find the patch version for eventing core, for now default to 0
+  start_release_knative_eventing "$(major_version ${eventing_version}).$(minor_version ${eventing_version}).0"
+
   echo "Installing latest release from ${PREVIOUS_RELEASE_URL}"
 
   ko apply ${KO_FLAGS} -f ./test/config/ || fail_test "Failed to apply test configurations"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -192,8 +192,8 @@ function install_latest_release() {
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
 
   # Restore test config.
-  kubectl replace -f ./test/config/100-config-tracing.yaml
-  kubectl replace -f ./test/config/100-config-kafka-features.yaml
+  kubectl apply -f ./test/config/100-config-tracing.yaml
+  kubectl apply -f ./test/config/100-config-kafka-features.yaml
 }
 
 function install_head() {
@@ -208,8 +208,8 @@ function install_head() {
   kubectl apply -f "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
 
   # Restore test config.
-  kubectl replace -f ./test/config/100-config-tracing.yaml
-  kubectl replace -f ./test/config/100-config-kafka-features.yaml
+  kubectl apply -f ./test/config/100-config-tracing.yaml
+  kubectl apply -f ./test/config/100-config-kafka-features.yaml
 }
 
 function install_latest_release_source() {
@@ -220,8 +220,8 @@ function install_latest_release_source() {
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SOURCE_BUNDLE_ARTIFACT}" || return $?
 
   # Restore test config.
-  kubectl replace -f ./test/config/100-config-tracing.yaml
-  kubectl replace -f ./test/config/100-config-kafka-features.yaml
+  kubectl apply -f ./test/config/100-config-tracing.yaml
+  kubectl apply -f ./test/config/100-config-kafka-features.yaml
 }
 
 function install_head_source() {
@@ -231,8 +231,8 @@ function install_head_source() {
   kubectl apply -f "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
 
   # Restore test config.
-  kubectl replace -f ./test/config/100-config-tracing.yaml
-  kubectl replace -f ./test/config/100-config-kafka-features.yaml
+  kubectl apply -f ./test/config/100-config-tracing.yaml
+  kubectl apply -f ./test/config/100-config-kafka-features.yaml
 }
 
 function test_setup() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -96,7 +96,7 @@ function install_eventing_core() {
     kubectl apply -f "${KNATIVE_EVENTING_RELEASE_TLS}"
   fi
 
-  ! kubectl patch horizontalpodautoscalers.autoscaling -n knative-eventing eventing-webhook -p '{"spec": {"minReplicas": '${REPLICAS}'}}'
+  kubectl patch horizontalpodautoscalers.autoscaling -n knative-eventing eventing-webhook -p '{"spec": {"minReplicas": '${REPLICAS}'}}'
 }
 
 function knative_eventing() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -111,8 +111,6 @@ function knative_eventing() {
 
   install_eventing_core
 
-  ! kubectl patch horizontalpodautoscalers.autoscaling -n knative-eventing eventing-webhook -p '{"spec": {"minReplicas": '${REPLICAS}'}}'
-
   # Publish test images.
   echo ">> Publishing test images from eventing"
   ./test/upload-test-images.sh ${VENDOR_EVENTING_TEST_IMAGES} e2e || fail_test "Error uploading test images"

--- a/test/upgrade/installation/githead.go
+++ b/test/upgrade/installation/githead.go
@@ -21,6 +21,7 @@ import pkgupgrade "knative.dev/pkg/test/upgrade"
 // GitHead installs the eventing kafka from git HEAD.
 func GitHead() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("GitHead", func(c pkgupgrade.Context) {
+		runShellFunc("install_eventing_core", c)
 		runShellFunc("install_head", c)
 	})
 }


### PR DESCRIPTION
Currently, the scripts we use to install eventing and eventing kafka broker components in the upgrade tests do not install a previous release of eventing when installing the previous release of eventing kafka broker. This can cause some test failures due to incompatible versioning.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Install the previous eventing release along with the previous eventing kafka broker release
- Install the latest eventing nightly when upgrading to the newer eventing kafka broker code
