### PR TITLE
TestClientCloses consistently passes

### DIFF
--- a/control-plane/pkg/kafka/clientpool/clientpool_test.go
+++ b/control-plane/pkg/kafka/clientpool/clientpool_test.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	kafkatesting "knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/testing"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 )
@@ -151,11 +152,9 @@ func TestClientCloses(t *testing.T) {
 	clusterAdmin.Close()
 	client1.Close()
 
-	time.Sleep(time.Second * 2)
-
 	// the client should have been closed successfully now
-	assert.True(t, clientClosed.Load())
-	assert.True(t, adminClosed.Load())
+	assert.Eventuallyf(t, func() bool { return clientClosed.Load() }, 10*time.Second, time.Second, "client not closed")
+	assert.Eventuallyf(t, func() bool { return adminClosed.Load() }, 10*time.Second, time.Second, "admin not closed")
 
 	cancel()
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes https://github.com/knative-extensions/eventing-kafka-broker/issues/4023

Tested with
```
$ go test -run TestClientCloses -count=42 -parallel=42 ./control-plane/pkg/kafka/clientpool/
ok      knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/clientpool    98.083s
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Do not use sleep and instead use eventually with a longer timeout

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
