### PR TITLE
Allow the kafka-controller to list EventTransform API

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -225,6 +225,15 @@ rules:
       - update
 
   - apiGroups:
+      - "eventing.knative.dev"
+    resources:
+      - "eventtransforms"
+      - "eventtransforms/status"
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - "sinks.knative.dev"
     resources:
       - "jobsinks"


### PR DESCRIPTION
Similar like https://github.com/knative-extensions/eventing-kafka-broker/pull/4155

but for `Eventtranform` API