### PR TITLE
fix: prober cache returns StatusUnknown by default

### DIFF
--- a/control-plane/pkg/prober/async_prober.go
+++ b/control-plane/pkg/prober/async_prober.go
@@ -56,7 +56,7 @@ func NewAsync(ctx context.Context, client httpClient, port string, IPsLister IPs
 		client:    client,
 		enqueue:   enqueue,
 		logger:    logger,
-		cache:     NewLocalExpiringCache[string, Status, types.NamespacedName](ctx, cacheExpiryTime),
+		cache:     NewLocalExpiringCacheWithDefault[string, Status, types.NamespacedName](ctx, cacheExpiryTime, StatusUnknown),
 		IPsLister: IPsLister,
 		port:      port,
 	}

--- a/control-plane/pkg/prober/cache_test.go
+++ b/control-plane/pkg/prober/cache_test.go
@@ -27,6 +27,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+func TestInMemoryLocalCacheDefaults(t *testing.T) {
+	d := time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), d*4)
+	defer cancel()
+	c := NewLocalExpiringCacheWithDefault[string, Status, int](ctx, d, StatusUnknown)
+
+	v, ok := c.Get("unknown")
+	require.False(t, ok)
+	require.Equal(t, v, StatusUnknown)
+}
+
 func TestInMemoryLocalCache(t *testing.T) {
 	d := time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), d*4)


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #4012

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add a way to specify the default return value of a cache
- Specify the default return value for the prober cache
