### PR TITLE
treat offsets skipped due to kafka transactions as comitted

### DIFF
--- a/data-plane/config/source/100-config-kafka-source-data-plane.yaml
+++ b/data-plane/config/source/100-config-kafka-source-data-plane.yaml
@@ -112,7 +112,7 @@ data:
     enable.auto.commit=false
     exclude.internal.topics=true
     fetch.max.bytes=52428800
-    isolation.level=read_uncommitted
+    isolation.level=read_committed
     max.poll.interval.ms=300000
     max.poll.records=50
     partition.assignment.strategy=org.apache.kafka.clients.consumer.StickyAssignor

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -132,6 +132,12 @@ public class Metrics {
 
     /**
      * @link https://knative.dev/docs/eventing/observability/metrics/eventing-metrics/
+     * @see Metrics#skippedOffsetCount(io.micrometer.core.instrument.Tags)
+     */
+    public static final String SKIPPED_OFFSET_COUNT = "skipped_offset_count";
+
+    /**
+     * @link https://knative.dev/docs/eventing/observability/metrics/eventing-metrics/
      * @see Metrics#executorQueueLatency(io.micrometer.core.instrument.Tags)
      */
     public static final String EXECUTOR_QUEUE_LATENCY = "executor_queue_latencies";
@@ -348,6 +354,13 @@ public class Metrics {
     public static Counter.Builder discardedEventCount(final io.micrometer.core.instrument.Tags tags) {
         return Counter.builder(DISCARDED_EVENTS_COUNT)
                 .description("Number of invalid events discarded")
+                .tags(tags)
+                .baseUnit(Metrics.Units.DIMENSIONLESS);
+    }
+
+    public static Counter.Builder skippedOffsetCount(final io.micrometer.core.instrument.Tags tags) {
+        return Counter.builder(SKIPPED_OFFSET_COUNT)
+                .description("Number of skipped offsets")
                 .tags(tags)
                 .baseUnit(Metrics.Units.DIMENSIONLESS);
     }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -71,6 +71,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
 
     // Invalid cloud event records that are discarded by dispatch may not have a record type. So we set Tag as below.
     private static final Tag INVALID_EVENT_TYPE_TAG = Tag.of(Metrics.Tags.EVENT_TYPE, "InvalidCloudEvent");
+    private static final Tag OFFSET_SKIPPING_TYPE_TAG = Tag.of(Metrics.Tags.EVENT_TYPE, "OffsetSkippingCloudEvent");
 
     private static final String KN_ERROR_DEST_EXT_NAME = "knativeerrordest";
     private static final String KN_ERROR_CODE_EXT_NAME = "knativeerrorcode";
@@ -456,6 +457,9 @@ public class RecordDispatcherImpl implements RecordDispatcher {
     private Tags getTags(final ConsumerRecordContext recordContext) {
         if (recordContext.getRecord().value() instanceof InvalidCloudEvent) {
             return this.consumerVerticleContext.getTags().and(INVALID_EVENT_TYPE_TAG);
+        }
+        if (recordContext.getRecord().value() instanceof OffsetSkippingCloudEvent) {
+            return this.consumerVerticleContext.getTags().and(OFFSET_SKIPPING_TYPE_TAG);
         }
         return this.consumerVerticleContext
                 .getTags()

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java
@@ -186,7 +186,7 @@ public class RecordDispatcherImpl implements RecordDispatcher {
             logger.debug(msg);
             recordDispatcherListener.recordReceived(record);
             recordDispatcherListener.recordDiscarded(record);
-            return Future.failedFuture(msg);
+            return Future.succeededFuture();
         }
 
         try {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
@@ -35,7 +35,7 @@ public class CloudEventOverridesMutator implements CloudEventMutator {
 
     @Override
     public CloudEvent apply(ConsumerRecord<Object, CloudEvent> record) {
-        if (record.value() instanceof InvalidCloudEvent) {
+        if (record.value() instanceof InvalidCloudEvent || record.value() instanceof OffsetSkippingCloudEvent) {
             return record.value();
         }
         final var builder = CloudEventBuilder.from(record.value());

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetSkippingCloudEvent.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetSkippingCloudEvent.java
@@ -18,7 +18,6 @@ package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 import io.cloudevents.SpecVersion;
-
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.Set;
@@ -29,8 +28,7 @@ import java.util.Set;
  * <p>
  */
 public class OffsetSkippingCloudEvent implements CloudEvent {
-    public OffsetSkippingCloudEvent() {
-    }
+    public OffsetSkippingCloudEvent() {}
 
     @Override
     public CloudEventData getData() {

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetSkippingCloudEvent.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetSkippingCloudEvent.java
@@ -1,0 +1,79 @@
+package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.SpecVersion;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Set;
+
+/**
+ * This class represents a skipped offset. (e.g. transactional control events, or events skipped due to aborted transactions
+ * with read_committed)
+ * <p>
+ */
+public class OffsetSkippingCloudEvent implements CloudEvent {
+    public OffsetSkippingCloudEvent() {
+    }
+
+    @Override
+    public CloudEventData getData() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SpecVersion getSpecVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI getSource() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getDataContentType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI getDataSchema() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getSubject() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OffsetDateTime getTime() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAttribute(String attributeName) throws IllegalArgumentException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getExtension(String extensionName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<String> getExtensionNames() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetSkippingCloudEvent.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetSkippingCloudEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.knative.eventing.kafka.broker.dispatcher.impl.consumer;
 
 import io.cloudevents.CloudEvent;

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -50,6 +50,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
     private static final Duration POLLING_TIMEOUT = Duration.ofMillis(1000L);
 
     private final Map<TopicPartition, OrderedAsyncExecutor> recordDispatcherExecutors;
+    private final Map<TopicPartition, Long> lastOffsets;
     private final PartitionRevokedHandler partitionRevokedHandler;
     private final Bucket bucket;
 
@@ -73,6 +74,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
         }
 
         this.recordDispatcherExecutors = new ConcurrentHashMap<>();
+        this.lastOffsets = new  ConcurrentHashMap<>();
         this.closed = new AtomicBoolean(false);
         this.isPollInFlight = new AtomicBoolean(false);
         this.pollTimer = new AtomicLong(-1);
@@ -80,6 +82,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
         partitionRevokedHandler = partitions -> {
             // Stop executors associated with revoked partitions.
             for (final TopicPartition partition : partitions) {
+                lastOffsets.remove(partition);
                 final var executor = recordDispatcherExecutors.remove(partition);
                 if (executor != null) {
                     logger.info(
@@ -186,7 +189,20 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
 
         // Put records in internal per-partition queues.
         for (var record : records) {
-            final var executor = executorFor(new TopicPartition(record.topic(), record.partition()));
+            final var topicPartition = new TopicPartition(record.topic(), record.partition());
+
+            final var executor = executorFor(topicPartition);
+
+            // Handle skipped offsets first, we dispatch an OffsetSkippingCloudEvent in stead of the missing offsets
+            if (lastOffsets.containsKey(topicPartition)) {
+                for (long skipOffset = lastOffsets.get(topicPartition) + 1; skipOffset < record.offset(); skipOffset++) {
+                    final long skipOffsetFinal = skipOffset;
+                    executor.offer(() -> dispatch(new ConsumerRecord<>(record.topic(), record.partition(), skipOffsetFinal, null, new OffsetSkippingCloudEvent())));
+                }
+            }
+
+            lastOffsets.put(topicPartition, record.offset());
+
             executor.offer(() -> dispatch(record));
         }
     }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OrderedConsumerVerticle.java
@@ -74,7 +74,7 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
         }
 
         this.recordDispatcherExecutors = new ConcurrentHashMap<>();
-        this.lastOffsets = new  ConcurrentHashMap<>();
+        this.lastOffsets = new ConcurrentHashMap<>();
         this.closed = new AtomicBoolean(false);
         this.isPollInFlight = new AtomicBoolean(false);
         this.pollTimer = new AtomicLong(-1);
@@ -195,9 +195,16 @@ public class OrderedConsumerVerticle extends ConsumerVerticle {
 
             // Handle skipped offsets first, we dispatch an OffsetSkippingCloudEvent in stead of the missing offsets
             if (lastOffsets.containsKey(topicPartition)) {
-                for (long skipOffset = lastOffsets.get(topicPartition) + 1; skipOffset < record.offset(); skipOffset++) {
+                for (long skipOffset = lastOffsets.get(topicPartition) + 1;
+                        skipOffset < record.offset();
+                        skipOffset++) {
                     final long skipOffsetFinal = skipOffset;
-                    executor.offer(() -> dispatch(new ConsumerRecord<>(record.topic(), record.partition(), skipOffsetFinal, null, new OffsetSkippingCloudEvent())));
+                    executor.offer(() -> dispatch(new ConsumerRecord<>(
+                            record.topic(),
+                            record.partition(),
+                            skipOffsetFinal,
+                            null,
+                            new OffsetSkippingCloudEvent())));
                 }
             }
 

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -23,12 +23,18 @@ import io.cloudevents.CloudEvent;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,11 +55,23 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
     private final AtomicInteger inFlightRecords;
     private final AtomicBoolean isPollInFlight;
 
+    private final PartitionRevokedHandler partitionRevokedHandler;
+
+    private final Map<TopicPartition, Long> lastOffsets;
+
     public UnorderedConsumerVerticle(final ConsumerVerticleContext context, final Initializer initializer) {
         super(context, initializer);
         this.inFlightRecords = new AtomicInteger(0);
         this.closed = new AtomicBoolean(false);
         this.isPollInFlight = new AtomicBoolean(false);
+        this.lastOffsets = new ConcurrentHashMap<>();
+
+        this.partitionRevokedHandler = partitions -> {
+            for (final TopicPartition partition : partitions) {
+                lastOffsets.remove(partition);
+            }
+            return Future.succeededFuture();
+        };
     }
 
     @Override
@@ -130,7 +148,23 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
         isPollInFlight.compareAndSet(true, false);
 
         for (var record : records) {
-            this.recordDispatcher.dispatch(record).onComplete(v -> {
+
+            final var topicPartition = new TopicPartition(record.topic(), record.partition());
+
+            final List<Future<Void>> recordDispatcherFutures = new ArrayList<>();
+
+            // Handle skipped offsets first, we dispatch an OffsetSkippingCloudEvent in stead of the missing offsets
+            if (lastOffsets.containsKey(topicPartition)) {
+                for (long skipOffset = lastOffsets.get(topicPartition) + 1; skipOffset < record.offset(); skipOffset++) {
+                  recordDispatcherFutures.add(this.recordDispatcher.dispatch(new ConsumerRecord<>(record.topic(), record.partition(), skipOffset, null, new OffsetSkippingCloudEvent())));
+                }
+            }
+
+            lastOffsets.put(topicPartition, record.offset());
+
+            recordDispatcherFutures.add(this.recordDispatcher.dispatch(record));
+
+            Future.all(recordDispatcherFutures).onComplete(v -> {
                 this.inFlightRecords.decrementAndGet();
                 poll();
             });
@@ -148,6 +182,6 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
 
     @Override
     public PartitionRevokedHandler getPartitionRevokedHandler() {
-        return partitions -> Future.succeededFuture();
+        return partitionRevokedHandler;
     }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -155,8 +155,11 @@ public final class UnorderedConsumerVerticle extends ConsumerVerticle {
 
             // Handle skipped offsets first, we dispatch an OffsetSkippingCloudEvent in stead of the missing offsets
             if (lastOffsets.containsKey(topicPartition)) {
-                for (long skipOffset = lastOffsets.get(topicPartition) + 1; skipOffset < record.offset(); skipOffset++) {
-                  recordDispatcherFutures.add(this.recordDispatcher.dispatch(new ConsumerRecord<>(record.topic(), record.partition(), skipOffset, null, new OffsetSkippingCloudEvent())));
+                for (long skipOffset = lastOffsets.get(topicPartition) + 1;
+                        skipOffset < record.offset();
+                        skipOffset++) {
+                    recordDispatcherFutures.add(this.recordDispatcher.dispatch(new ConsumerRecord<>(
+                            record.topic(), record.partition(), skipOffset, null, new OffsetSkippingCloudEvent())));
                 }
             }
 

--- a/test/e2e_source/helpers/kafka_helper.go
+++ b/test/e2e_source/helpers/kafka_helper.go
@@ -54,7 +54,7 @@ var (
 	ImcGVR   = schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1", Resource: "inmemorychannels"}       //nolinte:unused
 )
 
-func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, topic string, key string, headers map[string]string, value string) {
+func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, topic string, key string, headers map[string]string, transactionalId string, value string) {
 	cgName := topic + "-" + key + "z"
 
 	payload := value
@@ -85,6 +85,9 @@ func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, top
 	client.Tracker.Add(corev1.SchemeGroupVersion.Group, corev1.SchemeGroupVersion.Version, "configmap", client.Namespace, cgName)
 
 	args := []string{"-P", "-T", "-b", bootstrapServer, "-t", topic}
+	if transactionalId != "" {
+		args = append(args, "-X", "transactional.id="+transactionalId)
+	}
 	if key != "" {
 		args = append(args, "-K=")
 	}

--- a/test/e2e_source/helpers/kafka_source.go
+++ b/test/e2e_source/helpers/kafka_source.go
@@ -22,6 +22,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/storage/names"
+	"knative.dev/eventing-kafka-broker/test/pkg/kafka"
+
 	. "github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
 	testlib "knative.dev/eventing/test/lib"
@@ -34,9 +39,10 @@ import (
 )
 
 const (
-	KafkaBootstrapUrlPlain = "my-cluster-kafka-bootstrap.kafka.svc:9092"
-	KafkaClusterName       = "my-cluster"
-	KafkaClusterNamespace  = "kafka"
+	KafkaBootstrapUrlPlain   = "my-cluster-kafka-bootstrap.kafka.svc:9092"
+	KafkaClusterName         = "my-cluster"
+	KafkaClusterNamespace    = "kafka"
+	verifyCommittedOffsetJob = "verify-committed"
 )
 
 // SourceTestScope returns true if we should proceed with given
@@ -48,13 +54,16 @@ type SourceTestScope func(auth, testCase, version string) bool
 func AssureKafkaSourceConsumesMsgNoEvent(t *testing.T) {
 	tests := map[string]struct {
 		messageKey     string
+		messageCount   int
 		messageHeaders map[string]string
+		transactional  bool
 		messagePayload string
 		matcherGen     func(cloudEventsSourceName, cloudEventsEventType string) EventMatcher
 		extensions     map[string]string
 	}{
 		"no_event": {
-			messageKey: "0",
+			messageKey:   "0",
+			messageCount: 1,
 			messageHeaders: map[string]string{
 				"content-type": "application/json",
 			},
@@ -71,6 +80,7 @@ func AssureKafkaSourceConsumesMsgNoEvent(t *testing.T) {
 		},
 		"no_event_no_content_type": {
 			messageKey:     "0",
+			messageCount:   1,
 			messagePayload: `{"value":5}`,
 			matcherGen: func(cloudEventsSourceName, cloudEventsEventType string) EventMatcher {
 				return AllOf(
@@ -82,6 +92,7 @@ func AssureKafkaSourceConsumesMsgNoEvent(t *testing.T) {
 			},
 		},
 		"no_event_content_type_or_key": {
+			messageCount:   1,
 			messagePayload: `{"value":5}`,
 			matcherGen: func(cloudEventsSourceName, cloudEventsEventType string) EventMatcher {
 				return AllOf(
@@ -92,7 +103,8 @@ func AssureKafkaSourceConsumesMsgNoEvent(t *testing.T) {
 			},
 		},
 		"no_event_with_text_plain_body": {
-			messageKey: "0",
+			messageKey:   "0",
+			messageCount: 1,
 			messageHeaders: map[string]string{
 				"content-type": "text/plain",
 			},
@@ -107,6 +119,24 @@ func AssureKafkaSourceConsumesMsgNoEvent(t *testing.T) {
 				)
 			},
 		},
+		"no_event_with_transactional_id": {
+			messageKey:    "0",
+			messageCount:  10,
+			transactional: true,
+			messageHeaders: map[string]string{
+				"content-type": "application/json",
+			},
+			messagePayload: `{"value":5}`,
+			matcherGen: func(cloudEventsSourceName, cloudEventsEventType string) EventMatcher {
+				return AllOf(
+					HasSource(cloudEventsSourceName),
+					HasType(cloudEventsEventType),
+					HasDataContentType("application/json"),
+					HasData([]byte(`{"value":5}`)),
+					HasExtension("key", "0"),
+				)
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -115,14 +145,14 @@ func AssureKafkaSourceConsumesMsgNoEvent(t *testing.T) {
 		for _, version := range []string{"v1"} {
 			testName := name + "-" + version
 			t.Run(testName, func(t *testing.T) {
-				testKafkaSource(t, name, version, test.messageKey, test.messageHeaders, test.messagePayload, test.matcherGen, KafkaBootstrapUrlPlain, test.extensions)
+				testKafkaSource(t, name, version, test.messageKey, test.messageCount, test.messageHeaders, test.transactional, test.messagePayload, test.matcherGen, KafkaBootstrapUrlPlain, test.extensions)
 			})
 		}
 	}
 }
 
 func testKafkaSource(t *testing.T,
-	name string, version string, messageKey string, messageHeaders map[string]string, messagePayload string,
+	name string, version string, messageKey string, messageCount int, messageHeaders map[string]string, transactional bool, messagePayload string,
 	matcherGen func(cloudEventsSourceName, cloudEventsEventType string) EventMatcher,
 	bootStrapServer string, extensions map[string]string) {
 
@@ -147,6 +177,8 @@ func testKafkaSource(t *testing.T,
 	var (
 		cloudEventsSourceName string
 		cloudEventsEventType  string
+		transactionalId       string
+		expectedLag           uint64
 	)
 
 	t.Logf("Creating KafkaSource %s", version)
@@ -169,7 +201,28 @@ func testKafkaSource(t *testing.T,
 
 	client.WaitForAllTestResourcesReadyOrFail(context.Background())
 
-	MustPublishKafkaMessage(client, KafkaBootstrapUrlPlain, kafkaTopicName, messageKey, messageHeaders, messagePayload)
+	if transactional {
+		transactionalId = kafkaTopicName
+	}
 
-	eventTracker.AssertExact(1, recordevents.MatchEvent(matcherGen(cloudEventsSourceName, cloudEventsEventType)))
+	for range messageCount {
+		MustPublishKafkaMessage(client, KafkaBootstrapUrlPlain, kafkaTopicName, messageKey, messageHeaders, transactionalId, messagePayload)
+	}
+
+	eventTracker.AssertExact(messageCount, recordevents.MatchEvent(matcherGen(cloudEventsSourceName, cloudEventsEventType)))
+
+	// With transactions, the last event is a transaction control record, which will not be consumed, so the expected lag is 1
+	if transactional {
+		expectedLag = 1
+	}
+
+	err := kafka.VerifyLagEquals(client.Kube, client.Tracker, types.NamespacedName{
+		Namespace: client.Namespace,
+		Name:      names.SimpleNameGenerator.GenerateName(verifyCommittedOffsetJob + "-" + kafkaTopicName),
+	}, &kafka.AdminConfig{
+		BootstrapServers: bootStrapServer,
+		Topic:            kafkaTopicName,
+		Group:            consumerGroup,
+	}, expectedLag)
+	require.Nil(t, err, "Failed to verify committed offset")
 }

--- a/test/test_images/committed-offset/admin.go
+++ b/test/test_images/committed-offset/admin.go
@@ -27,12 +27,17 @@ import (
 	kafkatest "knative.dev/eventing-kafka-broker/test/pkg/kafka"
 )
 
+type CommittedOffsetConfig struct {
+	kafkatest.AdminConfig
+	ExpectedLag uint64 `json:"expectedLag" required:"false" split_words:"true" default:"0"`
+}
+
 func main() {
 
 	adminConfig := sarama.NewConfig()
 	adminConfig.Version = sarama.V2_0_0_0
 
-	envConfig := &kafkatest.AdminConfig{}
+	envConfig := &CommittedOffsetConfig{}
 
 	if err := envconfig.Process("", envConfig); err != nil {
 		log.Fatal("Failed to process environment variables", err)
@@ -53,7 +58,7 @@ func main() {
 		log.Fatal("Failed to get lag", err)
 	}
 
-	if lag.Total() != 0 {
-		log.Fatal("Lag is not 0", lag)
+	if lag.Total() != envConfig.ExpectedLag {
+		log.Fatal("Lag is not as expected", lag, envConfig.ExpectedLag)
 	}
 }


### PR DESCRIPTION
Fixes #4451

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- introduce OffsetSkippingCloudEvent to represent a "skipped offset"
- make RecordDispatcher discard OffsetSkippingCloudEvents
- add a kafka_source test variant with transactional id to verify KafkaSource behavior with a topic in which events are produced with Kafka transactions.


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fixes a KafkaSource issue, where the kafka-source-dispatcher would stop committing offsets if the events were produced by a producer using Kafka transactions. 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
