### PR TITLE
Use rhel/ubi9-openjdk21 runtime image for data plane containers

### DIFF
--- a/data-plane/dispatcher-loom/pom.xml
+++ b/data-plane/dispatcher-loom/pom.xml
@@ -79,7 +79,7 @@
         <version>${jib.version}</version>
         <configuration>
           <from>
-            <image>docker.io/library/eclipse-temurin:21-jre</image>
+            <image>registry.access.redhat.com/ubi9/openjdk-21-runtime</image>
             <platforms>
               <platform>
                 <architecture>amd64</architecture>

--- a/data-plane/receiver-loom/pom.xml
+++ b/data-plane/receiver-loom/pom.xml
@@ -96,7 +96,7 @@
         <version>${jib.version}</version>
         <configuration>
           <from>
-            <image>docker.io/library/eclipse-temurin:21-jre</image>
+            <image>registry.access.redhat.com/ubi9/openjdk-21-runtime</image>
             <platforms>
               <platform>
                 <architecture>amd64</architecture>


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- as per title
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
