### PR TITLE
Support explicit protocol configuration in KafkaChannel secret 

### DIFF
--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -736,6 +736,15 @@ func (r *Reconciler) getChannelContractResource(ctx context.Context, topic strin
 		resource.Auth = &contract.Resource_MultiAuthSecret{
 			MultiAuthSecret: auth.MultiSecretReference,
 		}
+	} else if auth != nil && auth.VirtualSecret != nil {
+		resource.Auth = &contract.Resource_AuthSecret{
+			AuthSecret: &contract.Reference{
+				Uuid:      string(auth.VirtualSecret.UID),
+				Namespace: auth.VirtualSecret.Namespace,
+				Name:      auth.VirtualSecret.Name,
+				Version:   auth.VirtualSecret.ResourceVersion,
+			},
+		}
 	}
 
 	if audience != nil {

--- a/control-plane/pkg/security/secrets_provider_legacy_channel_secret.go
+++ b/control-plane/pkg/security/secrets_provider_legacy_channel_secret.go
@@ -29,6 +29,12 @@ func ResolveAuthContextFromLegacySecret(s *corev1.Secret) (*NetSpecAuthContext, 
 		return &NetSpecAuthContext{}, nil
 	}
 
+	// Check if the secret is a legacy secret format without the explicit `protocol` key
+	if v, ok := s.Data[ProtocolKey]; ok && len(v) > 0 {
+		// The secret is explicitly using `protocol` configuration, no need to guess it.
+		return &NetSpecAuthContext{VirtualSecret: s}, nil
+	}
+
 	protocolStr, protocolContract := getProtocolFromLegacyChannelSecret(s)
 
 	virtualSecret := s.DeepCopy()

--- a/control-plane/pkg/security/secrets_provider_net_spec.go
+++ b/control-plane/pkg/security/secrets_provider_net_spec.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+
 	bindings "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/bindings/v1beta1"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -459,7 +459,6 @@ function create_sasl_secrets() {
     --from-literal=user="my-sasl-user" \
     --from-literal=protocol="SASL_SSL" \
     --from-literal=sasl.mechanism="SCRAM-SHA-512" \
-    --from-literal=saslType="SCRAM-SHA-512" \
     --dry-run=client -o yaml | kubectl apply -n "${SYSTEM_NAMESPACE}" -f -
 
   kubectl create secret --namespace "${SYSTEM_NAMESPACE}" generic strimzi-sasl-secret-legacy \
@@ -474,7 +473,6 @@ function create_sasl_secrets() {
     --from-literal=user="my-sasl-user" \
     --from-literal=protocol="SASL_PLAINTEXT" \
     --from-literal=sasl.mechanism="SCRAM-SHA-512" \
-    --from-literal=saslType="SCRAM-SHA-512" \
     --dry-run=client -o yaml | kubectl apply -n "${SYSTEM_NAMESPACE}" -f -
 
   kubectl create secret --namespace "${SYSTEM_NAMESPACE}" generic strimzi-sasl-plain-secret-legacy \

--- a/test/rekt/features/kafka_source.go
+++ b/test/rekt/features/kafka_source.go
@@ -44,10 +44,11 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 
+	"knative.dev/eventing/test/rekt/features/source"
+
 	testpkg "knative.dev/eventing-kafka-broker/test/pkg"
 	"knative.dev/eventing-kafka-broker/test/rekt/features/featuressteps"
 	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkasink"
-	"knative.dev/eventing/test/rekt/features/source"
 
 	internalscg "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1"
 	sources "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1beta1"
@@ -338,7 +339,7 @@ func KafkaSourceFeatureSetup(f *feature.Feature,
 			kafkasource.WithSASLEnabled(),
 			kafkasource.WithSASLUser(secretName, "user"),
 			kafkasource.WithSASLPassword(secretName, "password"),
-			kafkasource.WithSASLType(secretName, "saslType"),
+			kafkasource.WithSASLType(secretName, "sasl.mechanism"),
 			kafkasource.WithTLSEnabled(),
 			kafkasource.WithTLSCACert(secretName, "ca.crt"),
 		)

--- a/test/rekt/features/kafka_source_create_secrets_after.go
+++ b/test/rekt/features/kafka_source_create_secrets_after.go
@@ -48,7 +48,7 @@ func CreateSecretsAfterKafkaSource() *feature.Feature {
 		kafkasource.WithSASLEnabled(),
 		kafkasource.WithSASLUser(saslSecretName, "user"),
 		kafkasource.WithSASLPassword(saslSecretName, "password"),
-		kafkasource.WithSASLType(saslSecretName, "saslType"),
+		kafkasource.WithSASLType(saslSecretName, "sasl.mechanism"),
 		kafkasource.WithTLSEnabled(),
 		kafkasource.WithTLSCACert(tlsSecretName, "ca.crt"),
 	))


### PR DESCRIPTION
KafkaChannel has historically used the "legacy" secret format,
however, it has limitations as not having the explicit protocol
configuration, we're left with guessing the protocol.

We will continue supporting the "legacy" format, however,
we will encourage users to use the new secret format, so that
it can also be used for Kafka Broker, KafkaChannel and KafkaSink.

Fixes #4123
Fixes #2231

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Support explicit protocol configuration in KafkaChannel secret to align Broker, KafkaChannel and KafkaSink

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Support explicit protocol configuration in KafkaChannel secret so that the same format as Kafka Broker secrets can be used for KafkaChannel authentication configuration.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
