### PR TITLE
fix: correct clusterrole permissions for post install job

### DIFF
--- a/control-plane/config/post-install/200-controller-cluster-role.yaml
+++ b/control-plane/config/post-install/200-controller-cluster-role.yaml
@@ -28,6 +28,7 @@ rules:
       - "deployments"
     verbs:
       - "delete"
+      - "get"
       - "list"
   # we need to get statefulsets
   - apiGroups:


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #4000 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add the missing rbac verb for the post install to work properly