### PR TITLE
Create cluster-issuer before creating kafka certificate for tests

### DIFF
--- a/test/kafka/kafka_setup.sh
+++ b/test/kafka/kafka_setup.sh
@@ -27,6 +27,9 @@ header "Applying Strimzi Cluster Operator file"
 cat $(dirname $0)/strimzi-cluster-operator.yaml | sed 's/namespace: .*/namespace: kafka/' | sed "s/cluster.local/${CLUSTER_SUFFIX}/g" | kubectl apply -n kafka -f -
 
 echo "Create Kafka Certificate"
+# create the cluster-issuer, as the certificate links to this cluster-issuer
+kubectl apply -f "$(dirname $0)/../../vendor/knative.dev/eventing/test/config/tls/eventing-ca-issuer.yaml"
+kubectl apply -f "$(dirname $0)/../../vendor/knative.dev/eventing/test/config/tls/selfsigned-issuer.yaml"
 kubectl -n kafka apply -f $(dirname $0)/kafka-certificate.yaml
 
 sleep 10


### PR DESCRIPTION
In test/kafka_setup.sh, we're [creating a Certificate](https://github.com/knative-extensions/eventing-kafka-broker/blob/f4c76b517f6a41b18a8df6e42651ab1e58de0382/test/kafka/kafka_setup.sh#L30) for Kafka with the cluster-issuer `knative-eventing-ca-issuer` referenced. This requires that the cluster-issuer was created before, otherwise the certificate won't become ready.
Although we create the cluster-issuer when we setup knative-eventing for the tests (via ./hack/run.sh), we should make sure we have the cluster-issuer setup correctly before we apply the certificate in case knative-eventing is not installed via ./hack/run.sh (e.g. like we do in eventing-istio).