### PR TITLE
fix: do not double increment clientpool wg

### DIFF
--- a/control-plane/pkg/kafka/clientpool/clientpool.go
+++ b/control-plane/pkg/kafka/clientpool/clientpool.go
@@ -117,7 +117,7 @@ func (cp *ClientPool) getClient(ctx context.Context, bootstrapServers []string, 
 
 			logger.Debug("Closing client")
 
-			if err := value.client.Close(); !errors.Is(err, sarama.ErrClosedClient) {
+			if err := value.client.Close(); err != nil && !errors.Is(err, sarama.ErrClosedClient) {
 				logger.Errorw("Failed to close client", zap.Error(err))
 			}
 		}()

--- a/control-plane/pkg/kafka/clientpool/clientpool.go
+++ b/control-plane/pkg/kafka/clientpool/clientpool.go
@@ -127,12 +127,11 @@ func (cp *ClientPool) getClient(ctx context.Context, bootstrapServers []string, 
 }
 
 func (cp *ClientPool) GetClusterAdmin(ctx context.Context, bootstrapServers []string, secret *corev1.Secret) (sarama.ClusterAdmin, error) {
-	c, err := cp.getClient(ctx, bootstrapServers, secret)
+	c, err := cp.GetClient(ctx, bootstrapServers, secret)
 	if err != nil {
 		return nil, err
 	}
 
-	c.incrementCallers()
 	ca, err := clusterAdminFromClient(c, cp.newClusterAdminFromClient)
 	if err != nil {
 		c.Close()

--- a/control-plane/pkg/kafka/clientpool/clusteradmin.go
+++ b/control-plane/pkg/kafka/clientpool/clusteradmin.go
@@ -46,8 +46,6 @@ func clusterAdminFromClient(saramaClient sarama.Client, makeClusterAdmin kafka.N
 		return nil, err
 	}
 
-	c.incrementCallers()
-
 	return &clusterAdmin{
 		client:       c,
 		clusterAdmin: ca,

--- a/control-plane/pkg/kafka/clientpool/clusteradmin.go
+++ b/control-plane/pkg/kafka/clientpool/clusteradmin.go
@@ -289,5 +289,5 @@ func (a *clusterAdmin) RemoveMemberFromConsumerGroup(groupId string, groupInstan
 }
 
 func (a *clusterAdmin) Close() error {
-	return a.client.Close()
+	return a.clusterAdmin.Close()
 }

--- a/control-plane/pkg/kafka/testing/admin_mock.go
+++ b/control-plane/pkg/kafka/testing/admin_mock.go
@@ -58,6 +58,8 @@ type MockKafkaClusterAdmin struct {
 
 	ErrorOnDeleteConsumerGroup error
 
+	OnClose func()
+
 	T *testing.T
 }
 
@@ -301,5 +303,8 @@ func (m *MockKafkaClusterAdmin) RemoveMemberFromConsumerGroup(groupId string, gr
 
 func (m *MockKafkaClusterAdmin) Close() error {
 	m.ExpectedClose = true
+	if m.OnClose != nil {
+		m.OnClose()
+	}
 	return m.ExpectedCloseError
 }

--- a/control-plane/pkg/kafka/testing/client_mock.go
+++ b/control-plane/pkg/kafka/testing/client_mock.go
@@ -28,6 +28,7 @@ type MockKafkaClient struct {
 	ShouldFailRefreshMetadata bool
 	ShouldFailRefreshBrokers  bool
 	ShouldFailBrokenPipe      bool
+	OnClose                   func()
 }
 
 var _ sarama.Client = &MockKafkaClient{}
@@ -195,6 +196,9 @@ func (m MockKafkaClient) LeastLoadedBroker() *sarama.Broker {
 
 func (m *MockKafkaClient) Close() error {
 	m.IsClosed = true
+	if m.OnClose != nil {
+		m.OnClose()
+	}
 	return m.CloseError
 }
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #3999

Currently, when creating a cluster admin from a client, we increment the client wait group once, but this causes the group to be incremented twice as it was already incremented once when retrieving the client from the clientpool. This leads to the client not being able to be closed.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Increment the wait group once for client, once for clusteradmin rather than twice in the latter case.
