### PR TITLE
Update setup-java GH action to v4

### DIFF
--- a/.github/workflows/knative-java-test.yaml
+++ b/.github/workflows/knative-java-test.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           cache: 'maven'
           java-version: ${{ matrix.java-version }}


### PR DESCRIPTION
As per title

Java Unit tests fail currently on setup-java step (e.g. in https://github.com/knative-extensions/eventing-kafka-broker/actions/runs/14518216315/job/40732376258?pr=4336)