### PR TITLE
Discard invalid consumer records

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherMutatorChain.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherMutatorChain.java
@@ -38,8 +38,11 @@ public class RecordDispatcherMutatorChain implements RecordDispatcher {
 
     @Override
     public Future<Void> dispatch(ConsumerRecord<Object, CloudEvent> record) {
-        return next.dispatch(
-                KafkaConsumerRecordUtils.copyRecordAssigningValue(record, cloudEventMutator.apply(record)));
+        final var n = cloudEventMutator.apply(record);
+        if (n == record.value()) {
+            return next.dispatch(record);
+        }
+        return next.dispatch(KafkaConsumerRecordUtils.copyRecordAssigningValue(record, n));
     }
 
     @Override

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
@@ -35,6 +35,9 @@ public class CloudEventOverridesMutator implements CloudEventMutator {
 
     @Override
     public CloudEvent apply(ConsumerRecord<Object, CloudEvent> record) {
+        if (record.value() instanceof InvalidCloudEvent) {
+            return record.value();
+        }
         final var builder = CloudEventBuilder.from(record.value());
         applyKafkaMetadata(builder, record.partition(), record.offset());
         applyCloudEventOverrides(builder);


### PR DESCRIPTION
Invalid records shouldn't block consuming events.

The record will eventually end up here and discarded: 

https://github.com/knative-extensions/eventing-kafka-broker/blob/main/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java#L168-L177

Fixes #4129

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Discard invalid consumer records

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

