### PR TITLE
feat: use namespaced indexers for eventtypes in receiver

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreator.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/eventtype/EventTypeCreator.java
@@ -18,6 +18,7 @@ package dev.knative.eventing.kafka.broker.core.eventtype;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import io.cloudevents.CloudEvent;
+import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.vertx.core.Future;
 
 /**
@@ -25,5 +26,6 @@ import io.vertx.core.Future;
  */
 @FunctionalInterface
 public interface EventTypeCreator {
-    Future<EventType> create(CloudEvent event, DataPlaneContract.Reference reference);
+    Future<EventType> create(
+            CloudEvent event, Lister<EventType> eventTypeLister, DataPlaneContract.Reference reference);
 }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/IngressProducer.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/IngressProducer.java
@@ -17,7 +17,9 @@ package dev.knative.eventing.kafka.broker.receiver;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.ReactiveKafkaProducer;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventType;
 import io.cloudevents.CloudEvent;
+import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.vertx.core.Future;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -57,6 +59,11 @@ public interface IngressProducer {
     default boolean isEventTypeAutocreateEnabled() {
         return false;
     }
+
+    /**
+     * @return the Lister for eventtypes in the correct namespace for this producer
+     */
+    Lister<EventType> getEventTypeLister();
 
     /**
      * @return the OIDC audience for the ingress.

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/IngressRequestHandlerImpl.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/IngressRequestHandlerImpl.java
@@ -169,7 +169,10 @@ public class IngressRequestHandlerImpl implements IngressRequestHandler {
                             .compose((recordMetadata) -> {
                                 if (producer.isEventTypeAutocreateEnabled()) {
                                     return this.eventTypeCreator
-                                            .create(record.value(), producer.getReference())
+                                            .create(
+                                                    record.value(),
+                                                    producer.getEventTypeLister(),
+                                                    producer.getReference())
                                             .compose(
                                                     et -> {
                                                         logger.debug("successfully created eventtype {}", et);

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -21,6 +21,7 @@ import dev.knative.eventing.kafka.broker.core.ReactiveProducerFactory;
 import dev.knative.eventing.kafka.broker.core.eventbus.ContractMessageCodec;
 import dev.knative.eventing.kafka.broker.core.eventbus.ContractPublisher;
 import dev.knative.eventing.kafka.broker.core.eventtype.EventType;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeListerFactory;
 import dev.knative.eventing.kafka.broker.core.features.FeaturesConfig;
 import dev.knative.eventing.kafka.broker.core.file.FileWatcher;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
@@ -32,8 +33,6 @@ import dev.knative.eventing.kafka.broker.core.utils.Shutdown;
 import io.cloudevents.kafka.CloudEventSerializer;
 import io.cloudevents.kafka.PartitionKeyExtensionInterceptor;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
-import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Verticle;
@@ -44,12 +43,9 @@ import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.tracing.opentelemetry.OpenTelemetryOptions;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -131,21 +127,8 @@ public class Main {
         }
 
         final var kubernetesClient = new KubernetesClientBuilder().build();
-        final SharedInformerFactory sharedInformerFactory = kubernetesClient.informers();
         final var eventTypeClient = kubernetesClient.resources(EventType.class);
-        SharedIndexInformer<EventType> eventTypeInformer = null;
-        try {
-            eventTypeInformer = sharedInformerFactory.sharedIndexInformerFor(
-                    EventType.class, 30 * 1000L); // refresh every 30 seconds
-            sharedInformerFactory.startAllRegisteredInformers().get(5, TimeUnit.SECONDS);
-        } catch (InterruptedException | TimeoutException interruptedException) {
-            logger.warn(
-                    "failed to start informers, this will lead to unnecessary POST requests for eventtype autocreate");
-        } catch (Exception informerException) {
-            logger.warn(
-                    "the data-plane does not have sufficient permissions to list/watch eventtypes. This will lead to unnecessary CREATE requests if eventtype-auto-create is enabled",
-                    informerException);
-        }
+        final var eventTypeListerFactory = new EventTypeListerFactory(eventTypeClient);
 
         // Configure the verticle to deploy and the deployment options
 
@@ -158,9 +141,9 @@ public class Main {
                     httpsServerOptions,
                     kafkaProducerFactory,
                     eventTypeClient,
-                    eventTypeInformer,
                     vertx,
-                    oidcDiscoveryConfig);
+                    oidcDiscoveryConfig,
+                    eventTypeListerFactory);
             DeploymentOptions deploymentOptions =
                     new DeploymentOptions().setInstances(Runtime.getRuntime().availableProcessors());
             // Deploy the receiver verticles
@@ -176,15 +159,9 @@ public class Main {
             FileWatcher fileWatcher = new FileWatcher(file, () -> publisher.updateContract(file));
             fileWatcher.start();
 
-            var closeables =
-                    new ArrayList<>(Arrays.asList(publisher, fileWatcher, openTelemetry.getSdkTracerProvider()));
-
-            if (eventTypeInformer != null) {
-                closeables.add(eventTypeInformer);
-            }
-
             // Register shutdown hook for graceful shutdown.
-            Shutdown.registerHook(vertx, closeables.toArray(new AutoCloseable[0]));
+            Shutdown.registerHook(
+                    vertx, publisher, fileWatcher, openTelemetry.getSdkTracerProvider(), eventTypeListerFactory);
 
         } catch (final Exception ex) {
             logger.error("Failed to startup the receiver", ex);

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -30,7 +30,6 @@ import io.cloudevents.CloudEvent;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
@@ -50,6 +49,7 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
 
     private final IngressRequestHandler ingressRequestHandler;
     private final OIDCDiscoveryConfig oidcDiscoveryConfig;
+    private final EventTypeListerFactory eventTypeListerFactory;
 
     private ReactiveProducerFactory<String, CloudEvent> kafkaProducerFactory;
 
@@ -61,9 +61,9 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
             final HttpServerOptions httpsServerOptions,
             final ReactiveProducerFactory<String, CloudEvent> kafkaProducerFactory,
             final MixedOperation<EventType, KubernetesResourceList<EventType>, Resource<EventType>> eventTypeClient,
-            final SharedIndexInformer<EventType> eventTypeInformer,
             Vertx vertx,
-            final OIDCDiscoveryConfig oidcDiscoveryConfig)
+            final OIDCDiscoveryConfig oidcDiscoveryConfig,
+            final EventTypeListerFactory eventTypeListerFactory)
             throws NoSuchAlgorithmException {
         {
             this.env = env;
@@ -73,9 +73,10 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
             this.ingressRequestHandler = new IngressRequestHandlerImpl(
                     StrictRequestToRecordMapper.getInstance(),
                     metricsRegistry,
-                    new EventTypeCreatorImpl(eventTypeClient, new EventTypeListerFactory(eventTypeInformer), vertx));
+                    new EventTypeCreatorImpl(eventTypeClient, vertx));
             this.kafkaProducerFactory = kafkaProducerFactory;
             this.oidcDiscoveryConfig = oidcDiscoveryConfig;
+            this.eventTypeListerFactory = eventTypeListerFactory;
         }
     }
 
@@ -88,7 +89,8 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
                 v -> new IngressProducerReconcilableStore(
                         AuthProvider.kubernetes(v),
                         producerConfigs,
-                        properties -> kafkaProducerFactory.create(v, properties)),
+                        properties -> kafkaProducerFactory.create(v, properties),
+                        eventTypeListerFactory),
                 this.ingressRequestHandler,
                 secretVolumePath,
                 oidcDiscoveryConfig);

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTest.java
@@ -34,6 +34,7 @@ import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.ReactiveKafkaProducer;
 import dev.knative.eventing.kafka.broker.core.eventbus.ContractMessageCodec;
 import dev.knative.eventing.kafka.broker.core.eventbus.ContractPublisher;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeListerFactory;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler;
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
@@ -125,7 +126,8 @@ public class ReceiverVerticleTest {
                 new MockProducer<>(true, new StringSerializer(), new CloudEventSerializerMock());
         ReactiveKafkaProducer<String, CloudEvent> producer = new MockReactiveKafkaProducer<>(mockProducer);
 
-        store = new IngressProducerReconcilableStore(AuthProvider.noAuth(), new Properties(), properties -> producer);
+        store = new IngressProducerReconcilableStore(
+                AuthProvider.noAuth(), new Properties(), properties -> producer, mock(EventTypeListerFactory.class));
 
         registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
@@ -149,7 +151,7 @@ public class ReceiverVerticleTest {
                 httpsServerOptions,
                 v -> store,
                 new IngressRequestHandlerImpl(
-                        StrictRequestToRecordMapper.getInstance(), registry, ((event, reference) -> null)),
+                        StrictRequestToRecordMapper.getInstance(), registry, ((event, lister, reference) -> null)),
                 SECRET_VOLUME_PATH,
                 null);
         vertx.deployVerticle(verticle, testContext.succeeding(ar -> testContext.completeNow()));

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTracingTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/ReceiverVerticleTracingTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.ReactiveKafkaProducer;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeListerFactory;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
 import dev.knative.eventing.kafka.broker.core.testing.CloudEventSerializerMock;
@@ -107,7 +108,10 @@ public abstract class ReceiverVerticleTracingTest {
         this.mockProducer = new MockProducer<>(true, new StringSerializer(), new CloudEventSerializerMock());
 
         this.store = new IngressProducerReconcilableStore(
-                AuthProvider.noAuth(), new Properties(), properties -> createKafkaProducer(vertx, mockProducer));
+                AuthProvider.noAuth(),
+                new Properties(),
+                properties -> createKafkaProducer(vertx, mockProducer),
+                mock(EventTypeListerFactory.class));
 
         final var env = mock(ReceiverEnv.class);
         when(env.getLivenessProbePath()).thenReturn("/healthz");
@@ -131,7 +135,9 @@ public abstract class ReceiverVerticleTracingTest {
                 httpsServerOptions,
                 v -> store,
                 new IngressRequestHandlerImpl(
-                        StrictRequestToRecordMapper.getInstance(), Metrics.getRegistry(), ((event, reference) -> null)),
+                        StrictRequestToRecordMapper.getInstance(),
+                        Metrics.getRegistry(),
+                        ((event, lister, reference) -> null)),
                 SECRET_VOLUME_PATH,
                 null);
 

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/AuthenticationHandlerTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/AuthenticationHandlerTest.java
@@ -21,9 +21,11 @@ import static org.mockito.Mockito.when;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.ReactiveKafkaProducer;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventType;
 import dev.knative.eventing.kafka.broker.core.oidc.TokenVerifier;
 import dev.knative.eventing.kafka.broker.receiver.IngressProducer;
 import io.cloudevents.CloudEvent;
+import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -68,6 +70,11 @@ public class AuthenticationHandlerTest {
                     @Override
                     public DataPlaneContract.Reference getReference() {
                         return null;
+                    }
+
+                    @Override
+                    public Lister<EventType> getEventTypeLister() {
+                        return mock(Lister.class);
                     }
 
                     @Override
@@ -116,6 +123,11 @@ public class AuthenticationHandlerTest {
                     @Override
                     public DataPlaneContract.Reference getReference() {
                         return null;
+                    }
+
+                    @Override
+                    public Lister<EventType> getEventTypeLister() {
+                        return mock(Lister.class);
                     }
 
                     @Override

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/IngressRequestHandlerImplTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/impl/handler/IngressRequestHandlerImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import dev.knative.eventing.kafka.broker.core.ReactiveKafkaProducer;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventType;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.testing.CoreObjects;
 import dev.knative.eventing.kafka.broker.receiver.IngressProducer;
@@ -30,6 +31,7 @@ import dev.knative.eventing.kafka.broker.receiver.MockReactiveKafkaProducer;
 import dev.knative.eventing.kafka.broker.receiver.RequestContext;
 import dev.knative.eventing.kafka.broker.receiver.RequestToRecordMapper;
 import io.cloudevents.CloudEvent;
+import io.fabric8.kubernetes.client.informers.cache.Lister;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.core.Future;
@@ -81,7 +83,8 @@ public class IngressRequestHandlerImplTest {
         final HttpServerRequest request = mockHttpServerRequest("/hello");
         final var response = mockResponse(request, statusCode);
 
-        final var handler = new IngressRequestHandlerImpl(mapper, Metrics.getRegistry(), ((event, reference) -> null));
+        final var handler =
+                new IngressRequestHandlerImpl(mapper, Metrics.getRegistry(), ((event, lister, reference) -> null));
 
         handler.handle(new RequestContext(request), new IngressProducer() {
             @Override
@@ -97,6 +100,11 @@ public class IngressRequestHandlerImplTest {
             @Override
             public DataPlaneContract.Reference getReference() {
                 return DataPlaneContract.Reference.newBuilder().build();
+            }
+
+            @Override
+            public Lister<EventType> getEventTypeLister() {
+                return mock(Lister.class);
             }
 
             @Override
@@ -117,7 +125,8 @@ public class IngressRequestHandlerImplTest {
         final HttpServerRequest request = mockHttpServerRequest("/hello");
         final var response = mockResponse(request, IngressRequestHandlerImpl.MAPPER_FAILED);
 
-        final var handler = new IngressRequestHandlerImpl(mapper, Metrics.getRegistry(), ((event, reference) -> null));
+        final var handler =
+                new IngressRequestHandlerImpl(mapper, Metrics.getRegistry(), ((event, lister, reference) -> null));
 
         handler.handle(new RequestContext(request), new IngressProducer() {
             @Override
@@ -133,6 +142,11 @@ public class IngressRequestHandlerImplTest {
             @Override
             public DataPlaneContract.Reference getReference() {
                 return DataPlaneContract.Reference.newBuilder().build();
+            }
+
+            @Override
+            public Lister<EventType> getEventTypeLister() {
+                return mock(Lister.class);
             }
 
             @Override

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactoryTest.java
@@ -20,11 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import dev.knative.eventing.kafka.broker.core.eventtype.EventType;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeListerFactory;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.oidc.OIDCDiscoveryConfig;
 import dev.knative.eventing.kafka.broker.receiver.MockReactiveProducerFactory;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerOptions;
@@ -54,9 +54,9 @@ public class ReceiverVerticleFactoryTest {
                 mock(HttpServerOptions.class),
                 mock(MockReactiveProducerFactory.class),
                 mockClient.resources(EventType.class),
-                mock(SharedIndexInformer.class),
                 vertx,
-                mock(OIDCDiscoveryConfig.class));
+                mock(OIDCDiscoveryConfig.class),
+                mock(EventTypeListerFactory.class));
 
         assertThat(supplier.get()).isNotSameAs(supplier.get());
     }

--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/AbstractDataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/AbstractDataPlaneTest.java
@@ -31,6 +31,7 @@ import dev.knative.eventing.kafka.broker.core.ReactiveConsumerFactory;
 import dev.knative.eventing.kafka.broker.core.ReactiveProducerFactory;
 import dev.knative.eventing.kafka.broker.core.eventbus.ContractMessageCodec;
 import dev.knative.eventing.kafka.broker.core.eventbus.ContractPublisher;
+import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeListerFactory;
 import dev.knative.eventing.kafka.broker.core.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.reconciler.impl.ResourcesReconcilerMessageHandler;
 import dev.knative.eventing.kafka.broker.core.security.AuthProvider;
@@ -389,12 +390,14 @@ public abstract class AbstractDataPlaneTest {
                 httpServerOptions,
                 httpsServerOptions,
                 v -> new IngressProducerReconcilableStore(
-                        AuthProvider.noAuth(), producerConfigs(), properties -> getReactiveProducerFactory()
-                                .create(v, properties)),
+                        AuthProvider.noAuth(),
+                        producerConfigs(),
+                        properties -> getReactiveProducerFactory().create(v, properties),
+                        mock(EventTypeListerFactory.class)),
                 new IngressRequestHandlerImpl(
                         StrictRequestToRecordMapper.getInstance(),
                         Metrics.getRegistry(),
-                        (((event, reference) -> null))),
+                        (((event, lister, reference) -> null))),
                 SECRET_VOLUME_PATH,
                 null);
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes continued bugs with the EventType lister/indexer failing to watch EventTypes at the cluster scope.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use namespaced indexers as well as listers
- Create indexer/lister in the IngressProducerReconcilableStore instead of on the request path to make autocreate faster
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fixed bug where EventTypes are watched at the cluster scope
```

