### PR TITLE
Move to using namespaced listers for eventtypes in data plane

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreatorImpl.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreatorImpl.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
@@ -66,7 +65,9 @@ public class EventTypeCreatorImpl implements EventTypeCreator {
     }
 
     private EventType eventTypeExists(String etName, DataPlaneContract.Reference reference) {
-        return this.eventTypeListerFactory.getForNamespace(reference.getNamespace()).get(etName);
+        return this.eventTypeListerFactory
+                .getForNamespace(reference.getNamespace())
+                .get(etName);
     }
 
     @Override

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreatorImpl.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreatorImpl.java
@@ -36,7 +36,7 @@ public class EventTypeCreatorImpl implements EventTypeCreator {
 
     private final MixedOperation<EventType, KubernetesResourceList<EventType>, Resource<EventType>> eventTypeClient;
 
-    private final Lister<EventType> eventTypeLister;
+    private final EventTypeListerFactory eventTypeListerFactory;
 
     private MessageDigest messageDigest;
 
@@ -44,14 +44,11 @@ public class EventTypeCreatorImpl implements EventTypeCreator {
 
     public EventTypeCreatorImpl(
             MixedOperation<EventType, KubernetesResourceList<EventType>, Resource<EventType>> eventTypeClient,
-            Lister<EventType> eventTypeLister,
+            EventTypeListerFactory eventTypeListerFactory,
             Vertx vertx)
             throws IllegalArgumentException, NoSuchAlgorithmException {
         this.eventTypeClient = eventTypeClient;
-        if (eventTypeLister == null) {
-            throw new IllegalArgumentException("eventTypeLister must be non null");
-        }
-        this.eventTypeLister = eventTypeLister;
+        this.eventTypeListerFactory = eventTypeListerFactory;
         this.executor = vertx.createSharedWorkerExecutor("et-creator-worker", 1);
         this.messageDigest = MessageDigest.getInstance("MD5");
     }
@@ -69,7 +66,7 @@ public class EventTypeCreatorImpl implements EventTypeCreator {
     }
 
     private EventType eventTypeExists(String etName, DataPlaneContract.Reference reference) {
-        return this.eventTypeLister.namespace(reference.getNamespace()).get(etName);
+        return this.eventTypeListerFactory.getForNamespace(reference.getNamespace()).get(etName);
     }
 
     @Override

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeListerFactory.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeListerFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.knative.eventing.kafka.broker.core.eventtype;
 
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeListerFactory.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeListerFactory.java
@@ -18,32 +18,31 @@ package dev.knative.eventing.kafka.broker.core.eventtype;
 
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Lister;
-
 import java.util.HashMap;
 import java.util.Map;
 
 public class EventTypeListerFactory {
-  private final Map<String, Lister<EventType>> listerMap;
-  private final SharedIndexInformer<EventType> eventTypeInformer;
+    private final Map<String, Lister<EventType>> listerMap;
+    private final SharedIndexInformer<EventType> eventTypeInformer;
 
-  public EventTypeListerFactory(SharedIndexInformer<EventType> eventTypeInformer) {
-    if (eventTypeInformer == null) {
-      throw new IllegalArgumentException("you must provide a non null eventtype informer");
+    public EventTypeListerFactory(SharedIndexInformer<EventType> eventTypeInformer) {
+        if (eventTypeInformer == null) {
+            throw new IllegalArgumentException("you must provide a non null eventtype informer");
+        }
+        this.eventTypeInformer = eventTypeInformer;
+        this.listerMap = new HashMap<>();
     }
-    this.eventTypeInformer = eventTypeInformer;
-    this.listerMap = new HashMap<>();
-  }
 
-  public Lister<EventType> getForNamespace(String namespace) {
-    if (this.listerMap.containsKey(namespace)) {
-      return this.listerMap.get(namespace);
+    public Lister<EventType> getForNamespace(String namespace) {
+        if (this.listerMap.containsKey(namespace)) {
+            return this.listerMap.get(namespace);
+        }
+        return this.createListerForNamespace(namespace);
     }
-    return this.createListerForNamespace(namespace);
-  }
 
-  private Lister<EventType> createListerForNamespace(String namespace) {
-    final var lister = new Lister<>(this.eventTypeInformer.getIndexer(), namespace);
-    this.listerMap.put(namespace, lister);
-    return lister;
-  }
+    private Lister<EventType> createListerForNamespace(String namespace) {
+        final var lister = new Lister<>(this.eventTypeInformer.getIndexer(), namespace);
+        this.listerMap.put(namespace, lister);
+        return lister;
+    }
 }

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeListerFactory.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeListerFactory.java
@@ -1,0 +1,33 @@
+package dev.knative.eventing.kafka.broker.core.eventtype;
+
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.fabric8.kubernetes.client.informers.cache.Lister;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EventTypeListerFactory {
+  private final Map<String, Lister<EventType>> listerMap;
+  private final SharedIndexInformer<EventType> eventTypeInformer;
+
+  public EventTypeListerFactory(SharedIndexInformer<EventType> eventTypeInformer) {
+    if (eventTypeInformer == null) {
+      throw new IllegalArgumentException("you must provide a non null eventtype informer");
+    }
+    this.eventTypeInformer = eventTypeInformer;
+    this.listerMap = new HashMap<>();
+  }
+
+  public Lister<EventType> getForNamespace(String namespace) {
+    if (this.listerMap.containsKey(namespace)) {
+      return this.listerMap.get(namespace);
+    }
+    return this.createListerForNamespace(namespace);
+  }
+
+  private Lister<EventType> createListerForNamespace(String namespace) {
+    final var lister = new Lister<>(this.eventTypeInformer.getIndexer(), namespace);
+    this.listerMap.put(namespace, lister);
+    return lister;
+  }
+}

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreatorImplTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreatorImplTest.java
@@ -21,7 +21,6 @@ import io.cloudevents.core.v1.CloudEventBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.vertx.core.Vertx;

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreatorImplTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreatorImplTest.java
@@ -47,8 +47,7 @@ public class EventTypeCreatorImplTest {
     public void testCreate(Vertx vertx, VertxTestContext vertxTestContext) throws NoSuchAlgorithmException {
         final var eventTypeClient = kubernetesClient.resources(EventType.class);
         final var informer = kubernetesClient.informers().sharedIndexInformerFor(EventType.class, 100L);
-        final var eventTypeLister = new Lister<>(informer.getIndexer());
-        var eventTypeCreator = new EventTypeCreatorImpl(eventTypeClient, eventTypeLister, vertx);
+        var eventTypeCreator = new EventTypeCreatorImpl(eventTypeClient, new EventTypeListerFactory(informer), vertx);
         var event = new CloudEventBuilder()
                 .withType("example.event.type")
                 .withSource(URI.create("/example/source"))
@@ -100,8 +99,7 @@ public class EventTypeCreatorImplTest {
         final var eventTypeClient = kubernetesClient.resources(EventType.class);
         final var informer = kubernetesClient.informers().sharedIndexInformerFor(EventType.class, 100L);
         informer.run();
-        final var eventTypeLister = new Lister<>(informer.getIndexer());
-        var eventTypeCreator = new EventTypeCreatorImpl(eventTypeClient, eventTypeLister, vertx);
+        var eventTypeCreator = new EventTypeCreatorImpl(eventTypeClient, new EventTypeListerFactory(informer), vertx);
         var event = new CloudEventBuilder()
                 .withType("example.event.type")
                 .withSource(URI.create("/example/source"))

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -34,7 +34,6 @@ import io.cloudevents.kafka.PartitionKeyExtensionInterceptor;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
-import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Verticle;

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -135,7 +135,6 @@ public class Main {
         final SharedInformerFactory sharedInformerFactory = kubernetesClient.informers();
         final var eventTypeClient = kubernetesClient.resources(EventType.class);
         SharedIndexInformer<EventType> eventTypeInformer = null;
-        Lister<EventType> eventTypeLister = null;
         try {
             eventTypeInformer = sharedInformerFactory.sharedIndexInformerFor(
                     EventType.class, 30 * 1000L); // refresh every 30 seconds
@@ -147,9 +146,6 @@ public class Main {
             logger.warn(
                     "the data-plane does not have sufficient permissions to list/watch eventtypes. This will lead to unnecessary CREATE requests if eventtype-auto-create is enabled",
                     informerException);
-        }
-        if (eventTypeInformer != null) {
-            eventTypeLister = new Lister<>(eventTypeInformer.getIndexer());
         }
 
         // Configure the verticle to deploy and the deployment options
@@ -163,7 +159,7 @@ public class Main {
                     httpsServerOptions,
                     kafkaProducerFactory,
                     eventTypeClient,
-                    eventTypeLister,
+                    eventTypeInformer,
                     vertx,
                     oidcDiscoveryConfig);
             DeploymentOptions deploymentOptions =

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -18,6 +18,7 @@ package dev.knative.eventing.kafka.broker.receiver.main;
 import dev.knative.eventing.kafka.broker.core.ReactiveProducerFactory;
 import dev.knative.eventing.kafka.broker.core.eventtype.EventType;
 import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeCreatorImpl;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeListerFactory;
 import dev.knative.eventing.kafka.broker.core.oidc.OIDCDiscoveryConfig;
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
 import dev.knative.eventing.kafka.broker.receiver.IngressRequestHandler;
@@ -29,6 +30,7 @@ import io.cloudevents.CloudEvent;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Verticle;
@@ -53,16 +55,16 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
     private ReactiveProducerFactory<String, CloudEvent> kafkaProducerFactory;
 
     ReceiverVerticleFactory(
-            final ReceiverEnv env,
-            final Properties producerConfigs,
-            final MeterRegistry metricsRegistry,
-            final HttpServerOptions httpServerOptions,
-            final HttpServerOptions httpsServerOptions,
-            final ReactiveProducerFactory<String, CloudEvent> kafkaProducerFactory,
-            final MixedOperation<EventType, KubernetesResourceList<EventType>, Resource<EventType>> eventTypeClient,
-            final Lister<EventType> eventTypeLister,
-            Vertx vertx,
-            final OIDCDiscoveryConfig oidcDiscoveryConfig)
+      final ReceiverEnv env,
+      final Properties producerConfigs,
+      final MeterRegistry metricsRegistry,
+      final HttpServerOptions httpServerOptions,
+      final HttpServerOptions httpsServerOptions,
+      final ReactiveProducerFactory<String, CloudEvent> kafkaProducerFactory,
+      final MixedOperation<EventType, KubernetesResourceList<EventType>, Resource<EventType>> eventTypeClient,
+      final SharedIndexInformer<EventType> eventTypeInformer,
+      Vertx vertx,
+      final OIDCDiscoveryConfig oidcDiscoveryConfig)
             throws NoSuchAlgorithmException {
         {
             this.env = env;
@@ -72,7 +74,7 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
             this.ingressRequestHandler = new IngressRequestHandlerImpl(
                     StrictRequestToRecordMapper.getInstance(),
                     metricsRegistry,
-                    new EventTypeCreatorImpl(eventTypeClient, eventTypeLister, vertx));
+                    new EventTypeCreatorImpl(eventTypeClient, new EventTypeListerFactory(eventTypeInformer), vertx));
             this.kafkaProducerFactory = kafkaProducerFactory;
             this.oidcDiscoveryConfig = oidcDiscoveryConfig;
         }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -31,7 +31,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
-import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
@@ -55,16 +54,16 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
     private ReactiveProducerFactory<String, CloudEvent> kafkaProducerFactory;
 
     ReceiverVerticleFactory(
-      final ReceiverEnv env,
-      final Properties producerConfigs,
-      final MeterRegistry metricsRegistry,
-      final HttpServerOptions httpServerOptions,
-      final HttpServerOptions httpsServerOptions,
-      final ReactiveProducerFactory<String, CloudEvent> kafkaProducerFactory,
-      final MixedOperation<EventType, KubernetesResourceList<EventType>, Resource<EventType>> eventTypeClient,
-      final SharedIndexInformer<EventType> eventTypeInformer,
-      Vertx vertx,
-      final OIDCDiscoveryConfig oidcDiscoveryConfig)
+            final ReceiverEnv env,
+            final Properties producerConfigs,
+            final MeterRegistry metricsRegistry,
+            final HttpServerOptions httpServerOptions,
+            final HttpServerOptions httpsServerOptions,
+            final ReactiveProducerFactory<String, CloudEvent> kafkaProducerFactory,
+            final MixedOperation<EventType, KubernetesResourceList<EventType>, Resource<EventType>> eventTypeClient,
+            final SharedIndexInformer<EventType> eventTypeInformer,
+            Vertx vertx,
+            final OIDCDiscoveryConfig oidcDiscoveryConfig)
             throws NoSuchAlgorithmException {
         {
             this.env = env;

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
@@ -20,13 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import dev.knative.eventing.kafka.broker.core.eventtype.EventType;
-import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeListerFactory;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.oidc.OIDCDiscoveryConfig;
 import dev.knative.eventing.kafka.broker.receiver.MockReactiveProducerFactory;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
-import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerOptions;

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
@@ -20,10 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import dev.knative.eventing.kafka.broker.core.eventtype.EventType;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeListerFactory;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.oidc.OIDCDiscoveryConfig;
 import dev.knative.eventing.kafka.broker.receiver.MockReactiveProducerFactory;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;
@@ -54,7 +56,7 @@ public class ReceiverVerticleFactoryTest {
                 mock(HttpServerOptions.class),
                 mock(MockReactiveProducerFactory.class),
                 mockClient.resources(EventType.class),
-                mock(Lister.class),
+                mock(SharedIndexInformer.class),
                 vertx,
                 mock(OIDCDiscoveryConfig.class));
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Currently, there are some error logs in the namespaced broker data plane stating that "the data-plane does not have sufficient permissions to list/watch eventtypes"

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use namespaced listers instead of a global lister

```release-note
:bug: The namespaced broker receiver only tries to list eventtypes in it's own namespace
```

