### PR TITLE
Set globalResync function for KafkaChannel reconciler

### DIFF
--- a/control-plane/pkg/reconciler/channel/controller.go
+++ b/control-plane/pkg/reconciler/channel/controller.go
@@ -47,10 +47,11 @@ import (
 	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 
+	"knative.dev/eventing/pkg/apis/feature"
+
 	consumergroupclient "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/client"
 	consumergroupinformer "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/informers/eventing/v1alpha1/consumergroup"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
-	"knative.dev/eventing/pkg/apis/feature"
 
 	"knative.dev/pkg/controller"
 
@@ -122,6 +123,10 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *conf
 				ConfigStore: featureStore,
 			}
 		})
+
+	globalResync = func(obj interface{}) {
+		impl.GlobalResync(channelInformer.Informer())
+	}
 
 	kafkaConfigStore := apisconfig.NewStore(ctx, func(name string, value *apisconfig.KafkaFeatureFlags) {
 		reconciler.KafkaFeatureFlags.Reset(value)


### PR DESCRIPTION
Fix for panic
```
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1f9a4c0, 0x3a9fbb0})
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000ec6380?})
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x1f9a4c0?, 0x3a9fbb0?})
	/usr/lib/golang/src/runtime/panic.go:770 +0x132
knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/channel.NewController.HandleAll.PassNew.func12({0x4?, 0x23?}, {0x22c8200?, 0xc0033a2000?})
	/go/src/github.com/openshift/origin/vendor/knative.dev/pkg/controller/controller.go:76 +0x1c
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
	/go/src/github.com/openshift/origin/vendor/k8s.io/client-go/tools/cache/controller.go:246
k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnUpdate({0xc000669470?, {0x269eb70?, 0xc0005cd248?}}, {0x22c8200, 0xc0059745a0}, {0x22c8200, 0xc0033a2000})
	/go/src/github.com/openshift/origin/vendor/k8s.io/client-go/tools/cache/controller.go:311 +0xdc
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/go/src/github.com/openshift/origin/vendor/k8s.io/client-go/tools/cache/shared_informer.go:970 +0xea
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0044e3f70, {0x268b2c0, 0xc000e85500}, 0x1, 0xc000e8d5c0)
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000ec0f70, 0x3b9aca00, 0x0, 0x1, 0xc000e8d5c0)
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
k8s.io/client-go/tools/cache.(*processorListener).run(0xc0006485a0)
	/go/src/github.com/openshift/origin/vendor/k8s.io/client-go/tools/cache/shared_informer.go:966 +0x69
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x52
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 326
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1cdbc1c]
```

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->