### PR TITLE
Allow kafka-controller to list JobSinks

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -224,6 +224,16 @@ rules:
     verbs:
       - update
 
+  - apiGroups:
+      - "sinks.knative.dev"
+    resources:
+      - "jobsinks"
+      - "jobsinks/status"
+    verbs:
+      - get
+      - list
+      - watch
+
   # resources needed to grant eventtype autocreate rbac to namespaced data plane component
   - apiGroups:
       - "eventing.knative.dev"


### PR DESCRIPTION
This is required otherwise KafkaBroker and KafkaSource can't forward events to JobSink. This type of error is thrown on Kafka Broker status:

```
failed to reconcile contract: failed to reconcile egress: failed to resolve subscriber: failed to get lister for sinks.knative.dev/v1alpha1, Resource=jobsinks: jobsinks.sinks.knative.dev is forbidden: User "system:serviceaccount:knative-eventing:kafka-controller" cannot list resource "jobsinks" in API group "sinks.knative.dev" at the cluster scope
```

I have also created a test for KafkaBroker forwarding events to JobSink to verify the fix. But it's probably not necessary to include it. Anyway, it's available here: https://github.com/mgencur/eventing-kafka-broker/commit/57dbb533751c825762d94ca51b10d66e1d8a5439


<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
