### PR TITLE
fix: virtual secrets created from netspec have name and namespace

### DIFF
--- a/control-plane/pkg/security/secrets_provider_net_spec.go
+++ b/control-plane/pkg/security/secrets_provider_net_spec.go
@@ -19,8 +19,11 @@ package security
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	bindings "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/bindings/v1beta1"
 
@@ -53,7 +56,7 @@ func ResolveAuthContextFromNetSpec(lister corelisters.SecretLister, namespace st
 			return nil, err
 		}
 	}
-	references, virtualSecretData := toContract(securityFields)
+	references, virtualSecretData, virtualSecretName, virtualSecretNamespace := toContract(securityFields)
 	multiSecretReference := &contract.MultiSecretReference{
 		Protocol:   getProtocolContractFromNetSpec(netSpec),
 		References: references,
@@ -61,13 +64,19 @@ func ResolveAuthContextFromNetSpec(lister corelisters.SecretLister, namespace st
 	virtualSecretData[ProtocolKey] = []byte(getProtocolFromNetSpec(netSpec))
 
 	authContext := &NetSpecAuthContext{
-		VirtualSecret:        &corev1.Secret{Data: virtualSecretData},
+		VirtualSecret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      virtualSecretName,
+				Namespace: virtualSecretNamespace,
+			},
+			Data: virtualSecretData,
+		},
 		MultiSecretReference: multiSecretReference,
 	}
 	return authContext, nil
 }
 
-func toContract(securityFields []*securityField) ([]*contract.SecretReference, map[string][]byte) {
+func toContract(securityFields []*securityField) ([]*contract.SecretReference, map[string][]byte, string, string) {
 	virtualSecretData := make(map[string][]byte)
 	bySecretName := make(map[string][]securityField)
 	for _, f := range securityFields {
@@ -79,6 +88,8 @@ func toContract(securityFields []*securityField) ([]*contract.SecretReference, m
 	}
 
 	refs := make([]*contract.SecretReference, 0, 6 /* max number of secrets */)
+	names := make([]string, 0, 6)
+	namespaces := make([]string, 0, 6)
 	for secretName, securityFields := range bySecretName {
 		keyFieldReferences := make([]*contract.KeyFieldReference, 0, len(securityFields))
 		for _, f := range securityFields {
@@ -97,8 +108,10 @@ func toContract(securityFields []*securityField) ([]*contract.SecretReference, m
 			},
 			KeyFieldReferences: keyFieldReferences,
 		})
+		names = append(names, any.secret.Name)
+		namespaces = append(namespaces, any.secret.Namespace)
 	}
-	return refs, virtualSecretData
+	return refs, virtualSecretData, stableConcat(names), stableConcat(namespaces)
 }
 
 type securityField struct {
@@ -159,4 +172,12 @@ func resolveSecret(lister corelisters.SecretLister, ns string, ref *corev1.Secre
 		return nil, nil, fmt.Errorf("missing secret key or empty secret value (%s/%s.%s)", ns, ref.Name, ref.Key)
 	}
 	return value, secret, nil
+}
+
+func stableConcat(elements []string) string {
+	sort.SliceStable(elements, func(i, j int) bool {
+		return elements[i] < elements[j]
+	})
+
+	return strings.Join(elements, "")
 }

--- a/control-plane/pkg/security/secrets_provider_net_spec_test.go
+++ b/control-plane/pkg/security/secrets_provider_net_spec_test.go
@@ -123,7 +123,11 @@ func TestResolveAuthContextFromNetSpec(t *testing.T) {
 					SaslMechanismKey: SaslScramSha512,
 					SaslUserKey:      "key",
 					SaslPasswordKey:  "key",
-				}},
+				}, ObjectMeta: metav1.ObjectMeta{
+					Name:      "cacertcertkeypasswordtypeuser",
+					Namespace: "nsnsnsnsnsns",
+				},
+				},
 				MultiSecretReference: &contract.MultiSecretReference{
 					Protocol: contract.Protocol_SASL_SSL,
 					References: []*contract.SecretReference{
@@ -249,7 +253,11 @@ func TestResolveAuthContextFromNetSpec(t *testing.T) {
 					SaslMechanismKey: SaslScramSha256,
 					SaslUserKey:      "key",
 					SaslPasswordKey:  "key",
-				}},
+				}, ObjectMeta: metav1.ObjectMeta{
+					Name:      "cacertcertkeypasswordtypeuser",
+					Namespace: "nsnsnsnsnsns",
+				},
+				},
 				MultiSecretReference: &contract.MultiSecretReference{
 					Protocol: contract.Protocol_SASL_SSL,
 					References: []*contract.SecretReference{
@@ -339,6 +347,9 @@ func TestResolveAuthContextFromNetSpec(t *testing.T) {
 					CaCertificateKey: "key",
 					UserCertificate:  "key",
 					UserKey:          "key",
+				}, ObjectMeta: metav1.ObjectMeta{
+					Name:      "cacertcertkey",
+					Namespace: "nsnsns",
 				}},
 				MultiSecretReference: &contract.MultiSecretReference{
 					Protocol: contract.Protocol_SSL,
@@ -400,6 +411,9 @@ func TestResolveAuthContextFromNetSpec(t *testing.T) {
 					ProtocolKey:     ProtocolSSL,
 					UserCertificate: "key",
 					UserKey:         "key",
+				}, ObjectMeta: metav1.ObjectMeta{
+					Name:      "certkey",
+					Namespace: "nsns",
 				}},
 				MultiSecretReference: &contract.MultiSecretReference{
 					Protocol: contract.Protocol_SSL,
@@ -466,6 +480,9 @@ func TestResolveAuthContextFromNetSpec(t *testing.T) {
 					SaslMechanismKey: SaslScramSha256,
 					SaslUserKey:      "key",
 					SaslPasswordKey:  "key",
+				}, ObjectMeta: metav1.ObjectMeta{
+					Name:      "passwordtypeuser",
+					Namespace: "nsnsns",
 				}},
 				MultiSecretReference: &contract.MultiSecretReference{
 					Protocol: contract.Protocol_SASL_PLAINTEXT,
@@ -538,6 +555,9 @@ func TestResolveAuthContextFromNetSpec(t *testing.T) {
 					SaslMechanismKey: SaslScramSha512,
 					SaslUserKey:      "key",
 					SaslPasswordKey:  "key",
+				}, ObjectMeta: metav1.ObjectMeta{
+					Name:      "passwordtypeuser",
+					Namespace: "nsnsns",
 				}},
 				MultiSecretReference: &contract.MultiSecretReference{
 					Protocol: contract.Protocol_SASL_PLAINTEXT,


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

In the clientpool code, we use the name and namespace of a secret along with the bootstrap servers to uniquely identify the connections being created. However, the virtual secrets created from the net spec did not have these fields set.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Create a name for the virtual secret by concatenating all secret names
- Create a namespace for the virtual secret by concatentatinf all secret namespaces