### PR TITLE
fix: kafka controller does not panic on invalid kafka client config

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_validation.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_validation.go
@@ -57,6 +57,9 @@ func (cts *ConsumerTemplateSpec) Validate(ctx context.Context) *apis.FieldError 
 		cts.Spec.Delivery.Validate(specCtx).ViaField("delivery"),
 		cts.Spec.Subscriber.Validate(specCtx).ViaField("subscriber"),
 	)
+	if cts.Spec.Configs.Configs == nil {
+		err = err.Also(apis.ErrMissingField("spec.configs"))
+	}
 	return err
 }
 

--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_validation_test.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_validation_test.go
@@ -109,6 +109,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Host:   "127.0.0.1",
 								},
 							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
+							},
 						},
 					},
 				},
@@ -135,6 +138,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Name:       "my-seq",
 									APIVersion: "flows.knative.dev/v1",
 								},
+							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
 							},
 						},
 					},
@@ -191,6 +197,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Host:   "127.0.0.1",
 								},
 							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
+							},
 						},
 					},
 				},
@@ -214,6 +223,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Scheme: "http",
 									Host:   "127.0.0.1",
 								},
+							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
 							},
 						},
 					},
@@ -243,6 +255,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Host:   "127.0.0.1",
 								},
 							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
+							},
 						},
 					},
 				},
@@ -266,6 +281,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Scheme: "http",
 									Host:   "127.0.0.1",
 								},
+							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
 							},
 						},
 					},

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -301,10 +301,6 @@ func (r *Reconciler) deleteConsumerGroupMetadata(ctx context.Context, cg *kafkai
 		return fmt.Errorf("failed to get secret for Kafka cluster auth: %w", err)
 	}
 
-	if cg.Spec.Template.Spec.Configs.Configs == nil {
-		return fmt.Errorf("no consumer config supplied, unable to get bootstrap.servers")
-	}
-
 	bootstrapServers := kafka.BootstrapServersArray(cg.Spec.Template.Spec.Configs.Configs["bootstrap.servers"])
 
 	kafkaClusterAdminClient, err := r.GetKafkaClusterAdmin(ctx, bootstrapServers, kafakSecret)
@@ -598,10 +594,6 @@ func (r *Reconciler) reconcileInitialOffset(ctx context.Context, cg *kafkaintern
 	kafkaSecret, err := r.newAuthSecret(ctx, cg)
 	if err != nil {
 		return fmt.Errorf("failed to get secret for Kafka cluster auth: %w", err)
-	}
-
-	if cg.Spec.Template.Spec.Configs.Configs == nil {
-		return fmt.Errorf("no consumer config supplied, unable to get bootstrap.servers")
 	}
 
 	bootstrapServers := kafka.BootstrapServersArray(cg.Spec.Template.Spec.Configs.Configs["bootstrap.servers"])


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #3935

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Only defer closing the cluster admin if it is not nil
- Check that the configs map exists before accessing a value in it

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The kafka controller does not panic on invalid kafka client configmaps anymore
```

