### PR TITLE
Enable AuthZ e2e tests

### DIFF
--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -332,7 +332,6 @@ func TestBrokerSupportsAuthZ(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
-		environment.WithPollTimings(4*time.Second, 12*time.Minute),
 		environment.Managed(t),
 		eventshub.WithTLS(t),
 	)

--- a/test/e2e_new_channel/kafka_channel_test.go
+++ b/test/e2e_new_channel/kafka_channel_test.go
@@ -37,6 +37,9 @@ import (
 	"knative.dev/eventing-kafka-broker/test/rekt/features"
 	"knative.dev/eventing-kafka-broker/test/rekt/features/kafkachannel"
 	kafkachannelresource "knative.dev/eventing-kafka-broker/test/rekt/resources/kafkachannel"
+	channelresource "knative.dev/eventing/test/rekt/resources/channel"
+
+	"knative.dev/eventing/test/rekt/features/authz"
 )
 
 const (
@@ -109,6 +112,42 @@ func TestKafkaChannelOIDC(t *testing.T) {
 	env.Prerequisite(ctx, t, channel.ImplGoesReady(name))
 
 	env.TestSet(ctx, t, oidc.AddressableOIDCConformance(kafkachannelresource.GVR(), "KafkaChannel", name, env.Namespace()))
+}
+
+func TestChannelWithBackingKafkaChannelSupportsAuthZ(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	name := feature.MakeRandomK8sName("channel")
+	env.Prerequisite(ctx, t, channel.GoesReady(name))
+
+	env.TestSet(ctx, t, authz.AddressableAuthZConformance(channelresource.GVR(), "Channel", name))
+}
+
+func TestKafkaChannelSupportsAuthZ(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	name := feature.MakeRandomK8sName("kafkachannel")
+	env.Prerequisite(ctx, t, channel.ImplGoesReady(name))
+
+	env.TestSet(ctx, t, authz.AddressableAuthZConformance(kafkachannelresource.GVR(), "KafkaChannel", name))
 }
 
 func TestKafkaChannelKedaScaling(t *testing.T) {


### PR DESCRIPTION
Fixes #4068

## Proposed Changes

- :gift: Enable AuthZ e2e tests for KafkaSink
- :gift: Enable AuthZ e2e tests for KafkaChannel

Hint: AuthZ test for Broker were already enabled in https://github.com/knative-extensions/eventing-kafka-broker/pull/4086/commits/99f3b33e15ee5608726ed22aec020856c6112f2f

requires:
* #4038 
* #4039
