### PR TITLE
feat: receiver verticle now has a grace period before closing

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -68,6 +68,8 @@ public class Main {
 
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
+    private static final long receiverGracePeriodMs = 20_000; // 20 seconds, in milliseconds
+
     /**
      * Start receiver.
      *
@@ -165,7 +167,8 @@ public class Main {
                     eventTypeClient,
                     eventTypeLister,
                     vertx,
-                    oidcDiscoveryConfig);
+                    oidcDiscoveryConfig,
+                    receiverGracePeriodMs);
             DeploymentOptions deploymentOptions =
                     new DeploymentOptions().setInstances(Runtime.getRuntime().availableProcessors());
             // Deploy the receiver verticles

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -52,6 +52,8 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
 
     private ReactiveProducerFactory<String, CloudEvent> kafkaProducerFactory;
 
+    private final long terminationGracePeriodMs;
+
     ReceiverVerticleFactory(
             final ReceiverEnv env,
             final Properties producerConfigs,
@@ -62,7 +64,8 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
             final MixedOperation<EventType, KubernetesResourceList<EventType>, Resource<EventType>> eventTypeClient,
             final Lister<EventType> eventTypeLister,
             Vertx vertx,
-            final OIDCDiscoveryConfig oidcDiscoveryConfig)
+            final OIDCDiscoveryConfig oidcDiscoveryConfig,
+            final long terminationGracePeriodMs)
             throws NoSuchAlgorithmException {
         {
             this.env = env;
@@ -75,6 +78,7 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
                     new EventTypeCreatorImpl(eventTypeClient, eventTypeLister, vertx));
             this.kafkaProducerFactory = kafkaProducerFactory;
             this.oidcDiscoveryConfig = oidcDiscoveryConfig;
+            this.terminationGracePeriodMs = terminationGracePeriodMs;
         }
     }
 
@@ -90,6 +94,7 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
                         properties -> kafkaProducerFactory.create(v, properties)),
                 this.ingressRequestHandler,
                 secretVolumePath,
-                oidcDiscoveryConfig);
+                oidcDiscoveryConfig,
+                terminationGracePeriodMs);
     }
 }

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTest.java
@@ -151,7 +151,8 @@ public class ReceiverVerticleTest {
                 new IngressRequestHandlerImpl(
                         StrictRequestToRecordMapper.getInstance(), registry, ((event, reference) -> null)),
                 SECRET_VOLUME_PATH,
-                null);
+                null,
+                0);
         vertx.deployVerticle(verticle, testContext.succeeding(ar -> testContext.completeNow()));
 
         // Connect to the logger in ReceiverVerticle

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTracingTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTracingTest.java
@@ -133,7 +133,8 @@ public abstract class ReceiverVerticleTracingTest {
                 new IngressRequestHandlerImpl(
                         StrictRequestToRecordMapper.getInstance(), Metrics.getRegistry(), ((event, reference) -> null)),
                 SECRET_VOLUME_PATH,
-                null);
+                null,
+                0);
 
         vertx.deployVerticle(verticle).toCompletionStage().toCompletableFuture().get();
     }

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
@@ -56,7 +56,8 @@ public class ReceiverVerticleFactoryTest {
                 mockClient.resources(EventType.class),
                 mock(Lister.class),
                 vertx,
-                mock(OIDCDiscoveryConfig.class));
+                mock(OIDCDiscoveryConfig.class),
+                0);
 
         assertThat(supplier.get()).isNotSameAs(supplier.get());
     }

--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/AbstractDataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/AbstractDataPlaneTest.java
@@ -396,7 +396,8 @@ public abstract class AbstractDataPlaneTest {
                         Metrics.getRegistry(),
                         (((event, reference) -> null))),
                 SECRET_VOLUME_PATH,
-                null);
+                null,
+                0);
 
         final CountDownLatch latch = new CountDownLatch(1);
         vertx.deployVerticle(verticle, context.succeeding(h -> latch.countDown()));


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #1684 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add parameter to ReceiverVerticleFactory for how long to wait before closing the http servers in the receiver
- Use timeout in the receiver stop handler to wait until the grace period has finished before closing the servers
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The receiver http/https servers now wait for 20 seconds after receiving SIGTERM before closing, helping with more graceful shutdown
```

