### PR TITLE
fix: repeat args from sub-func call

### DIFF
--- a/test/rekt/features/kafka_source.go
+++ b/test/rekt/features/kafka_source.go
@@ -326,7 +326,6 @@ func KafkaSourceFeatureSetup(f *feature.Feature,
 	case TLSMech:
 		f.Setup("Create TLS secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), TLSSecretName, secretName))
 		kafkaSourceOpts = append(kafkaSourceOpts, kafkasource.WithBootstrapServers(testingpkg.BootstrapServersSslArr),
-			kafkasource.WithTLSCACert(secretName, "ca.crt"),
 			kafkasource.WithTLSCert(secretName, "user.crt"),
 			kafkasource.WithTLSKey(secretName, "user.key"),
 			kafkasource.WithTLSEnabled(),


### PR DESCRIPTION
## Proposed Changes

I am verifying some lint idea in my project see https://github.com/alingse/sundrylint/pull/10
it report the function call with repeat args from a sub-function call.

we think the sub-function call is heavy, so the repeat args probably a copy-and-paste mistake.

I check the top 4000 github repos, and found this repo has this case.

**Release Note**

```release-note

```

**Docs**
