### PR TITLE
Fix Keda Trigger SSL & SASL test to install broker only once

### DIFF
--- a/test/keda-reconciler-tests.sh
+++ b/test/keda-reconciler-tests.sh
@@ -39,7 +39,7 @@ export_logs_continuously
 
 header "Running tests"
 
-go_test_e2e -timeout=1h -run=KafkaSource ./test/e2e_new/... || fail_test "E2E (new) suite failed"
+go_test_e2e -timeout=1h -run=KafkaSource -run=Keda ./test/e2e_new/... || fail_test "E2E (new) suite failed"
 
 if ! ${LOCAL_DEVELOPMENT}; then
 	go_test_e2e -run=KafkaSource -tags=sacura -timeout=40m ./test/e2e/... || fail_test "E2E sacura tests failed"

--- a/test/rekt/features/keda_scaling.go
+++ b/test/rekt/features/keda_scaling.go
@@ -244,7 +244,6 @@ func TriggerSASLScalesToZeroWithKeda() *feature.Feature {
 	))
 
 	f.Setup("install sink", eventshub.Install(sinkName, eventshub.StartReceiver))
-	f.Setup("install broker", broker.Install(brokerName))
 	f.Setup("install trigger", trigger.Install(triggerName, trigger.WithBrokerName(brokerName), trigger.WithSubscriber(service.AsKReference(sinkName), "")))
 
 	f.Requirement("install source", eventshub.Install(sourceName, eventshub.StartSenderToResource(broker.GVR(), brokerName), eventshub.InputEvent(event)))
@@ -290,7 +289,6 @@ func TriggerSSLScalesToZeroWithKeda() *feature.Feature {
 	))
 
 	f.Setup("install sink", eventshub.Install(sinkName, eventshub.StartReceiver))
-	f.Setup("install broker", broker.Install(brokerName))
 	f.Setup("install trigger", trigger.Install(triggerName, trigger.WithBrokerName(brokerName), trigger.WithSubscriber(service.AsKReference(sinkName), "")))
 
 	f.Requirement("install source", eventshub.Install(sourceName, eventshub.StartSenderToResource(broker.GVR(), brokerName), eventshub.InputEvent(event)))


### PR DESCRIPTION
Currently the `TriggerSSLScalesToZeroWithKeda` and `TriggerSASLScalesToZeroWithKeda` tests try to install the broker two times. This PR cleans it up and installs it only once.

Also enables to run all tests containing "Keda" in their name from the e2e_new folder as part of the keda-rekt-test suite