### PR TITLE
Customizable prefix for cloudevent extensions

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
@@ -30,7 +30,8 @@ public class CloudEventOverridesMutator implements CloudEventMutator {
     private final DataPlaneContract.CloudEventOverrides cloudEventOverrides;
     private final String ceMetadataExtensionPrefix;
 
-    public CloudEventOverridesMutator(final DataPlaneContract.CloudEventOverrides cloudEventOverrides, final String ceMetadataExtensionPrefix) {
+    public CloudEventOverridesMutator(
+            final DataPlaneContract.CloudEventOverrides cloudEventOverrides, final String ceMetadataExtensionPrefix) {
         this.cloudEventOverrides = cloudEventOverrides;
         this.ceMetadataExtensionPrefix = ceMetadataExtensionPrefix;
     }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
@@ -28,9 +28,11 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 public class CloudEventOverridesMutator implements CloudEventMutator {
 
     private final DataPlaneContract.CloudEventOverrides cloudEventOverrides;
+    private final String ceMetadataExtensionPrefix;
 
-    public CloudEventOverridesMutator(final DataPlaneContract.CloudEventOverrides cloudEventOverrides) {
+    public CloudEventOverridesMutator(final DataPlaneContract.CloudEventOverrides cloudEventOverrides, final String ceMetadataExtensionPrefix) {
         this.cloudEventOverrides = cloudEventOverrides;
+        this.ceMetadataExtensionPrefix = ceMetadataExtensionPrefix;
     }
 
     @Override
@@ -49,7 +51,7 @@ public class CloudEventOverridesMutator implements CloudEventMutator {
     }
 
     private void applyKafkaMetadata(CloudEventBuilder builder, Number partition, Number offset) {
-        builder.withExtension("knativekafkapartition", partition);
-        builder.withExtension("knativekafkaoffset", offset);
+        builder.withExtension(ceMetadataExtensionPrefix + "partition", partition);
+        builder.withExtension(ceMetadataExtensionPrefix + "offset", offset);
     }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -122,7 +122,9 @@ public class ConsumerVerticleBuilder {
                                 TracingPolicy.PROPAGATE),
                         Metrics.getRegistry()),
                 new CloudEventOverridesMutator(
-                        consumerVerticleContext.getResource().getCloudEventOverrides()));
+                        consumerVerticleContext.getResource().getCloudEventOverrides(),
+                        consumerVerticleContext.getCeMetadataExtensionPrefix()
+                        ));
         consumerVerticle.setRecordDispatcher(recordDispatcher);
 
         final var partitionRevokedHandlers =

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -123,8 +123,7 @@ public class ConsumerVerticleBuilder {
                         Metrics.getRegistry()),
                 new CloudEventOverridesMutator(
                         consumerVerticleContext.getResource().getCloudEventOverrides(),
-                        consumerVerticleContext.getCeMetadataExtensionPrefix()
-                        ));
+                        consumerVerticleContext.getCeMetadataExtensionPrefix()));
         consumerVerticle.setRecordDispatcher(recordDispatcher);
 
         final var partitionRevokedHandlers =

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
@@ -165,8 +165,7 @@ public class ConsumerVerticleContext {
         return this;
     }
 
-    public ConsumerVerticleContext withCeMetadataExtensionPrefix(
-            final String ceMetadataExtensionPrefix) {
+    public ConsumerVerticleContext withCeMetadataExtensionPrefix(final String ceMetadataExtensionPrefix) {
         this.ceMetadataExtensionPrefix = ceMetadataExtensionPrefix;
         return this;
     }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleContext.java
@@ -61,6 +61,8 @@ public class ConsumerVerticleContext {
     private ReactiveConsumerFactory<Object, CloudEvent> consumerFactory;
     private ReactiveProducerFactory<String, CloudEvent> producerFactory;
 
+    private String ceMetadataExtensionPrefix;
+
     private Integer maxPollRecords;
     private static final int DEFAULT_MAX_POLL_RECORDS = 50;
 
@@ -163,6 +165,12 @@ public class ConsumerVerticleContext {
         return this;
     }
 
+    public ConsumerVerticleContext withCeMetadataExtensionPrefix(
+            final String ceMetadataExtensionPrefix) {
+        this.ceMetadataExtensionPrefix = ceMetadataExtensionPrefix;
+        return this;
+    }
+
     public DataPlaneContract.Resource getResource() {
         return resource;
     }
@@ -228,6 +236,10 @@ public class ConsumerVerticleContext {
 
     public ReactiveProducerFactory<String, CloudEvent> getProducerFactory() {
         return this.producerFactory;
+    }
+
+    public String getCeMetadataExtensionPrefix() {
+        return this.ceMetadataExtensionPrefix;
     }
 
     public Tags getTags() {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -39,6 +39,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
     private final MeterRegistry metricsRegistry;
     private final ReactiveConsumerFactory reactiveConsumerFactory;
     private final ReactiveProducerFactory reactiveProducerFactory;
+    private final String ceMetadataExtensionPrefix;
 
     /**
      * All args constructor.
@@ -56,7 +57,8 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
             final AuthProvider authProvider,
             final MeterRegistry metricsRegistry,
             final ReactiveConsumerFactory reactiveConsumerFactory,
-            final ReactiveProducerFactory reactiveProducerFactory) {
+            final ReactiveProducerFactory reactiveProducerFactory,
+            final String ceMetadataExtensionPrefix) {
 
         Objects.requireNonNull(consumerConfigs, "provide consumerConfigs");
         Objects.requireNonNull(webClientOptions, "provide webClientOptions");
@@ -75,6 +77,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
         this.metricsRegistry = metricsRegistry;
         this.reactiveConsumerFactory = reactiveConsumerFactory;
         this.reactiveProducerFactory = reactiveProducerFactory;
+        this.ceMetadataExtensionPrefix = ceMetadataExtensionPrefix;
     }
 
     /**
@@ -93,7 +96,8 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
                         .withMeterRegistry(metricsRegistry)
                         .withResource(egressContext)
                         .withConsumerFactory(reactiveConsumerFactory)
-                        .withProducerFactory(reactiveProducerFactory))
+                        .withProducerFactory(reactiveProducerFactory)
+                        .withCeMetadataExtensionPrefix(ceMetadataExtensionPrefix))
                 .build();
     }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/DispatcherEnv.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/DispatcherEnv.java
@@ -16,6 +16,7 @@
 package dev.knative.eventing.kafka.broker.dispatcher.main;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 import dev.knative.eventing.kafka.broker.core.utils.BaseEnv;
 import java.util.function.Function;
@@ -31,12 +32,16 @@ public class DispatcherEnv extends BaseEnv {
     public static final String EGRESSES_INITIAL_CAPACITY = "EGRESSES_INITIAL_CAPACITY";
     private final int egressesInitialCapacity;
 
+    public static final String CE_METADATA_EXTENSION_PREFIX = "CE_METADATA_EXTENSION_PREFIX";
+    private final String ceMetadataExtensionPrefix;
+  
     public DispatcherEnv(Function<String, String> envProvider) {
         super(envProvider);
 
         this.consumerConfigFilePath = requireNonNull(envProvider.apply(CONSUMER_CONFIG_FILE_PATH));
         this.webClientConfigFilePath = requireNonNull(envProvider.apply(WEBCLIENT_CONFIG_FILE_PATH));
         this.egressesInitialCapacity = Integer.parseInt(requireNonNull(envProvider.apply(EGRESSES_INITIAL_CAPACITY)));
+        this.ceMetadataExtensionPrefix = requireNonNullElse(envProvider.apply(CE_METADATA_EXTENSION_PREFIX), "knativekafka");
     }
 
     public String getConsumerConfigFilePath() {
@@ -49,6 +54,10 @@ public class DispatcherEnv extends BaseEnv {
 
     public int getEgressesInitialCapacity() {
         return egressesInitialCapacity;
+    }
+
+    public String getCeMetadataExtensionPrefix() {
+        return ceMetadataExtensionPrefix;
     }
 
     @Override

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/DispatcherEnv.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/DispatcherEnv.java
@@ -34,14 +34,15 @@ public class DispatcherEnv extends BaseEnv {
 
     public static final String CE_METADATA_EXTENSION_PREFIX = "CE_METADATA_EXTENSION_PREFIX";
     private final String ceMetadataExtensionPrefix;
-  
+
     public DispatcherEnv(Function<String, String> envProvider) {
         super(envProvider);
 
         this.consumerConfigFilePath = requireNonNull(envProvider.apply(CONSUMER_CONFIG_FILE_PATH));
         this.webClientConfigFilePath = requireNonNull(envProvider.apply(WEBCLIENT_CONFIG_FILE_PATH));
         this.egressesInitialCapacity = Integer.parseInt(requireNonNull(envProvider.apply(EGRESSES_INITIAL_CAPACITY)));
-        this.ceMetadataExtensionPrefix = requireNonNullElse(envProvider.apply(CE_METADATA_EXTENSION_PREFIX), "knativekafka");
+        this.ceMetadataExtensionPrefix =
+                requireNonNullElse(envProvider.apply(CE_METADATA_EXTENSION_PREFIX), "knativekafka");
     }
 
     public String getConsumerConfigFilePath() {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
@@ -119,7 +119,8 @@ public class Main {
                             AuthProvider.kubernetes(vertx),
                             Metrics.getRegistry(),
                             reactiveConsumerFactory,
-                            reactiveProducerFactory),
+                            reactiveProducerFactory,
+                            env.getCeMetadataExtensionPrefix()),
                     env.getEgressesInitialCapacity());
 
             // Deploy the consumer deployer

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutatorTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutatorTest.java
@@ -38,8 +38,9 @@ public class CloudEventOverridesMutatorTest {
         final var ceOverrides = DataPlaneContract.CloudEventOverrides.newBuilder()
                 .putAllExtensions(extensions)
                 .build();
+        final var ceMetadataExtensionPrefix = "knativekafka";
 
-        final var mutator = new CloudEventOverridesMutator(ceOverrides);
+        final var mutator = new CloudEventOverridesMutator(ceOverrides, ceMetadataExtensionPrefix);
 
         final var given = CloudEventBuilder.v1()
                 .withId(UUID.randomUUID().toString())
@@ -50,8 +51,8 @@ public class CloudEventOverridesMutatorTest {
 
         final var expected = CloudEventBuilder.from(given);
         extensions.forEach(expected::withExtension);
-        expected.withExtension("knativekafkaoffset", 1L);
-        expected.withExtension("knativekafkapartition", 1);
+        expected.withExtension(ceMetadataExtensionPrefix + "offset", 1L);
+        expected.withExtension(ceMetadataExtensionPrefix + "partition", 1);
 
         final var got = mutator.apply(new ConsumerRecord<>("test-topic", 1, 1, "key", given));
 
@@ -67,7 +68,7 @@ public class CloudEventOverridesMutatorTest {
                 .putAllExtensions(extensions)
                 .build();
 
-        final var mutator = new CloudEventOverridesMutator(ceOverrides);
+        final var mutator = new CloudEventOverridesMutator(ceOverrides, "knativekafka");
 
         final var given = new InvalidCloudEvent(null);
 
@@ -87,8 +88,9 @@ public class CloudEventOverridesMutatorTest {
         final var ceOverrides = DataPlaneContract.CloudEventOverrides.newBuilder()
                 .putAllExtensions(Map.of())
                 .build();
+        final var ceMetadataExtensionPrefix = "knativekafka";
 
-        final var mutator = new CloudEventOverridesMutator(ceOverrides);
+        final var mutator = new CloudEventOverridesMutator(ceOverrides, ceMetadataExtensionPrefix);
 
         final var given = CloudEventBuilder.v1()
                 .withId(UUID.randomUUID().toString())
@@ -98,8 +100,8 @@ public class CloudEventOverridesMutatorTest {
                 .build();
 
         final var expected = CloudEventBuilder.from(given)
-                .withExtension("knativekafkaoffset", 1L)
-                .withExtension("knativekafkapartition", 1)
+                .withExtension(ceMetadataExtensionPrefix + "offset", 1L)
+                .withExtension(ceMetadataExtensionPrefix + "partition", 1)
                 .build();
 
         final var got = mutator.apply(new ConsumerRecord<>("test-topic", 1, 1, "key", given));

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImplTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImplTest.java
@@ -75,7 +75,8 @@ public class ConsumerVerticleFactoryImplTest {
                 mock(AuthProvider.class),
                 mock(MeterRegistry.class),
                 new MockReactiveConsumerFactory<>(),
-                new dev.knative.eventing.kafka.broker.receiver.MockReactiveProducerFactory<>());
+                new dev.knative.eventing.kafka.broker.receiver.MockReactiveProducerFactory<>(),
+                "knativekafka");
 
         final var egress = DataPlaneContract.Egress.newBuilder()
                 .setConsumerGroup("1234")
@@ -120,7 +121,8 @@ public class ConsumerVerticleFactoryImplTest {
                 mock(AuthProvider.class),
                 mock(MeterRegistry.class),
                 new MockReactiveConsumerFactory<>(),
-                new MockReactiveProducerFactory<>());
+                new MockReactiveProducerFactory<>(),
+                "knativekafka");
 
         final var egress = DataPlaneContract.Egress.newBuilder()
                 .setConsumerGroup("1234")
@@ -169,7 +171,8 @@ public class ConsumerVerticleFactoryImplTest {
                 mock(AuthProvider.class),
                 mock(MeterRegistry.class),
                 new MockReactiveConsumerFactory<>(),
-                new MockReactiveProducerFactory<>());
+                new MockReactiveProducerFactory<>(),
+                "knativekafka");
 
         final var egress = DataPlaneContract.Egress.newBuilder()
                 .setConsumerGroup("1234")

--- a/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/AbstractDataPlaneTest.java
+++ b/data-plane/tests/src/test/java/dev/knative/eventing/kafka/broker/tests/AbstractDataPlaneTest.java
@@ -361,7 +361,8 @@ public abstract class AbstractDataPlaneTest {
                 AuthProvider.noAuth(),
                 Metrics.getRegistry(),
                 getReactiveConsumerFactory(),
-                getReactiveProducerFactory());
+                getReactiveProducerFactory(),
+                "knativekafka");
 
         final var verticle = new ConsumerDeployerVerticle(consumerVerticleFactory, 10);
 


### PR DESCRIPTION
## Proposed Changes

- allow the CloudEvent extension attributes "partition" and "offset" to have a customizable prefix

As brought up before in this issue https://github.com/knative-extensions/eventing-kafka-broker/issues/3992, a previous version of NodeJS `cloudevents` would throw an error for any extension > 20 chars in length.

We are in a tough position to update this package for a large number of legacy services, so we were hoping you could consider a change like this for versions 1.14 and onward.

The code I have changed here is incomplete, but I wanted to check if this change would be allowable first.

Basically just adding a new env var "CE_METADATA_EXTENSION_PREFIX" to change the "knativekafka" part of the "knativekafkapartition" and "knativekafkaoffset" CE extensions.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:broom: allow customization of the prefix of the CE extensions
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
