### PR TITLE
Remove broken symlink to deprecated resource configs

### DIFF
--- a/control-plane/config/eventing-kafka-source/200-controller/100-config-kafka-descheduler.yaml
+++ b/control-plane/config/eventing-kafka-source/200-controller/100-config-kafka-descheduler.yaml
@@ -1,1 +1,0 @@
-../../eventing-kafka-broker/200-controller/100-config-kafka-descheduler.yaml

--- a/control-plane/config/eventing-kafka-source/200-controller/100-config-kafka-scheduler.yaml
+++ b/control-plane/config/eventing-kafka-source/200-controller/100-config-kafka-scheduler.yaml
@@ -1,1 +1,0 @@
-../../eventing-kafka-broker/200-controller/100-config-kafka-scheduler.yaml


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove broken symlink to deprecated resource configs

Affecting release script during resouce generation:
```
2025/01/26 10:49:07 Building knative.dev/eventing-kafka-broker/control-plane/cmd/webhook-kafka for linux/arm64/v8
Error: error processing import paths in "control-plane/config/eventing-kafka-source/200-controller/100-config-kafka-descheduler.yaml": open control-plane/config/eventing-kafka-source/200-controller/100-config-kafka-descheduler.yaml: no such file or directory
+ EXIT_VALUE=1
```

Per title, the original files were removed in https://github.com/knative-extensions/eventing-kafka-broker/pull/4189. This PR will remove dangling symlinks too.

I'll create cherry-pick PR immediately to skip merge dance with bot. 

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Remove broken symlink to deprecated resource configs
```

/cc @pierDipi @creydr @knative-extensions/knative-release-leads 