### PR TITLE
Revert "Allow kafka-controller to list JobSinks (#4155)"

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -224,16 +224,6 @@ rules:
     verbs:
       - update
 
-  - apiGroups:
-      - "sinks.knative.dev"
-    resources:
-      - "jobsinks"
-      - "jobsinks/status"
-    verbs:
-      - get
-      - list
-      - watch
-
   # resources needed to grant eventtype autocreate rbac to namespaced data plane component
   - apiGroups:
       - "eventing.knative.dev"


### PR DESCRIPTION
This reverts commit 1616ec39684f890992aa53fedd91b63464d019ef.


The `jobsinks` rbac are already in the aggregated role for addressable, hence here is not really needed