### PR TITLE
Fix shaded build with current Quarkus version

### DIFF
--- a/hack/data-plane.sh
+++ b/hack/data-plane.sh
@@ -86,7 +86,7 @@ function dispatcher_build_push() {
 
 function data_plane_build_push() {
   pushd "${DATA_PLANE_DIR}" || return $?
-  ./mvnw install -DskipTests || fail_test "failed to install data plane"
+  ./mvnw clean install -DskipTests || fail_test "failed to install data plane"
   receiver_build_push || receiver_build_push || fail_test "failed to build receiver"
   dispatcher_build_push || dispatcher_build_push || fail_test "failed to build dispatcher"
   popd || return $?
@@ -167,7 +167,7 @@ function data_plane_setup() {
 
 function data_plane_source_setup() {
   pushd "${DATA_PLANE_DIR}" || return $?
-  ./mvnw install -DskipTests || fail_test "failed to install data plane"
+  ./mvnw clean install -DskipTests || fail_test "failed to install data plane"
   dispatcher_build_push || dispatcher_build_push || fail_test "failed to build dispatcher"
   popd || return $?
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix shaded build with current Quarkus version

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fix shaded build with current Quarkus version
```

Should fix the following in release jobs.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.6.0:shade (default) on project receiver-loom: Error creating shaded jar: Unsupported class file major version 68 -> [Help 1]
```

/cc @Cali0707 @creydr @gauron99 