### PR TITLE
Set the `name` value for metrics tags to the correct top-level resource

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -108,6 +109,10 @@ type ConsumerGroupSpec struct {
 	// OIDCServiceAccountName is the name of service account used for this components
 	// OIDC authentication.
 	OIDCServiceAccountName *string `json:"oidcServiceAccountName,omitempty"`
+
+	// TopLevelResourceRef is a reference to a top level resource.
+	// For a ConsumerGroup associated with a Trigger, a Broker reference will be set.
+	TopLevelResourceRef *corev1.ObjectReference `json:"topLevelResourceRef,omitempty"`
 }
 
 type ConsumerGroupStatus struct {
@@ -208,6 +213,13 @@ func (cg *ConsumerGroup) GetUserFacingResourceRef() *metav1.OwnerReference {
 		}
 	}
 	return nil
+}
+
+// GetTopLevelUserFacingResourceRef gets the top level resource reference to the user-facing resources
+// that are backed by this ConsumerGroup using the OwnerReference list.
+// For example, for a Trigger, it will return a Broker reference.
+func (cg *ConsumerGroup) GetTopLevelUserFacingResourceRef() *corev1.ObjectReference {
+	return cg.Spec.TopLevelResourceRef
 }
 
 func (cg *ConsumerGroup) IsNotScheduled() bool {

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -42,12 +42,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/clientpool"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/channel/resources"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/system"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/clientpool"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/channel/resources"
 
 	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	messaging "knative.dev/eventing/pkg/apis/messaging/v1"
@@ -602,6 +603,13 @@ func (r *Reconciler) reconcileConsumerGroup(ctx context.Context, channel *messag
 			},
 		},
 		Spec: internalscg.ConsumerGroupSpec{
+			TopLevelResourceRef: &corev1.ObjectReference{
+				APIVersion: messagingv1beta1.SchemeGroupVersion.String(),
+				Kind:       "KafkaChannel",
+				Name:       channel.Name,
+				Namespace:  channel.Namespace,
+				UID:        channel.UID,
+			},
 			Template: internalscg.ConsumerTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/control-plane/pkg/reconciler/channel/channel_test.go
+++ b/control-plane/pkg/reconciler/channel/channel_test.go
@@ -62,11 +62,12 @@ import (
 	messagingv1beta1kafkachannelreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel"
 
 	"github.com/rickb777/date/period"
+	eventingrekttesting "knative.dev/eventing/pkg/reconciler/testing/v1"
+	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
+
 	internalscg "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1"
 	kafkainternals "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1"
 	fakeconsumergroupinformer "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/client/fake"
-	eventingrekttesting "knative.dev/eventing/pkg/reconciler/testing/v1"
-	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
 )
 
 const (
@@ -478,6 +479,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerSubscriber(NewConsumerSpecSubscriber(Subscription1URI)),
 						ConsumerReply(ConsumerUrlReply(apis.HTTP(Subscription1ReplyURI))),
 					)),
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -551,6 +553,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerSubscriber(NewConsumerSpecSubscriber(Subscription1URI)),
 						ConsumerReply(ConsumerUrlReply(apis.HTTP(Subscription1ReplyURI))),
 					)),
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -625,6 +628,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerSubscriber(NewConsumerSpecSubscriber(Subscription1URI)),
 						ConsumerReply(ConsumerUrlReply(apis.HTTP(Subscription1ReplyURI))),
 					)),
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -684,6 +688,7 @@ func TestReconcileKind(t *testing.T) {
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(NewChannel())),
 					WithConsumerGroupMetaLabels(OwnerAsChannelLabel),
 					ConsumerGroupReady,
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -725,6 +730,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerReply(ConsumerUrlReply(apis.HTTP(Subscription1ReplyURI))),
 						)),
 						ConsumerGroupReady,
+						withChannelTopLevelResourceRef(),
 					),
 				},
 			},
@@ -779,6 +785,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					ConsumerGroupReplicas(1),
 					WithConsumerGroupFailed("failed to reconcile consumer group,", "internal error"),
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -858,6 +865,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerSubscriber(NewConsumerSpecSubscriber(Subscription1URI)),
 						ConsumerReply(ConsumerUrlReply(apis.HTTP(Subscription1ReplyURI))),
 					)),
+					withChannelTopLevelResourceRef(),
 				),
 				NewConsumerGroup(
 					WithConsumerGroupName(Subscription2UUID),
@@ -875,6 +883,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerSubscriber(NewConsumerSpecSubscriber(Subscription2URI)),
 						ConsumerReply(ConsumerNoReply()),
 					)),
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -946,6 +955,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerDelivery(NewConsumerSpecDelivery(kafkasource.Ordered)),
 						ConsumerSubscriber(NewConsumerSpecSubscriber(Subscription2URI)),
 					)),
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -967,6 +977,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerSubscriber(NewConsumerSpecSubscriber(Subscription1URI)),
 						ConsumerReply(ConsumerUrlReply(apis.HTTP(Subscription1ReplyURI))),
 					)),
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -1218,6 +1229,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					ConsumerGroupReplicas(1),
 					ConsumerGroupReady,
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -1324,6 +1336,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					ConsumerGroupReplicas(1),
 					ConsumerGroupReady,
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -1429,6 +1442,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					ConsumerGroupReplicas(1),
 					ConsumerGroupReady,
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -1528,6 +1542,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerSubscriber(NewConsumerSpecSubscriber(Subscription1URI)),
 						ConsumerReply(ConsumerUrlReply(apis.HTTP(Subscription1ReplyURI))),
 					)),
+					withChannelTopLevelResourceRef(),
 				),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{
@@ -2429,4 +2444,14 @@ func httpsURL(name string, namespace string) *apis.URL {
 		Host:   network.GetServiceHostname(DefaultEnv.IngressName, DefaultEnv.SystemNamespace),
 		Path:   fmt.Sprintf("/%s/%s", namespace, name),
 	}
+}
+
+func withChannelTopLevelResourceRef() ConsumerGroupOption {
+	return WithTopLevelResourceRef(&corev1.ObjectReference{
+		APIVersion: messagingv1beta.SchemeGroupVersion.String(),
+		Kind:       "KafkaChannel",
+		Namespace:  ChannelNamespace,
+		Name:       ChannelName,
+		UID:        ChannelUUID,
+	})
 }

--- a/control-plane/pkg/reconciler/testing/objects_consumergroup.go
+++ b/control-plane/pkg/reconciler/testing/objects_consumergroup.go
@@ -248,3 +248,9 @@ func WithConfigmapOwnerRef(ownerref *metav1.OwnerReference) reconcilertesting.Co
 		cg.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*ownerref}
 	}
 }
+
+func WithTopLevelResourceRef(ref *corev1.ObjectReference) ConsumerGroupOption {
+	return func(cg *kafkainternals.ConsumerGroup) {
+		cg.Spec.TopLevelResourceRef = ref
+	}
+}

--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
@@ -209,6 +209,13 @@ func (r *Reconciler) reconcileConsumerGroup(ctx context.Context, broker *eventin
 			},
 		},
 		Spec: internalscg.ConsumerGroupSpec{
+			TopLevelResourceRef: &corev1.ObjectReference{
+				APIVersion: eventing.SchemeGroupVersion.String(),
+				Kind:       "Broker",
+				Name:       broker.Name,
+				Namespace:  broker.Namespace,
+				UID:        broker.UID,
+			},
 			Template: internalscg.ConsumerTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2_test.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2_test.go
@@ -126,6 +126,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerFilters(NewConsumerSpecFilters()),
 						ConsumerReply(ConsumerTopicReply()),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			WantEvents: []string{
@@ -187,6 +188,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerFilters(NewConsumerSpecFilters()),
 						ConsumerReply(ConsumerTopicReply()),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
@@ -241,6 +243,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerFilters(NewConsumerSpecFilters()),
 						ConsumerReply(ConsumerTopicReply()),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
@@ -296,6 +299,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerFilters(NewConsumerSpecFilters()),
 						ConsumerReply(ConsumerTopicReply()),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			WantEvents: []string{
@@ -403,6 +407,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerReply(ConsumerTopicReply()),
 						)),
 						ConsumerGroupReady,
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -448,6 +453,7 @@ func TestReconcileKind(t *testing.T) {
 					WithConsumerGroupMetaLabels(OwnerAsTriggerLabel),
 					WithConsumerGroupLabels(ConsumerTriggerLabel),
 					ConsumerGroupReady,
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key:         testKey,
@@ -472,6 +478,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerReply(ConsumerTopicReply()),
 						)),
 						ConsumerGroupReady,
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -515,6 +522,7 @@ func TestReconcileKind(t *testing.T) {
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(newTrigger())),
 					WithConsumerGroupMetaLabels(OwnerAsTriggerLabel),
 					WithConsumerGroupLabels(ConsumerTriggerLabel),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key:         testKey,
@@ -537,6 +545,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerFilters(NewConsumerSpecFilters()),
 							ConsumerReply(ConsumerTopicReply()),
 						)),
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -597,6 +606,7 @@ func TestReconcileKind(t *testing.T) {
 							},
 						}),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 				NewLegacySASLSecret(ConfigMapNamespace, "secret-1"),
 			},
@@ -627,6 +637,7 @@ func TestReconcileKind(t *testing.T) {
 								},
 							}),
 						)),
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -682,6 +693,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					ConsumerGroupReady,
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -736,6 +748,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerReply(ConsumerTopicReply()),
 					)),
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -791,6 +804,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					WithConsumerGroupFailed("failed", "failed"),
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -845,6 +859,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					WithDeadLetterSinkURI(url.String()),
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -992,6 +1007,7 @@ func TestReconcileKind(t *testing.T) {
 					WithConsumerGroupMetaLabels(OwnerAsTriggerLabel),
 					WithConsumerGroupLabels(ConsumerTriggerLabel),
 					ConsumerGroupReady,
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key:         testKey,
@@ -1015,6 +1031,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerReply(ConsumerTopicReply()),
 						)),
 						ConsumerGroupReady,
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -1073,6 +1090,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					ConsumerGroupReady,
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -1171,4 +1189,14 @@ func removeFinalizers() clientgotesting.PatchActionImpl {
 	patch := `{"metadata":{"finalizers":[],"resourceVersion":""}}`
 	action.Patch = []byte(patch)
 	return action
+}
+
+func withBrokerTopLevelResourceRef() ConsumerGroupOption {
+	return WithTopLevelResourceRef(&corev1.ObjectReference{
+		APIVersion: eventing.SchemeGroupVersion.String(),
+		Kind:       "Broker",
+		Namespace:  BrokerNamespace,
+		Name:       BrokerName,
+		UID:        BrokerUUID,
+	})
 }


### PR DESCRIPTION
Previously to v2, we were setting `name` to the Broker or Channel name of the resource.