### PR TITLE
Run keda obj deletion only if the feature was previously enabled, to avoid GET requests for KEDA resources against the API server on each reconcilation

### DIFF
--- a/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_lifecycle.go
+++ b/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_lifecycle.go
@@ -26,6 +26,7 @@ const (
 	ConditionConsumerGroupConsumers          apis.ConditionType = "Consumers"
 	ConditionConsumerGroupConsumersScheduled apis.ConditionType = "ConsumersScheduled"
 	ConditionAutoscaling                     apis.ConditionType = "Autoscaler"
+	AutoscalerDisabled                                          = "AutoscalerDisabled"
 	// Labels
 	KafkaChannelNameLabel           = "kafkachannel-name"
 	ConsumerLabelSelector           = "kafka.eventing.knative.dev/metadata.uid"
@@ -98,7 +99,7 @@ func (cg *ConsumerGroup) MarkAutoscalerSucceeded() {
 }
 
 func (cg *ConsumerGroup) MarkAutoscalerDisabled() {
-	cg.GetConditionSet().Manage(cg.GetStatus()).MarkTrueWithReason(ConditionAutoscaling, "AutoscalerDisabled", "")
+	cg.GetConditionSet().Manage(cg.GetStatus()).MarkTrueWithReason(ConditionAutoscaling, AutoscalerDisabled, "")
 }
 
 func (cg *ConsumerGroup) MarkAutoscalerFailed(reason string, err error) error {

--- a/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_lifecycle.go
+++ b/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_lifecycle.go
@@ -98,7 +98,7 @@ func (cg *ConsumerGroup) MarkAutoscalerSucceeded() {
 }
 
 func (cg *ConsumerGroup) MarkAutoscalerDisabled() {
-	cg.GetConditionSet().Manage(cg.GetStatus()).MarkTrueWithReason(ConditionAutoscaling, "Autoscaler is disabled", "")
+	cg.GetConditionSet().Manage(cg.GetStatus()).MarkTrueWithReason(ConditionAutoscaling, "AutoscalerDisabled", "")
 }
 
 func (cg *ConsumerGroup) MarkAutoscalerFailed(reason string, err error) error {

--- a/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
@@ -240,8 +240,8 @@ func (cg *ConsumerGroup) IsAutoscalerNotDisabled() bool {
 		return true
 	}
 
-	// If condition is True but reason is not "AutoscalerDisabled", then it's actively enabled
-	return condition.Reason != "AutoscalerDisabled"
+	// If condition is True but reason is not "autoscaler is disabled", then it's actively enabled
+	return condition.Reason != AutoscalerDisabled
 }
 
 func (cg *ConsumerGroup) HasDeadLetterSink() bool {

--- a/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
@@ -232,6 +232,18 @@ func (cg *ConsumerGroup) IsNotScheduled() bool {
 	return cond.IsFalse() || cond.IsUnknown()
 }
 
+func (cg *ConsumerGroup) IsAutoscalerNotDisabled() bool {
+	condition := cg.Status.GetCondition(ConditionAutoscaling)
+
+	// If condition doesn't exist or is not true, it's not in "disabled" state
+	if condition == nil || condition.Status != corev1.ConditionTrue {
+		return true
+	}
+
+	// If condition is True but reason is not "AutoscalerDisabled", then it's actively enabled
+	return condition.Reason != "AutoscalerDisabled"
+}
+
 func (cg *ConsumerGroup) HasDeadLetterSink() bool {
 	return hasDeadLetterSink(cg.Spec.Template.Spec.Delivery)
 }


### PR DESCRIPTION

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #4361

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- move the `deleteKedaObjects` function before we mark the status that the Autoscaler is disabled, IF and only IF the status condition was NOT set to "disabled" before. That way we know we must delete them. This will restrict the level of GET requests against the apiserver

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
