### PR TITLE
Refactor `ExactFilterTest.java` to add non-empty subject

### DIFF
--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/ExactFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/ExactFilterTest.java
@@ -50,6 +50,7 @@ public class ExactFilterTest {
         final var event = CloudEventBuilder.v1()
                 .withId("123")
                 .withType("type")
+                .withSubject("test-subject")
                 .withSource(URI.create("/api/source"))
                 .build();
 
@@ -70,6 +71,7 @@ public class ExactFilterTest {
         final var event = CloudEventBuilder.v1()
                 .withId("123")
                 .withType("type")
+                .withSubject("test-subject")
                 .withSource(URI.create("/api/source"))
                 .withExtension("extension2", "valueExtension2")
                 .build();
@@ -92,6 +94,7 @@ public class ExactFilterTest {
         final var event = CloudEventBuilder.v1()
                 .withId("123")
                 .withType("type")
+                .withSubject("test-subject")
                 .withSource(URI.create("/api/source"))
                 .withExtension("extension2", "valueExtension2")
                 .build();


### PR DESCRIPTION
## Fixes

Please see [issue 4433](https://github.com/knative-extensions/eventing-kafka-broker/issues/4433)

## Proposed Changes

- replace `.withSubject("")` with `.withSubject("test-subject")`