### PR TITLE
Prevent generation only updates

### DIFF
--- a/control-plane/pkg/contract/extensions.go
+++ b/control-plane/pkg/contract/extensions.go
@@ -16,7 +16,16 @@
 
 package contract
 
+import (
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
 // IncrementGeneration increments Generation.
 func (x *Contract) IncrementGeneration() {
 	x.Generation++
+}
+
+func SemanticEqual(ct1 *Contract, ct2 *Contract) bool {
+	return cmp.Equal(ct1, ct2, protocmp.Transform(), protocmp.IgnoreFields(ct1, "generation"))
 }

--- a/control-plane/pkg/core/config/egress.go
+++ b/control-plane/pkg/core/config/egress.go
@@ -47,24 +47,17 @@ const (
 )
 
 // AddOrUpdateEgressConfig adds or updates the given egress to the given contract at the specified indexes.
-func AddOrUpdateEgressConfig(ct *contract.Contract, resourceIndex int, egress *contract.Egress, egressIndex int) int {
+func AddOrUpdateEgressConfig(ct *contract.Contract, resourceIndex int, egress *contract.Egress, egressIndex int) {
 
 	if egressIndex != NoEgress {
-		prev := ct.Resources[resourceIndex].Egresses[egressIndex]
 		ct.Resources[resourceIndex].Egresses[egressIndex] = egress
-
-		if proto.Equal(prev, egress) {
-			return EgressUnchanged
-		}
-		return EgressChanged
+		return
 	}
 
 	ct.Resources[resourceIndex].Egresses = append(
 		ct.Resources[resourceIndex].Egresses,
 		egress,
 	)
-
-	return EgressChanged
 }
 
 // AddOrUpdateEgressConfigForResource adds or updates the given egress to the given contract at the specified indexes.

--- a/control-plane/pkg/core/config/resource.go
+++ b/control-plane/pkg/core/config/resource.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
@@ -41,11 +40,6 @@ func FindResource(contract *contract.Contract, resource types.UID) int {
 	return resourceIndex
 }
 
-const (
-	ResourceChanged = iota
-	ResourceUnchanged
-)
-
 func SetResourceEgressesFromContract(contract *contract.Contract, resource *contract.Resource, index int) {
 	if index != NoResource {
 		resource.Egresses = contract.Resources[index].Egresses
@@ -53,25 +47,15 @@ func SetResourceEgressesFromContract(contract *contract.Contract, resource *cont
 }
 
 // AddOrUpdateResourceConfig adds or updates the given resourceConfig to the given resources at the specified index.
-func AddOrUpdateResourceConfig(contract *contract.Contract, resource *contract.Resource, index int, logger *zap.Logger) int {
-
+func AddOrUpdateResourceConfig(contract *contract.Contract, resource *contract.Resource, index int, logger *zap.Logger) {
 	if index != NoResource {
 		logger.Debug("Resource exists", zap.Int("index", index))
-
-		prev := contract.Resources[index]
 		contract.Resources[index] = resource
-
-		if proto.Equal(prev, resource) {
-			return ResourceUnchanged
-		}
-		return ResourceChanged
+		return
 	}
 
 	logger.Debug("Resource doesn't exist")
-
 	contract.Resources = append(contract.Resources, resource)
-
-	return ResourceChanged
 }
 
 // DeleteResource deletes the resource at the given index from Resources.

--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/utils/pointer"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/tracker"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
@@ -235,7 +236,21 @@ func GetDataPlaneConfigMapData(logger *zap.Logger, dataPlaneConfigMap *corev1.Co
 	return ct, nil
 }
 
+func CompareSemanticEqual(ctx context.Context, ct *contract.Contract, existing *corev1.ConfigMap, format string) bool {
+	existingCt, err := GetDataPlaneConfigMapData(logging.FromContext(ctx).Desugar(), existing, format)
+	if existingCt != nil && err == nil {
+		if contract.SemanticEqual(existingCt, ct) {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
 func (r *Reconciler) UpdateDataPlaneConfigMap(ctx context.Context, contract *contract.Contract, configMap *corev1.ConfigMap) error {
+	if CompareSemanticEqual(ctx, contract, configMap, r.ContractConfigMapFormat) {
+		return nil
+	}
 
 	var data []byte
 	var err error

--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -1060,7 +1060,9 @@ func triggerReconciliation(t *testing.T, format string, env config.Env, useNewFi
 						},
 					},
 				}, env.DataPlaneConfigMapNamespace, env.ContractConfigMapName, env.ContractConfigMapFormat),
-				BrokerDispatcherPod(env.SystemNamespace, nil),
+				BrokerDispatcherPod(env.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "0",
+				}),
 				DataPlaneConfigMap(env.DataPlaneConfigMapNamespace, env.DataPlaneConfigConfigMapName, brokerreconciler.ConsumerConfigKey,
 					DataPlaneConfigInitialOffset(brokerreconciler.ConsumerConfigKey, sources.OffsetLatest),
 				),


### PR DESCRIPTION
This guards and discard contract ConfigMap updates when only `generation`
changes.

While this approach is technically slightly slower, the latency is negligible,
and it is more robust and easier to maintain.

## Proposed Changes

- guards and discard contract ConfigMap updates when only `generation`
changes
- move change detection to the shared library

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Prevent unnecessary ConfigMap updates and reduce API server load
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
