### PR TITLE
Complete Consumer verticle stop promise only after closing dependencies

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
@@ -65,14 +65,14 @@ public abstract class ConsumerVerticle extends AbstractVerticle {
 
     @Override
     public void stop(Promise<Void> stopPromise) {
-        logger.info("Stopping consumer {}", consumerVerticleContext.getLoggingKeyValue());
+        logger.info("Stopping consumer verticle {}", consumerVerticleContext.getLoggingKeyValue());
 
         AsyncCloseable.compose(this.recordDispatcher, this.closeable, this.consumer::close)
                 .close()
-                .onComplete(
-                        r -> logger.info("Consumer verticle closed {}", consumerVerticleContext.getLoggingKeyValue()));
-
-        stopPromise.tryComplete();
+                .onComplete(r -> {
+                    stopPromise.tryComplete();
+                    logger.info("Consumer verticle closed {}", consumerVerticleContext.getLoggingKeyValue());
+                });
     }
 
     public void setConsumer(ReactiveKafkaConsumer<Object, CloudEvent> consumer) {


### PR DESCRIPTION
Completing the stop promise before the dependencies (dispatcher, client, etc) before will cause the WebClient to be closed.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Complete Consumer verticle stop promise only after closing dependencies
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Complete Consumer verticle stop promise only after closing dependencies
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
