### PR TITLE
fix: knative kafka extensions are short enough to meet the SHOULD req in spec

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
@@ -46,7 +46,7 @@ public class CloudEventOverridesMutator implements CloudEventMutator {
     }
 
     private void applyKafkaMetadata(CloudEventBuilder builder, Number partition, Number offset) {
-        builder.withExtension("knativekafkapartition", partition);
-        builder.withExtension("knativekafkaoffset", offset);
+        builder.withExtension("knkafkapartition", partition);
+        builder.withExtension("knkafkaoffset", offset);
     }
 }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutatorTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutatorTest.java
@@ -48,8 +48,8 @@ public class CloudEventOverridesMutatorTest {
 
         final var expected = CloudEventBuilder.from(given);
         extensions.forEach(expected::withExtension);
-        expected.withExtension("knativekafkaoffset", 1L);
-        expected.withExtension("knativekafkapartition", 1);
+        expected.withExtension("knkafkaoffset", 1L);
+        expected.withExtension("knkafkapartition", 1);
 
         final var got = mutator.apply(new ConsumerRecord<>("test-topic", 1, 1, "key", given));
 
@@ -72,8 +72,8 @@ public class CloudEventOverridesMutatorTest {
                 .build();
 
         final var expected = CloudEventBuilder.from(given)
-                .withExtension("knativekafkaoffset", 1L)
-                .withExtension("knativekafkapartition", 1)
+                .withExtension("knkafkaoffset", 1L)
+                .withExtension("knkafkapartition", 1)
                 .build();
 
         final var got = mutator.apply(new ConsumerRecord<>("test-topic", 1, 1, "key", given));

--- a/test/rekt/features/ce_extensions.go
+++ b/test/rekt/features/ce_extensions.go
@@ -38,16 +38,16 @@ import (
 
 func KnativeKafkaCEExtensionsAdded() *feature.FeatureSet {
 	return &feature.FeatureSet{
-		Name: "KnativeKafkaCEExtensionsAdded",
+		Name: "KnKafkaCEExtensionsAdded",
 		Features: []*feature.Feature{
-			brokerAddsKnativeKafkaCEExtensions(),
-			channelAddsKnativeKafkaCEExtensions(),
-			sourceAddsKnativeKafkaCEExtensions(),
+			brokerAddsKnKafkaCEExtensions(),
+			channelAddsKnKafkaCEExtensions(),
+			sourceAddsKnKafkaCEExtensions(),
 		},
 	}
 }
 
-func brokerAddsKnativeKafkaCEExtensions() *feature.Feature {
+func brokerAddsKnKafkaCEExtensions() *feature.Feature {
 	f := feature.NewFeature()
 
 	brokerName := feature.MakeRandomK8sName("broker")
@@ -77,12 +77,12 @@ func brokerAddsKnativeKafkaCEExtensions() *feature.Feature {
 
 	f.Alpha("broker").
 		Must("must add Knative Kafka CE extensions", eventasssert.OnStore(sinkName).
-			MatchEvent(test.ContainsExtensions("knativekafkapartition", "knativekafkaoffset")).
+			MatchEvent(test.ContainsExtensions("knkafkapartition", "knkafkaoffset")).
 			Exact(1))
 	return f
 }
 
-func channelAddsKnativeKafkaCEExtensions() *feature.Feature {
+func channelAddsKnKafkaCEExtensions() *feature.Feature {
 	f := feature.NewFeature()
 
 	channelName := feature.MakeRandomK8sName("channel")
@@ -119,12 +119,12 @@ func channelAddsKnativeKafkaCEExtensions() *feature.Feature {
 
 	f.Alpha("channel").
 		Must("add Knative Kafka CE extensions", eventasssert.OnStore(sinkName).
-			MatchEvent(test.ContainsExtensions("knativekafkapartition", "knativekafkaoffset")).
+			MatchEvent(test.ContainsExtensions("knkafkapartition", "knkafkaoffset")).
 			Exact(1))
 	return f
 }
 
-func sourceAddsKnativeKafkaCEExtensions() *feature.Feature {
+func sourceAddsKnKafkaCEExtensions() *feature.Feature {
 	f := feature.NewFeature()
 
 	kafkaSource := feature.MakeRandomK8sName("kafka-source")
@@ -162,7 +162,7 @@ func sourceAddsKnativeKafkaCEExtensions() *feature.Feature {
 
 	f.Alpha("source").
 		Must("add Knative Kafka CE extensions", eventasssert.OnStore(sinkName).
-			MatchEvent(test.ContainsExtensions("knativekafkapartition", "knativekafkaoffset")).
+			MatchEvent(test.ContainsExtensions("knkafkapartition", "knkafkaoffset")).
 			Exact(1))
 	return f
 }


### PR DESCRIPTION


<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #3992 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Shorten the extensions

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
BREAKING CHANGE: the knative kafka partition/offset ce extensions have been renamed to knkafkapartition and knkafkaoffset to keep them under 20 characters in length
```
