### PR TITLE
[WIP] Fix KEDA scaling with SASL auth for brokers

### DIFF
--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -21,14 +21,15 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/IBM/sarama"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 
 	bindings "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/bindings/v1"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internalskafkaeventing"
 	"knative.dev/eventing-kafka-broker/third_party/pkg/client/clientset/versioned"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/autoscaler"
@@ -42,6 +43,9 @@ import (
 const (
 	// AutoscalerClass is the KEDA autoscaler class.
 	AutoscalerClass = "keda.autoscaling.knative.dev"
+
+	KedaResourceLabel      = internalskafkaeventing.GroupName + "/resource"
+	KedaResourceLabelValue = "true"
 )
 
 func GenerateScaleTarget(cg *kafkainternals.ConsumerGroup) *kedav1alpha1.ScaleTarget {
@@ -95,8 +99,6 @@ func GenerateScaleTriggers(cg *kafkainternals.ConsumerGroup, triggerAuthenticati
 
 func GenerateTriggerAuthentication(cg *kafkainternals.ConsumerGroup, secretData map[string][]byte) (*kedav1alpha1.TriggerAuthentication, *corev1.Secret, error) {
 
-	secretTargetRefs := make([]kedav1alpha1.AuthSecretTargetRef, 0, 8)
-
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cg.Name,
@@ -104,28 +106,38 @@ func GenerateTriggerAuthentication(cg *kafkainternals.ConsumerGroup, secretData 
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(cg),
 			},
+			Labels: map[string]string{
+				KedaResourceLabel: KedaResourceLabelValue,
+			},
 		},
 		Data:       secretData,
 		StringData: make(map[string]string),
 	}
 
-	saslType := retrieveSaslTypeIfPresent(cg, secret)
-
-	if saslType != nil {
-		switch *saslType {
-		case "SCRAM-SHA-256":
-			secret.StringData["sasl"] = "scram_sha256"
-		case "SCRAM-SHA-512":
-			secret.StringData["sasl"] = "scram_sha512"
-		case "PLAIN":
-			secret.StringData["sasl"] = "plaintext"
-		default:
-			return nil, nil, fmt.Errorf("SASL type value %q is not supported", *saslType)
-		}
-	} else {
-		secret.StringData["sasl"] = "plaintext" //default
+	opt, err := security.NewSaramaSecurityOptionFromSecret(&secret)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get security option from secret: %w", err)
 	}
 
+	cfg := &sarama.Config{}
+	if err := opt(cfg); err != nil {
+		return nil, nil, fmt.Errorf("failed to get SASL config from secret: %w", err)
+	}
+
+	if cfg.Net.SASL.Enable {
+		switch cfg.Net.SASL.Mechanism {
+		case sarama.SASLTypePlaintext:
+			secret.StringData["sasl"] = "plaintext"
+		case sarama.SASLTypeSCRAMSHA256:
+			secret.StringData["sasl"] = "scram_sha256"
+		case sarama.SASLTypeSCRAMSHA512:
+			secret.StringData["sasl"] = "scram_sha512"
+		default:
+			return nil, nil, fmt.Errorf("SASL type value %q is not supported", cfg.Net.SASL.Mechanism)
+		}
+	}
+
+	secretTargetRefs := make([]kedav1alpha1.AuthSecretTargetRef, 0, 8)
 	triggerAuth := &kedav1alpha1.TriggerAuthentication{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cg.Name,
@@ -134,7 +146,7 @@ func GenerateTriggerAuthentication(cg *kafkainternals.ConsumerGroup, secretData 
 				*kmeta.NewControllerRef(cg),
 			},
 			Labels: map[string]string{
-				//TODO: may need to add labels like eventing-autoscaler-keda/pkg/reconciler/broker/resources/triggerauthentication.go#L39-L40
+				KedaResourceLabel: KedaResourceLabelValue,
 			},
 		},
 		Spec: kedav1alpha1.TriggerAuthenticationSpec{
@@ -169,7 +181,7 @@ func GenerateTriggerAuthentication(cg *kafkainternals.ConsumerGroup, secretData 
 
 	if cg.Spec.Template.Spec.Auth.SecretSpec != nil && cg.Spec.Template.Spec.Auth.SecretSpec.Ref.Name != "" {
 
-		if saslType != nil { //SASL enabled
+		if cfg.Net.SASL.Enable {
 			sasl := kedav1alpha1.AuthSecretTargetRef{Parameter: "sasl", Name: secret.Name, Key: "sasl"}
 			secretTargetRefs = append(secretTargetRefs, sasl)
 
@@ -204,22 +216,6 @@ func GenerateTriggerAuthentication(cg *kafkainternals.ConsumerGroup, secretData 
 	}
 
 	return triggerAuth, &secret, nil
-}
-
-func retrieveSaslTypeIfPresent(cg *kafkainternals.ConsumerGroup, secret corev1.Secret) *string {
-	if cg.Spec.Template.Spec.Auth.NetSpec != nil && cg.Spec.Template.Spec.Auth.NetSpec.SASL.Enable && cg.Spec.Template.Spec.Auth.NetSpec.SASL.Type.SecretKeyRef != nil {
-		secretKeyRefKey := cg.Spec.Template.Spec.Auth.NetSpec.SASL.Type.SecretKeyRef.Key
-		if saslTypeValue, ok := secret.Data[secretKeyRefKey]; ok {
-			return pointer.String(string(saslTypeValue))
-		}
-	}
-
-	if cg.Spec.Template.Spec.Auth.SecretSpec != nil && cg.Spec.Template.Spec.Auth.SecretSpec.Ref != nil {
-		if saslTypeValue, ok := secret.Data[security.SaslTypeLegacy]; ok {
-			return pointer.String(string(saslTypeValue))
-		}
-	}
-	return nil
 }
 
 func addAuthSecretTargetRef(parameter string, secretKeyRef bindings.SecretValueFromSource, secretTargetRefs []kedav1alpha1.AuthSecretTargetRef) []kedav1alpha1.AuthSecretTargetRef {

--- a/control-plane/pkg/security/secrets_provider_legacy_channel_secret.go
+++ b/control-plane/pkg/security/secrets_provider_legacy_channel_secret.go
@@ -39,16 +39,16 @@ func ResolveAuthContextFromLegacySecret(s *corev1.Secret) (*NetSpecAuthContext, 
 
 	virtualSecret := s.DeepCopy()
 	virtualSecret.Data[ProtocolKey] = []byte(protocolStr)
-	if v, ok := virtualSecret.Data["sasltype"]; ok {
+	if v, ok := virtualSecret.Data[SaslType]; ok {
 		virtualSecret.Data[SaslMechanismKey] = v
 	}
-	if v, ok := virtualSecret.Data["saslType"]; ok {
+	if v, ok := virtualSecret.Data[SaslTypeLegacy]; ok {
 		virtualSecret.Data[SaslMechanismKey] = v
 	}
-	if v, ok := virtualSecret.Data["username"]; ok {
+	if v, ok := virtualSecret.Data[SaslUsernameKey]; ok {
 		virtualSecret.Data[SaslUserKey] = v
 	}
-	if v, ok := virtualSecret.Data["user"]; ok {
+	if v, ok := virtualSecret.Data[SaslUserKey]; ok {
 		virtualSecret.Data[SaslUserKey] = v
 	}
 

--- a/test/rekt/features/keda_scaling.go
+++ b/test/rekt/features/keda_scaling.go
@@ -22,6 +22,8 @@ import (
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/autoscaler/keda"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
+	brokerconfigmap "knative.dev/eventing-kafka-broker/test/rekt/resources/configmap/broker"
+	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkaauthsecret"
 
 	"knative.dev/eventing/test/rekt/resources/trigger"
 
@@ -55,7 +57,7 @@ import (
 )
 
 func KafkaSourceScaledObjectHasNoEmptyAuthRef() *feature.Feature {
-	f := feature.NewFeatureNamed("KafkaSourceScalesToZeroWithKeda")
+	f := feature.NewFeature()
 
 	// we need to ensure that autoscaling is enabled for the rest of the feature to work
 	f.Prerequisite("Autoscaling is enabled", kafkafeatureflags.AutoscalingEnabled())
@@ -93,7 +95,7 @@ func KafkaSourceScaledObjectHasNoEmptyAuthRef() *feature.Feature {
 }
 
 func KafkaSourceScalesToZeroWithKeda() *feature.Feature {
-	f := feature.NewFeatureNamed("KafkaSourceScalesToZeroWithKeda")
+	f := feature.NewFeature()
 
 	// we need to ensure that autoscaling is enabled for the rest of the feature to work
 	f.Prerequisite("Autoscaling is enabled", kafkafeatureflags.AutoscalingEnabled())
@@ -142,6 +144,44 @@ func KafkaSourceScalesToZeroWithKeda() *feature.Feature {
 	return f
 }
 
+func KafkaSourceSASLScalesToZeroWithKeda() *feature.Feature {
+	f := feature.NewFeature()
+
+	// we need to ensure that autoscaling is enabled for the rest of the feature to work
+	f.Prerequisite("Autoscaling is enabled", kafkafeatureflags.AutoscalingEnabled())
+
+	sourceCfg := kafkaSourceConfig{
+		sourceName: feature.MakeRandomK8sName("kafka-source"),
+		authMech:   SASLMech,
+		topic:      feature.MakeRandomK8sName("kafka-source-keda-sasl"),
+	}
+	sinkCfg := kafkaSinkConfig{
+		sinkName: feature.MakeRandomK8sName("kafka-sink"),
+	}
+	sinkName, receiver := KafkaSourceFeatureSetup(f, sourceCfg, sinkCfg)
+
+	sender := feature.MakeRandomK8sName("eventshub-sender")
+
+	event := cetest.FullEvent()
+	event.SetID(uuid.New().String())
+
+	// check that the source initially has replicas = 0
+	f.Setup("Source should start with replicas = 0", verifyConsumerGroupReplicas(getKafkaSourceCg(sourceCfg.sourceName), 0, true))
+
+	options := []eventshub.EventsHubOption{
+		eventshub.StartSenderToResource(kafkasink.GVR(), sinkName),
+		eventshub.InputEvent(event),
+	}
+	f.Requirement("install eventshub sender", eventshub.Install(sender, options...))
+
+	f.Requirement("eventshub receiver gets event", assert.OnStore(receiver).MatchEvent(test.HasId(event.ID())).Exact(1))
+
+	// after the event is sent, the source should scale down to zero replicas
+	f.Alpha("KafkaSource").Must("Scale down to zero", verifyConsumerGroupReplicas(getKafkaSourceCg(sourceCfg.sourceName), 0, false))
+
+	return f
+}
+
 func TriggerScalesToZeroWithKeda() *feature.Feature {
 	f := feature.NewFeature()
 
@@ -156,6 +196,98 @@ func TriggerScalesToZeroWithKeda() *feature.Feature {
 
 	// check that the trigger initially has replicas = 0
 	f.Setup("Trigger should start with replicas = 0", verifyConsumerGroupReplicas(getTriggerCg(triggerName), 0, true))
+
+	f.Setup("install sink", eventshub.Install(sinkName, eventshub.StartReceiver))
+	f.Setup("install broker", broker.Install(brokerName))
+	f.Setup("install trigger", trigger.Install(triggerName, trigger.WithBrokerName(brokerName), trigger.WithSubscriber(service.AsKReference(sinkName), "")))
+
+	f.Requirement("install source", eventshub.Install(sourceName, eventshub.StartSenderToResource(broker.GVR(), brokerName), eventshub.InputEvent(event)))
+
+	f.Requirement("sink receives event", assert.OnStore(sinkName).MatchEvent(test.HasId(event.ID())).Exact(1))
+
+	//after the event is sent, the trigger should scale down to zero replicas
+	f.Alpha("Trigger").Must("Scale down to zero", verifyConsumerGroupReplicas(getTriggerCg(triggerName), 0, false))
+
+	return f
+}
+
+func TriggerSASLScalesToZeroWithKeda() *feature.Feature {
+	f := feature.NewFeature()
+
+	f.Prerequisite("Autoscaling is enabled", kafkafeatureflags.AutoscalingEnabled())
+
+	event := cetest.FullEvent()
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	sourceName := feature.MakeRandomK8sName("source")
+	sinkName := feature.MakeRandomK8sName("sink")
+	brokerConfigName := feature.MakeRandomK8sName("brokercfg")
+	authSecretName := feature.MakeRandomK8sName("kafkaauth")
+
+	// check that the trigger initially has replicas = 0
+	f.Setup("Trigger should start with replicas = 0", verifyConsumerGroupReplicas(getTriggerCg(triggerName), 0, true))
+
+	f.Setup("Create auth secret", func(ctx context.Context, t feature.T) {
+		kafkaauthsecret.Install(authSecretName, kafkaauthsecret.WithSslSaslScram512Data(ctx))(ctx, t)
+	})
+
+	f.Setup("Create broker config", brokerconfigmap.Install(brokerConfigName,
+		brokerconfigmap.WithNumPartitions(3),
+		brokerconfigmap.WithReplicationFactor(3),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersSslSaslScram),
+		brokerconfigmap.WithAuthSecret(authSecretName)))
+
+	f.Setup("Install broker", broker.Install(brokerName, append(
+		broker.WithEnvConfig(),
+		broker.WithConfig(brokerConfigName))...,
+	))
+
+	f.Setup("install sink", eventshub.Install(sinkName, eventshub.StartReceiver))
+	f.Setup("install broker", broker.Install(brokerName))
+	f.Setup("install trigger", trigger.Install(triggerName, trigger.WithBrokerName(brokerName), trigger.WithSubscriber(service.AsKReference(sinkName), "")))
+
+	f.Requirement("install source", eventshub.Install(sourceName, eventshub.StartSenderToResource(broker.GVR(), brokerName), eventshub.InputEvent(event)))
+
+	f.Requirement("sink receives event", assert.OnStore(sinkName).MatchEvent(test.HasId(event.ID())).Exact(1))
+
+	//after the event is sent, the trigger should scale down to zero replicas
+	f.Alpha("Trigger").Must("Scale down to zero", verifyConsumerGroupReplicas(getTriggerCg(triggerName), 0, false))
+
+	return f
+}
+
+func TriggerSSLScalesToZeroWithKeda() *feature.Feature {
+	f := feature.NewFeature()
+
+	f.Prerequisite("Autoscaling is enabled", kafkafeatureflags.AutoscalingEnabled())
+
+	event := cetest.FullEvent()
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	sourceName := feature.MakeRandomK8sName("source")
+	sinkName := feature.MakeRandomK8sName("sink")
+	brokerConfigName := feature.MakeRandomK8sName("brokercfg")
+	authSecretName := feature.MakeRandomK8sName("kafkaauth")
+
+	// check that the trigger initially has replicas = 0
+	f.Setup("Trigger should start with replicas = 0", verifyConsumerGroupReplicas(getTriggerCg(triggerName), 0, true))
+
+	f.Setup("Create auth secret", func(ctx context.Context, t feature.T) {
+		kafkaauthsecret.Install(authSecretName, kafkaauthsecret.WithSslData(ctx))(ctx, t)
+	})
+
+	f.Setup("Create broker config", brokerconfigmap.Install(brokerConfigName,
+		brokerconfigmap.WithNumPartitions(3),
+		brokerconfigmap.WithReplicationFactor(3),
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersSsl),
+		brokerconfigmap.WithAuthSecret(authSecretName)))
+
+	f.Setup("Install broker", broker.Install(brokerName, append(
+		broker.WithEnvConfig(),
+		broker.WithConfig(brokerConfigName))...,
+	))
 
 	f.Setup("install sink", eventshub.Install(sinkName, eventshub.StartReceiver))
 	f.Setup("install broker", broker.Install(brokerName))


### PR DESCRIPTION
TriggerAuthentication is misconfigured when Broker is configured to connect to Kafka with SASL since it was using only the legacy secret format.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix KEDA scaling with SASL auth for brokers
- Add e2e tests

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fix KEDA scaling with SASL auth for brokers.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
