### PR TITLE
:broom: Propagate the CaCerts and Audience of the ConsumerGroups Subscribers and DLS in the Triggers status too

### DIFF
--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
@@ -313,9 +313,13 @@ func propagateConsumerGroupStatus(cg *internalscg.ConsumerGroup, trigger *eventi
 		}
 	}
 	trigger.Status.SubscriberURI = cg.Status.SubscriberURI
+	trigger.Status.SubscriberCACerts = cg.Status.SubscriberCACerts
+	trigger.Status.SubscriberAudience = cg.Status.SubscriberAudience
 	trigger.Status.MarkSubscriberResolvedSucceeded()
 
 	trigger.Status.DeadLetterSinkURI = cg.Status.DeadLetterSinkURI
+	trigger.Status.DeadLetterSinkCACerts = cg.Status.DeadLetterSinkCACerts
+	trigger.Status.DeadLetterSinkAudience = cg.Status.DeadLetterSinkAudience
 	trigger.Status.MarkDeadLetterSinkResolvedSucceeded()
 
 	trigger.Status.PropagateSubscriptionCondition(&apis.Condition{


### PR DESCRIPTION
As per title, just to be consistent and propose this information in the triggers status too as we do for other resources.