### PR TITLE
Revert "fix: go version in go mod is correct now"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/eventing-kafka-broker
 
-go 1.22.3
+go 1.22
 
 require (
 	github.com/IBM/sarama v1.43.1


### PR DESCRIPTION
Reverts knative-extensions/eventing-kafka-broker#3950

I think if everything and us start using 1.22 installations, we wouldn't need this