### PR TITLE
[WIP] Check if OIDC SA is set, before requesting a token for it

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/http/WebClientCloudEventSender.java
@@ -193,7 +193,11 @@ public final class WebClientCloudEventSender implements CloudEventSender {
         if (this.targetOIDCAudience.isEmpty()) {
             requestToken = Future.succeededFuture(null);
         } else {
-            requestToken = this.tokenProvider.getToken(this.oidcServiceAccount, this.targetOIDCAudience);
+            if (this.oidcServiceAccount.name() == null || this.oidcServiceAccount.name().isEmpty()) {
+                requestToken = Future.failedFuture("can't request an OIDC token, as target has an audience set, but no OIDC service account set in client yet");
+            } else {
+                requestToken = this.tokenProvider.getToken(this.oidcServiceAccount, this.targetOIDCAudience);
+            }
         }
 
         return requestToken


### PR DESCRIPTION
We have seen a `java.lang.IllegalArgumentException: Name must be provided` in the dispatcher, when the target had an audience set, but the OIDC service account was not reconciled in time.

## Proposed Changes

- :bug: Only request an OIDC token, when OIDC SA is set