### PR TITLE
Introduce a `ENABLE_VIRTUAL_THREADS` env variable to enable virtual threads, default to real threads for now

### DIFF
--- a/.github/workflows/knative-profile-data-plane.yaml
+++ b/.github/workflows/knative-profile-data-plane.yaml
@@ -73,10 +73,18 @@ jobs:
           ./data-plane/profiler/run.sh || exit 1
           ls -al
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: profile-${{ matrix.event }}-receiver.html
           path: profile-${{ matrix.event }}-receiver.html
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: profile-${{ matrix.event }}-dispatcher.html
           path: profile-${{ matrix.event }}-dispatcher.html
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs
+          path: /tmp/eventing-kafka-broker-logs/profiler/

--- a/.github/workflows/knative-profile-data-plane.yaml
+++ b/.github/workflows/knative-profile-data-plane.yaml
@@ -86,5 +86,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs
+          name: logs-${{ matrix.event }}
           path: /tmp/eventing-kafka-broker-logs/profiler/

--- a/data-plane/dispatcher-loom/pom.xml
+++ b/data-plane/dispatcher-loom/pom.xml
@@ -109,6 +109,68 @@
           </container>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven.shade.plugin.version}</version>
+        <configuration>
+          <minimizeJar>true</minimizeJar>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <!-- This merges all the META-INF/services -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>dev.knative.eventing.kafka.broker.dispatcherloom.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludeDefaults>false</excludeDefaults>
+                </filter>
+                <filter>
+                  <artifact>net.logstash.logback:logstash-logback-encoder</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>ch.qos.logback:logback-core</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>ch.qos.logback:logback-classic</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>org.apache.kafka:kafka-clients</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>io.fabric8:kubernetes-client</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
+++ b/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
@@ -45,6 +45,7 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
     private final BlockingQueue<Runnable> taskQueue;
     private final AtomicBoolean isClosed;
     private final Thread taskRunnerThread;
+    private final Promise<Void> closePromise = Promise.promise();
 
     public LoomKafkaConsumer(Vertx vertx, Consumer<K, V> consumer) {
         this.consumer = consumer;
@@ -97,20 +98,21 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
 
     @Override
     public Future<Void> close() {
+        if (!this.isClosed.compareAndSet(false, true)) {
+            return closePromise.future();
+        }
 
-        final Promise<Void> promise = Promise.promise();
         taskQueue.add(() -> {
             try {
                 logger.debug("Closing underlying Kafka consumer client");
                 consumer.wakeup();
                 consumer.close();
             } catch (Exception e) {
-                promise.tryFail(e);
+                closePromise.tryFail(e);
             }
         });
 
         logger.debug("Closing consumer {}", keyValue("size", taskQueue.size()));
-        isClosed.set(true);
 
         Thread.ofVirtual().start(() -> {
             try {
@@ -122,7 +124,7 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
 
                 taskRunnerThread.interrupt();
                 taskRunnerThread.join();
-                promise.tryComplete();
+                closePromise.tryComplete();
 
                 logger.debug("Background thread completed");
 
@@ -132,11 +134,11 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
                         "Interrupted while waiting for taskRunnerThread to finish {}",
                         keyValue("taskQueueSize", size),
                         e);
-                promise.tryFail(new InterruptedException("taskQueue.size = " + size + ". " + e.getMessage()));
+                closePromise.tryFail(new InterruptedException("taskQueue.size = " + size + ". " + e.getMessage()));
             }
         });
 
-        return promise.future();
+        return closePromise.future();
     }
 
     @Override

--- a/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
+++ b/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
@@ -102,6 +102,7 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
         taskQueue.add(() -> {
             try {
                 logger.debug("Closing underlying Kafka consumer client");
+                consumer.wakeup();
                 consumer.close();
             } catch (Exception e) {
                 promise.tryFail(e);

--- a/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
+++ b/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
@@ -51,7 +51,13 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
         this.taskQueue = new LinkedBlockingQueue<>();
         this.isClosed = new AtomicBoolean(false);
 
-        this.taskRunnerThread = Thread.ofVirtual().start(this::processTaskQueue);
+        if (Boolean.parseBoolean(System.getenv("DISABLE_VIRTUAL_THREADS"))) {
+          this.taskRunnerThread = new Thread(this::processTaskQueue);
+          this.taskRunnerThread.start();
+        } else {
+          this.taskRunnerThread = Thread.ofVirtual().start(this::processTaskQueue);
+        }
+
     }
 
     private void addTask(Runnable task, Promise<?> promise) {

--- a/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
+++ b/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
@@ -52,12 +52,11 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
         this.isClosed = new AtomicBoolean(false);
 
         if (Boolean.parseBoolean(System.getenv("DISABLE_VIRTUAL_THREADS"))) {
-          this.taskRunnerThread = new Thread(this::processTaskQueue);
-          this.taskRunnerThread.start();
+            this.taskRunnerThread = new Thread(this::processTaskQueue);
+            this.taskRunnerThread.start();
         } else {
-          this.taskRunnerThread = Thread.ofVirtual().start(this::processTaskQueue);
+            this.taskRunnerThread = Thread.ofVirtual().start(this::processTaskQueue);
         }
-
     }
 
     private void addTask(Runnable task, Promise<?> promise) {

--- a/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
+++ b/data-plane/dispatcher-loom/src/main/java/dev/knative/eventing/kafka/broker/dispatcherloom/LoomKafkaConsumer.java
@@ -51,11 +51,11 @@ public class LoomKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K, V> {
         this.taskQueue = new LinkedBlockingQueue<>();
         this.isClosed = new AtomicBoolean(false);
 
-        if (Boolean.parseBoolean(System.getenv("DISABLE_VIRTUAL_THREADS"))) {
+        if (Boolean.parseBoolean(System.getenv("ENABLE_VIRTUAL_THREADS"))) {
+            this.taskRunnerThread = Thread.ofVirtual().start(this::processTaskQueue);
+        } else {
             this.taskRunnerThread = new Thread(this::processTaskQueue);
             this.taskRunnerThread.start();
-        } else {
-            this.taskRunnerThread = Thread.ofVirtual().start(this::processTaskQueue);
         }
     }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,7 +144,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
                     .poll(POLLING_TIMEOUT)
                     .onSuccess(records -> vertx.runOnContext(v -> this.recordsHandler(records)))
                     .onFailure(t -> {
-                        if (this.closed.get()) {
+                        if (this.closed.get() || t instanceof WakeupException) {
                             // The failure might have been caused by stopping the consumer, so we just ignore it
                             return;
                         }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -103,7 +103,7 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
                     .onSuccess(records -> vertx.runOnContext(v -> this.handleRecords(records)))
                     .onFailure(cause -> {
                         if (cause instanceof WakeupException) {
-                          return; // Do nothing we're shutting down
+                            return; // Do nothing we're shutting down
                         }
 
                         isPollInFlight.set(false);

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -86,7 +86,7 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
             return;
         }
         if (inFlightRecords.get() >= getConsumerVerticleContext().getMaxPollRecords()) {
-            logger.info(
+            logger.debug(
                     "In flight records exceeds " + ConsumerConfig.MAX_POLL_RECORDS_CONFIG
                             + " waiting for response from subscriber before polling for new records {} {} {}",
                     keyValue(

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.errors.WakeupException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,6 +102,10 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
                     .poll(POLL_TIMEOUT)
                     .onSuccess(records -> vertx.runOnContext(v -> this.handleRecords(records)))
                     .onFailure(cause -> {
+                        if (cause instanceof WakeupException) {
+                          return; // Do nothing we're shutting down
+                        }
+
                         isPollInFlight.set(false);
                         logger.error(
                                 "Failed to poll messages {}",

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
@@ -54,7 +54,9 @@ import org.slf4j.LoggerFactory;
 public class Main {
 
     static {
+      if (System.getProperty("logback.configurationFile") == null || System.getProperty("logback.configurationFile").isEmpty()) {
         System.setProperty("logback.configurationFile", "/etc/logging/config.xml");
+      }
     }
 
     private static final Logger logger = LoggerFactory.getLogger(Main.class);

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
@@ -54,9 +54,10 @@ import org.slf4j.LoggerFactory;
 public class Main {
 
     static {
-      if (System.getProperty("logback.configurationFile") == null || System.getProperty("logback.configurationFile").isEmpty()) {
-        System.setProperty("logback.configurationFile", "/etc/logging/config.xml");
-      }
+        if (System.getProperty("logback.configurationFile") == null
+                || System.getProperty("logback.configurationFile").isEmpty()) {
+            System.setProperty("logback.configurationFile", "/etc/logging/config.xml");
+        }
     }
 
     private static final Logger logger = LoggerFactory.getLogger(Main.class);

--- a/data-plane/profiler/resources/config-logging.xml
+++ b/data-plane/profiler/resources/config-logging.xml
@@ -19,7 +19,12 @@
   <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
   </appender>
+  <appender name="async" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="jsonConsoleAppender" />
+    <neverBlock>true</neverBlock>
+    <maxFlushTime>1000</maxFlushTime>
+  </appender>
   <root level="INFO">
-    <appender-ref ref="jsonConsoleAppender"/>
+    <appender-ref ref="async"/>
   </root>
 </configuration>

--- a/data-plane/profiler/run.sh
+++ b/data-plane/profiler/run.sh
@@ -97,7 +97,7 @@ export EGRESSES_INITIAL_CAPACITY="1"
 export HTTP2_DISABLE="true"
 export WAIT_STARTUP_SECONDS="8"
 export CONFIG_FEATURES_PATH=""
-export DISABLE_VIRTUAL_THREADS="true"
+export ENABLE_VIRTUAL_THREADS="true"
 
 # Define receiver specific env variables.
 export SERVICE_NAME="kafka-broker-receiver"

--- a/data-plane/profiler/run.sh
+++ b/data-plane/profiler/run.sh
@@ -96,6 +96,7 @@ export METRICS_PUBLISH_QUANTILES="false"
 export EGRESSES_INITIAL_CAPACITY="1"
 export HTTP2_DISABLE="true"
 export WAIT_STARTUP_SECONDS="8"
+export CONFIG_FEATURES_PATH=""
 
 # Define receiver specific env variables.
 export SERVICE_NAME="kafka-broker-receiver"

--- a/data-plane/profiler/run.sh
+++ b/data-plane/profiler/run.sh
@@ -97,6 +97,7 @@ export EGRESSES_INITIAL_CAPACITY="1"
 export HTTP2_DISABLE="true"
 export WAIT_STARTUP_SECONDS="8"
 export CONFIG_FEATURES_PATH=""
+export DISABLE_VIRTUAL_THREADS="true"
 
 # Define receiver specific env variables.
 export SERVICE_NAME="kafka-broker-receiver"

--- a/data-plane/profiler/run.sh
+++ b/data-plane/profiler/run.sh
@@ -111,6 +111,8 @@ export INSTANCE_ID="receiver"
 java \
   -XX:+UnlockDiagnosticVMOptions \
   -XX:+DebugNonSafepoints \
+  -XX:+EnableDynamicAgentLoading \
+  -Djdk.tracePinnedThreads=full \
   -Dlogback.configurationFile="${RESOURCES_DIR}"/config-logging.xml \
   -jar "${PROJECT_ROOT_DIR}"/receiver-loom/target/receiver-loom-1.0-SNAPSHOT.jar >"${LOG_DIR}/receiver.log" &
 receiver_pid=$!
@@ -127,6 +129,8 @@ export INSTANCE_ID="dispatcher"
 java \
   -XX:+UnlockDiagnosticVMOptions \
   -XX:+DebugNonSafepoints \
+  -XX:+EnableDynamicAgentLoading \
+  -Djdk.tracePinnedThreads=full \
   -Dlogback.configurationFile="${RESOURCES_DIR}"/config-logging.xml \
   -jar "${PROJECT_ROOT_DIR}"/dispatcher-loom/target/dispatcher-loom-1.0-SNAPSHOT.jar >"${LOG_DIR}/dispatcher.log" &
 dispatcher_pid=$!

--- a/data-plane/receiver-loom/pom.xml
+++ b/data-plane/receiver-loom/pom.xml
@@ -126,6 +126,69 @@
           </container>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven.shade.plugin.version}</version>
+        <configuration>
+          <minimizeJar>true</minimizeJar>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <!-- This merges all the META-INF/services -->
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>dev.knative.eventing.kafka.broker.receiverloom.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludeDefaults>false</excludeDefaults>
+                </filter>
+                <filter>
+                  <artifact>net.logstash.logback:logstash-logback-encoder</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>ch.qos.logback:logback-core</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>ch.qos.logback:logback-classic</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>org.apache.kafka:kafka-clients</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>io.fabric8:kubernetes-client</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
+++ b/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
@@ -61,12 +61,12 @@ public class LoomKafkaProducer<K, V> implements ReactiveKafkaProducer<K, V> {
             this.tracer = null;
         }
 
-      if (Boolean.parseBoolean(System.getenv("DISABLE_VIRTUAL_THREADS"))) {
-        this.sendFromQueueThread = new Thread(this::sendFromQueue);
-        this.sendFromQueueThread.start();
-      } else {
-        this.sendFromQueueThread = Thread.ofVirtual().start(this::sendFromQueue);
-      }
+        if (Boolean.parseBoolean(System.getenv("DISABLE_VIRTUAL_THREADS"))) {
+            this.sendFromQueueThread = new Thread(this::sendFromQueue);
+            this.sendFromQueueThread.start();
+        } else {
+            this.sendFromQueueThread = Thread.ofVirtual().start(this::sendFromQueue);
+        }
     }
 
     @Override

--- a/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
+++ b/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
@@ -61,11 +61,11 @@ public class LoomKafkaProducer<K, V> implements ReactiveKafkaProducer<K, V> {
             this.tracer = null;
         }
 
-        if (Boolean.parseBoolean(System.getenv("DISABLE_VIRTUAL_THREADS"))) {
+        if (Boolean.parseBoolean(System.getenv("ENABLE_VIRTUAL_THREADS"))) {
+            this.sendFromQueueThread = Thread.ofVirtual().start(this::sendFromQueue);
+        } else {
             this.sendFromQueueThread = new Thread(this::sendFromQueue);
             this.sendFromQueueThread.start();
-        } else {
-            this.sendFromQueueThread = Thread.ofVirtual().start(this::sendFromQueue);
         }
     }
 

--- a/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
+++ b/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
@@ -61,7 +61,12 @@ public class LoomKafkaProducer<K, V> implements ReactiveKafkaProducer<K, V> {
             this.tracer = null;
         }
 
-        sendFromQueueThread = Thread.ofVirtual().start(this::sendFromQueue);
+      if (Boolean.parseBoolean(System.getenv("DISABLE_VIRTUAL_THREADS"))) {
+        this.sendFromQueueThread = new Thread(this::sendFromQueue);
+        this.sendFromQueueThread.start();
+      } else {
+        this.sendFromQueueThread = Thread.ofVirtual().start(this::sendFromQueue);
+      }
     }
 
     @Override

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -60,7 +60,9 @@ import org.slf4j.LoggerFactory;
 public class Main {
 
     static {
+      if (System.getProperty("logback.configurationFile") == null || System.getProperty("logback.configurationFile").isEmpty()) {
         System.setProperty("logback.configurationFile", "/etc/logging/config.xml");
+      }
     }
 
     private static final Logger logger = LoggerFactory.getLogger(Main.class);

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -117,7 +117,7 @@ public class Main {
                     .toCompletionStage()
                     .toCompletableFuture()
                     .get();
-        } catch (ExecutionException ex) {
+        } catch (Exception ex) {
             if (featuresConfig.isAuthenticationOIDC()) {
                 logger.error("Could not load OIDC config while OIDC authentication feature is enabled.");
                 throw ex;

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -60,9 +60,10 @@ import org.slf4j.LoggerFactory;
 public class Main {
 
     static {
-      if (System.getProperty("logback.configurationFile") == null || System.getProperty("logback.configurationFile").isEmpty()) {
-        System.setProperty("logback.configurationFile", "/etc/logging/config.xml");
-      }
+        if (System.getProperty("logback.configurationFile") == null
+                || System.getProperty("logback.configurationFile").isEmpty()) {
+            System.setProperty("logback.configurationFile", "/etc/logging/config.xml");
+        }
     }
 
     private static final Logger logger = LoggerFactory.getLogger(Main.class);


### PR DESCRIPTION
As per title

- Introduce a `ENABLE_VIRTUAL_THREADS` env variable to enable virtual threads, default to real threads for now
- Add shade plugin to create an uber jar file
-  Define empty features config path
- Catch `Exception` and not only `ExecutionException` when missing  features config path
- Use normal threads until we stress test loom threads more
- Fix profiler job