### PR TITLE
[WIP] Init offsets trackers on consumer rebalance

### DIFF
--- a/data-plane/benchmarks/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedOffsetManagerBenchmark.java
+++ b/data-plane/benchmarks/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedOffsetManagerBenchmark.java
@@ -23,6 +23,7 @@ import io.vertx.core.Vertx;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -159,6 +160,11 @@ public class UnorderedOffsetManagerBenchmark {
 
         @Override
         public Future<Void> subscribe(Collection<String> topics, ConsumerRebalanceListener listener) {
+            return null;
+        }
+
+        @Override
+        public Future<Map<TopicPartition, OffsetAndMetadata>> committed(Set<TopicPartition> topicPartitions) {
             return null;
         }
 

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/ReactiveKafkaConsumer.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/ReactiveKafkaConsumer.java
@@ -20,9 +20,11 @@ import io.vertx.core.Handler;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
@@ -89,6 +91,18 @@ public interface ReactiveKafkaConsumer<K, V> {
      * @return A future indicating the success or failure of the subscribe operation.
      */
     Future<Void> subscribe(Collection<String> topics, ConsumerRebalanceListener listener);
+
+    /**
+     * Get the last committed offsets for the given partitions (whether the commit happened by this process or
+     * another). The returned offsets will be used as the position for the consumer in the event of a failure.
+     *
+     * @see KafkaConsumer#committed(Set)
+     *
+     * @param topicPartitions partitions to check.
+     * @return The latest committed offsets for the given partitions; {@code null} will be returned for the
+     *         partition if there is no such message.
+     */
+    Future<Map<TopicPartition, OffsetAndMetadata>> committed(final Set<TopicPartition> topicPartitions);
 
     /**
      * Retrieves the underlying Kafka Consumer instance.

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandler.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerMessageHandler.java
@@ -34,7 +34,7 @@ public class ResourcesReconcilerMessageHandler implements Handler<Message<Object
     private static final Logger logger = LoggerFactory.getLogger(ResourcesReconcilerMessageHandler.class);
 
     public static final String ADDRESS = "resourcesreconciler.core";
-    public static final int RECONCILE_TIMEOUT = 10000;
+    public static final int RECONCILE_TIMEOUT = 100000;
     public static final int RECONCILE_FAILED_RETRY_DELAY = 5000;
 
     private final Vertx vertx;
@@ -76,7 +76,7 @@ public class ResourcesReconcilerMessageHandler implements Handler<Message<Object
             // This is a safety timeout to the `reconcile` phase, there have been multiple times when libraries or our
             // components will cause the `Future` returned by `reconcile` to never complete (fail or succeed), in those
             // cases we stop reconciling resources completely.
-            vertx.setTimer(RECONCILE_TIMEOUT, v -> p.tryFail(v + "ms timeout reached"));
+            vertx.setTimer(RECONCILE_TIMEOUT, v -> p.tryFail(RECONCILE_TIMEOUT + "ms timeout reached"));
 
             try {
                 resourcesReconciler

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/PartitionAssignedHandler.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/PartitionAssignedHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
+
+import io.vertx.core.Future;
+import java.util.Collection;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * {@link PartitionAssignedHandler} is the handler called when some partitions are assigned to a
+ * {@link org.apache.kafka.clients.consumer.Consumer}
+ */
+public interface PartitionAssignedHandler {
+
+    /**
+     * @param partitions assigned partitions
+     * @return a successful or a failed future
+     */
+    Future<Void> partitionAssigned(final Collection<TopicPartition> partitions);
+}

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/MockReactiveKafkaConsumer.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/MockReactiveKafkaConsumer.java
@@ -24,6 +24,7 @@ import io.vertx.core.impl.ContextInternal;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -87,6 +88,11 @@ public class MockReactiveKafkaConsumer<K, V> implements ReactiveKafkaConsumer<K,
     public Future<Void> subscribe(Collection<String> topics, ConsumerRebalanceListener listener) {
         consumer.subscribe(topics, listener);
         return Future.succeededFuture();
+    }
+
+    @Override
+    public Future<Map<TopicPartition, OffsetAndMetadata>> committed(Set<TopicPartition> topicPartitions) {
+        return Future.succeededFuture(consumer.committed(topicPartitions));
     }
 
     @Override


### PR DESCRIPTION
We have seen a
`java.lang.IndexOutOfBoundsException: bitIndex < 0: -1`

The offsetTracker was removed because of the partition revocation but another recordReceived created it again/ and then some previous record (with offset just before the one with recordReceived ) did commit, so the bitSetOffset was set to -1.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Init offsets trackers on consumer rebalance

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
