### PR TITLE
Fix test image upload

### DIFF
--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -30,9 +30,17 @@ function upload_test_images() {
     tag_option="--tags $docker_tag,latest"
   fi
 
+  # If PLATFORM environment variable is specified, then images will be built for
+  # specific hardware architecture.
+  # Example of the variable values - "linux/arm64", "linux/s390x".
+  local platform=""
+  if [ -n "${PLATFORM}" ]; then
+    platform="--platform ${PLATFORM}"
+  fi
+
   # ko resolve is being used for the side-effect of publishing images,
   # so the resulting yaml produced is ignored.
-  ko resolve ${KO_FLAGS} ${tag_option} -RBf "${image_dir}" >/dev/null
+  ko resolve ${platform} ${tag_option} -RBf "${image_dir}" >/dev/null
 }
 
 : ${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO', see DEVELOPMENT.md"}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix test image upload

This is on pair with Eventing core repository script. We are now exporting KO_FLAGS from knative.dev/hack. However, the default is `KO_FLAGS=-P --platform=all`. The `-P` option is a culprit in this case of building test images, because it preservers import path. Therefore we see image pull errors in release job. Because of the fact that expected image URLs are different, affected by `KO_FLAGS`.

```
➜  eventing-kafka-broker git:(pr/fix-test-images) ko resolve --tags latest -RBf vendor/knative.dev/eventing/test/test_images/recordevents
2025/01/23 22:44:39 Using base gcr.io/distroless/static:nonroot@sha256:6ec5aa99dc335666e79dc64e4a6c8b89c33a543a1967f20d360922a80dd21f02 for knative.dev/eventing/test/test_images/recordevents
2025/01/23 22:44:41 Building knative.dev/eventing/test/test_images/recordevents for linux/amd64
2025/01/23 22:45:02 Publishing quay.io/dsimansk/recordevents:latest
Error: error processing import paths in "vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml": error resolving image references: writing sbom: HEAD https://quay.io/v2/dsimansk/recordevents/manifests/sha256-d49821d1e8064024f21870a652c7936eaaf5d1bcd964bb78efb7d7273a9e2c78.sbom: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)
➜  eventing-kafka-broker git:(pr/fix-test-images) ko resolve -P --platform=all --tags latest -RBf vendor/knative.dev/eventing/test/test_images/recordevents
2025/01/23 22:45:09 Using base gcr.io/distroless/static:nonroot@sha256:6ec5aa99dc335666e79dc64e4a6c8b89c33a543a1967f20d360922a80dd21f02 for knative.dev/eventing/test/test_images/recordevents
2025/01/23 22:45:10 Building knative.dev/eventing/test/test_images/recordevents for linux/amd64
2025/01/23 22:45:11 Building knative.dev/eventing/test/test_images/recordevents for linux/arm64/v8
2025/01/23 22:45:11 Building knative.dev/eventing/test/test_images/recordevents for linux/s390x
2025/01/23 22:45:11 Building knative.dev/eventing/test/test_images/recordevents for linux/ppc64le
2025/01/23 22:45:12 Building knative.dev/eventing/test/test_images/recordevents for linux/arm/v7
2025/01/23 22:46:12 Publishing quay.io/dsimansk/knative.dev/eventing/test/test_images/recordevents:latest
Error: error processing import paths in "vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml": error resolving image references: writing sbom: HEAD https://quay.io/v2/dsimansk/knative.dev/eventing/test/test_images/recordevents/manifests/sha256-66253a3e5f93a6cdef418919ad0be7e92e3dad1b57d288db8857114b7b849281.sbom: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)
```


https://github.com/knative/eventing/blob/main/test/upload-test-images.sh

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

