### PR TITLE
Thread safe improvements on OIDCDiscoveryConfigListener

### DIFF
--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/auth/OIDCDiscoveryConfigListener.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/auth/OIDCDiscoveryConfigListener.java
@@ -20,10 +20,11 @@ import dev.knative.eventing.kafka.broker.core.file.FileWatcher;
 import io.vertx.core.Vertx;
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -35,15 +36,17 @@ public class OIDCDiscoveryConfigListener implements AutoCloseable {
     private final Vertx vertx;
     private final FileWatcher configFeaturesWatcher;
     private final int timeoutSeconds;
-    private final CopyOnWriteArrayList<Consumer<OIDCDiscoveryConfig>> callbacks;
+    private final ConcurrentHashMap<Integer, Consumer<OIDCDiscoveryConfig>> callbacks;
     private final AtomicReference<OIDCDiscoveryConfig> oidcDiscoveryConfig;
+    private final AtomicInteger callbackIdGenerator;
 
     public OIDCDiscoveryConfigListener(String featuresConfigPath, Vertx vertx, int timeoutSeconds) throws IOException {
         this.featuresConfigPath = featuresConfigPath;
         this.vertx = vertx;
         this.timeoutSeconds = timeoutSeconds;
         this.oidcDiscoveryConfig = new AtomicReference<>();
-        this.callbacks = new CopyOnWriteArrayList<>();
+        this.callbacks = new ConcurrentHashMap<>();
+        this.callbackIdGenerator = new AtomicInteger(0);
 
         this.buildFeaturesAndOIDCDiscoveryConfig();
 
@@ -53,7 +56,7 @@ public class OIDCDiscoveryConfigListener implements AutoCloseable {
                         this.buildFeaturesAndOIDCDiscoveryConfig();
                         OIDCDiscoveryConfig config = this.oidcDiscoveryConfig.get();
                         if (config != null) {
-                            this.callbacks.forEach(callback -> callback.accept(config));
+                            this.callbacks.values().forEach(callback -> callback.accept(config));
                         }
                     }
                 });
@@ -66,12 +69,13 @@ public class OIDCDiscoveryConfigListener implements AutoCloseable {
     }
 
     public int registerCallback(Consumer<OIDCDiscoveryConfig> callback) {
-        this.callbacks.add(callback);
-        return this.callbacks.size() - 1;
+        int id = callbackIdGenerator.incrementAndGet();
+        this.callbacks.put(id, callback);
+        return id;
     }
 
     public void deregisterCallback(int callbackId) {
-        this.callbacks.set(callbackId, null);
+        this.callbacks.remove(callbackId);
     }
 
     private void buildOIDCDiscoveryConfig() throws ExecutionException, InterruptedException, TimeoutException {


### PR DESCRIPTION
## Proposed Changes

- using `ConcurrentHashMap`, `AtomicRef` and `AtomicInt` for improving thread safeness

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
