### PR TITLE
fix: flush all records before closing the producer

### DIFF
--- a/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
+++ b/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
@@ -139,6 +139,8 @@ public class LoomKafkaProducer<K, V> implements ReactiveKafkaProducer<K, V> {
                 sendFromQueueThread.interrupt();
                 logger.debug("Waiting for sendFromQueueThread thread to complete");
                 sendFromQueueThread.join();
+                logger.debug("flushing the producer");
+                producer.flush();
                 logger.debug("Closing the producer");
                 producer.close();
                 closePromise.complete();


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes a possible data race: we don't always flush all records before we stop receiving them.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- After we stop allowing records to be sent, we should call flush one more time on the producer

