### PR TITLE
feat: add updatescale method to generated clients for consumergroups

### DIFF
--- a/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
@@ -32,6 +32,8 @@ import (
 
 // +genclient
 // +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=ApplyScale,verb=apply,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 // +genreconciler
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/control-plane/pkg/client/clientset/versioned/typed/internalskafkaeventing/v1alpha1/consumergroup.go
+++ b/control-plane/pkg/client/clientset/versioned/typed/internalskafkaeventing/v1alpha1/consumergroup.go
@@ -49,6 +49,7 @@ type ConsumerGroupInterface interface {
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.ConsumerGroup, err error)
 	GetScale(ctx context.Context, consumerGroupName string, options v1.GetOptions) (*autoscalingv1.Scale, error)
+	UpdateScale(ctx context.Context, consumerGroupName string, scale *autoscalingv1.Scale, opts v1.UpdateOptions) (*autoscalingv1.Scale, error)
 
 	ConsumerGroupExpansion
 }
@@ -206,6 +207,21 @@ func (c *consumerGroups) GetScale(ctx context.Context, consumerGroupName string,
 		Name(consumerGroupName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *consumerGroups) UpdateScale(ctx context.Context, consumerGroupName string, scale *autoscalingv1.Scale, opts v1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("consumergroups").
+		Name(consumerGroupName).
+		SubResource("scale").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(scale).
 		Do(ctx).
 		Into(result)
 	return

--- a/control-plane/pkg/client/clientset/versioned/typed/internalskafkaeventing/v1alpha1/fake/fake_consumergroup.go
+++ b/control-plane/pkg/client/clientset/versioned/typed/internalskafkaeventing/v1alpha1/fake/fake_consumergroup.go
@@ -151,3 +151,14 @@ func (c *FakeConsumerGroups) GetScale(ctx context.Context, consumerGroupName str
 	}
 	return obj.(*autoscalingv1.Scale), err
 }
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeConsumerGroups) UpdateScale(ctx context.Context, consumerGroupName string, scale *autoscalingv1.Scale, opts v1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(consumergroupsResource, "scale", c.ns, scale), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
+}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Similar to https://github.com/knative-extensions/eventing-kafka-broker/pull/3976 but for the consumergroup client. This is useful since we currently do not expose the scale subresource for the triggers, so this will enable scaling the consumergroups directly

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add UpdateScale method to consumergroup generated client

```release-note
the consumergroup client now supports UpdateScale methods
```


