### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/build-dependabot-pr.yaml
+++ b/.github/workflows/build-dependabot-pr.yaml
@@ -45,7 +45,7 @@ jobs:
       # NOTE: Use actions/upload-artifact instead of actions/cache as the
       # workflow triggered on the default branch doesn't have access to caches
       # created on feature branches
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: dependabot-pr
           path: dependabot-pr/


### PR DESCRIPTION
Fixes 
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
``` 
e.g in https://github.com/knative-extensions/eventing-kafka-broker/actions/runs/12588648354/job/35086964011