### PR TITLE
Applying as 'rules: null', since that is how api server is treating i…

### DIFF
--- a/control-plane/config/post-install/200-controller-cluster-role.yaml
+++ b/control-plane/config/post-install/200-controller-cluster-role.yaml
@@ -20,4 +20,4 @@ metadata:
   name: knative-kafka-controller-post-install
   labels:
     app.kubernetes.io/version: devel
-rules: []
+rules: null


### PR DESCRIPTION
Instead of empty array (`[]`) we are now applying it as `rules: null`, since that is how _api server_ is treating it.

If applied via operator and the api-server treats it differently _will+ cause the operator to update back to its own `rules: []` version, instead of `null`, as treated by the api-server...

So, you end up with some back and forth, and have a lot of:

```
"msg":"Merging","diff":"{\"rules\":[]}"}
"msg":"Updating","name":"/knative-kafka-controller-post-install","type":"rbac.authorization.k8s.io/v1, Kind=ClusterRole"}
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- change empty rules field to `null` 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
