### PR TITLE
Change initializer to catch issues with setting consumer during build() function

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -79,17 +79,17 @@ public class ConsumerVerticleBuilder {
         return (vertx, consumerVerticle) -> {
             Promise<Void> promise = Promise.promise();
             consumerVerticleContext
-                .getAuthProvider()
-                .getCredentials(consumerVerticleContext.getResource())
-                .onSuccess(credentials -> {
-                try {
-                    build(vertx, consumerVerticle, credentials);
-                    promise.complete();
-                } catch (Exception e) {
-                    promise.fail(e);
-                    }
-                })
-                .onFailure(promise::fail);
+                    .getAuthProvider()
+                    .getCredentials(consumerVerticleContext.getResource())
+                    .onSuccess(credentials -> {
+                        try {
+                            build(vertx, consumerVerticle, credentials);
+                            promise.complete();
+                        } catch (Exception e) {
+                            promise.fail(e);
+                        }
+                    })
+                    .onFailure(promise::fail);
             return promise.future();
         };
     }


### PR DESCRIPTION

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #4357

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Adding a bit of defense coding here, since the consumer is set during the `build()` method, I have changed the initializer to  complete the `Promise` after `build()` has fully finished. Trying to avoid a potential race when the `start()` might use the consumer it was set.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
