### PR TITLE
fix: only add authentication ref to scaled objects when there is an actual value to reference

### DIFF
--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -77,13 +77,14 @@ func GenerateScaleTriggers(cg *kafkainternals.ConsumerGroup, triggerAuthenticati
 		}
 
 		trigger := kedav1alpha1.ScaleTriggers{
-			Type:              "kafka",
-			Metadata:          triggerMetadata,
-			AuthenticationRef: &kedav1alpha1.ScaledObjectAuthRef{},
+			Type:     "kafka",
+			Metadata: triggerMetadata,
 		}
 
 		if triggerAuthentication != nil {
-			trigger.AuthenticationRef.Name = triggerAuthentication.Name
+			trigger.AuthenticationRef = &kedav1alpha1.ScaledObjectAuthRef{
+				Name: triggerAuthentication.Name,
+			}
 		}
 
 		triggers = append(triggers, trigger)


### PR DESCRIPTION


<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #3939 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Only add the authentication ref to the scaled object if there is something to reference

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug: KEDA ScaledObjects are now only created with an authentication ref if there is a trigger authentication object to reference
```

