### PR TITLE
fix: go version in go mod is correct now

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/eventing-kafka-broker
 
-go 1.22
+go 1.22.3
 
 require (
 	github.com/IBM/sarama v1.43.1


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes issues with `go mod tidy` resulting from an incorrect go mod file. See https://github.com/golang/go/issues/62278#issuecomment-1693538776 for more info

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Move from `go 1.22` to explicit `go 1.22.3`
