### PR TITLE
Run `./hack/update-codegen.sh` on dependabot PRs

### DIFF
--- a/.github/workflows/update-dependabot-pr.yaml
+++ b/.github/workflows/update-dependabot-pr.yaml
@@ -2,68 +2,48 @@
 # READ-WRITE GITHUB_TOKEN from the default branch and pushes updated license
 # file changes back to the Dependabot PR branch.
 
-name: Update Dependabot Bundler PR
+name: Dependabot
+
 on:
-  workflow_run:
-    workflows: ["Build Dependabot Maven PR"]
-    types:
-      - completed
+  pull_request:
+
+permissions:
+  contents: write
 
 jobs:
-  update:
+  update-deps:
+    name: Update deps
     runs-on: ubuntu-latest
-    if: >
-      ${{ github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Download pr changes
-        uses: actions/github-script@v3.1.0
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "dependabot-pr"
-            })[0];
-            var download = await github.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('/home/runner/work/dependabot-pr.zip', Buffer.from(download.data));
-      - run: mkdir -p /home/runner/work/dependabot-pr
-      # NOTE: actions/checkout will delete the contents of the current workspace
-      # so we unpack the changes outside the current workspace
-      - name: Unpack dependabot pr changes
-        run: unzip -o /home/runner/work/dependabot-pr.zip -d /home/runner/work/dependabot-pr
-      - name: Set BRANCH_REF env var
-        run: printf "BRANCH_REF=%q" "$(head -1 '/home/runner/work/dependabot-pr/BRANCH_REF')" >> $GITHUB_ENV
-      - name: Checkout the branch that triggered 'Build Dependabot Maven PR'
-        uses: actions/checkout@v2
+          ref: ${{ github.head_ref }}
+          path: ./src/github.com/${{ github.repository }}
+          fetch-depth: 0
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5
         with:
-          ref: ${{ env.BRANCH_REF }}
-      - name: Configure git
+          go-version-file: ./src/github.com/${{ github.repository }}/go.mod
+
+      - name: Install yq
         run: |
-          git config --local user.email "automation@knative.team"
-          git config --local user.name "Knative Automation"
-      - name: Commit license changes
+          go install github.com/mikefarah/yq/v3@latest
+
+      - name: Run ./hack/update-codegen.sh
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: ./hack/update-codegen.sh
+
+      - name: git push
+        working-directory: ./src/github.com/${{ github.repository }}
         run: |
-          CHANGES_PATH=/home/runner/work/dependabot-pr/changes.patch
-          if [ -f "$CHANGES_PATH" ]; then
-            git am --keep-non-patch $CHANGES_PATH
-          else
-            echo "No changes where committed"
-          fi
-      - name: Push changes back to dependabot/maven branch
-        run: |
-          if [[ "$BRANCH_REF" =~ ^dependabot/maven* ]]; then
-            git push origin $BRANCH_REF
-          else
-            echo "Branch ref doesn't look like a dependabot/maven branch: $BRANCH_REF"
-            exit 1
+          if ! git diff --exit-code --quiet
+          then
+            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git add .
+            git commit -m "Run ./hack/update-codegen.sh"
+            git push
           fi

--- a/.github/workflows/update-dependabot-pr.yaml
+++ b/.github/workflows/update-dependabot-pr.yaml
@@ -28,10 +28,6 @@ jobs:
         with:
           go-version-file: ./src/github.com/${{ github.repository }}/go.mod
 
-      - name: Install yq
-        run: |
-          go install github.com/mikefarah/yq/v3@latest
-
       - name: Run ./hack/update-codegen.sh
         working-directory: ./src/github.com/${{ github.repository }}
         run: ./hack/update-codegen.sh


### PR DESCRIPTION
Running ./hack/update-codegen.sh on dependabot PRs currently fails (see for example https://github.com/knative-extensions/eventing-kafka-broker/pull/4280/files and https://github.com/knative-extensions/eventing-kafka-broker/actions/runs/13684783409).
This PR addresses it and simplifies running ./hack/update-codegen.sh on dependabot PRs