### PR TITLE
Remove unused editor config Java plugin

### DIFF
--- a/data-plane/contract/pom.xml
+++ b/data-plane/contract/pom.xml
@@ -39,16 +39,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.ec4j.maven</groupId>
-        <artifactId>editorconfig-maven-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -35,7 +35,6 @@
     <maven.jar.plugin.version>3.4.2</maven.jar.plugin.version>
     <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
     <maven.shade.plugin.version>3.5.1</maven.shade.plugin.version>
-    <maven.editorconfig.plugin.version>0.1.1</maven.editorconfig.plugin.version>
     <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
     <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
     <maven.license.plugin.version>2.0.0</maven.license.plugin.version>
@@ -458,27 +457,6 @@
                 </platform>
               </platforms>
             </from>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.ec4j.maven</groupId>
-          <artifactId>editorconfig-maven-plugin</artifactId>
-          <version>${maven.editorconfig.plugin.version}</version>
-          <executions>
-            <execution>
-              <id>check</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <excludes>
-              <exclude>.dockerignore</exclude>
-              <exclude>config/***</exclude>
-              <exclude>.mvn/***</exclude>
-            </excludes>
           </configuration>
         </plugin>
         <plugin>

--- a/data-plane/profiler/run.sh
+++ b/data-plane/profiler/run.sh
@@ -52,7 +52,7 @@ echo "Async profiler URL: ${ASYNC_PROFILER_URL}"
 echo "Kafka URL: ${KAFKA_URL}"
 
 # Build the data plane.
-cd "${PROJECT_ROOT_DIR}" && ./mvnw package -DskipTests -Dlicense.skip -Deditorconfig.skip -B -U --no-transfer-progress && cd - || exit 1
+cd "${PROJECT_ROOT_DIR}" && ./mvnw package -DskipTests -Dlicense.skip -B -U --no-transfer-progress && cd - || exit 1
 
 # Download async profiler.
 rm -rf async-profiler


### PR DESCRIPTION
We use spotless to reformat Java code and editor config is not used anymore.