### PR TITLE
Update KafkaSink and KafkaChannel to have AppliedEventPoliciesStatus

### DIFF
--- a/control-plane/config/eventing-kafka-broker/100-channel/100-kafka-channel.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-channel/100-kafka-channel.yaml
@@ -213,6 +213,18 @@ spec:
                   description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                policies:
+                  description: List of applied EventPolicies
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: The API version of the applied EventPolicy. This indicates, which version of EventPolicy is supported by the resource.
+                        type: string
+                      name:
+                        description: The name of the applied EventPolicy
+                        type: string
                 conditions:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array

--- a/control-plane/config/eventing-kafka-broker/100-sink/100-kafka-sink.yaml
+++ b/control-plane/config/eventing-kafka-broker/100-sink/100-kafka-sink.yaml
@@ -138,6 +138,18 @@ spec:
                       just the reconciler conveying richer information outwards.'
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                policies:
+                  description: List of applied EventPolicies
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: The API version of the applied EventPolicy. This indicates, which version of EventPolicy is supported by the resource.
+                        type: string
+                      name:
+                        description: The name of the applied EventPolicy
+                        type: string
                 conditions:
                   description: 'Conditions the latest available observations of a resource''s
                       current state.'

--- a/control-plane/pkg/apis/eventing/v1alpha1/kafka_sink_types.go
+++ b/control-plane/pkg/apis/eventing/v1alpha1/kafka_sink_types.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
@@ -127,6 +128,10 @@ type KafkaSinkStatus struct {
 
 	// Kafka Sink is Addressable.
 	duckv1.AddressStatus
+
+	// AppliedEventPoliciesStatus contains the list of EventPolicies which apply to this KafkaSink
+	// +optional
+	eventingduckv1.AppliedEventPoliciesStatus `json:",inline"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/control-plane/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
+++ b/control-plane/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
@@ -153,6 +153,7 @@ func (in *KafkaSinkStatus) DeepCopyInto(out *KafkaSinkStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
 	in.AddressStatus.DeepCopyInto(&out.AddressStatus)
+	in.AppliedEventPoliciesStatus.DeepCopyInto(&out.AppliedEventPoliciesStatus)
 	return
 }
 


### PR DESCRIPTION
Fixes #4069 

## Proposed Changes

- Adding the AppliedEventPoliciesStatus to the KafkaSink type and CRD
- Adding the AppliedEventPoliciesStatus to the KafkaChannel (in the go type it is already available through the ChannelableStatus, but not in the YAML CRD)