### PR TITLE
Use calmer poll timings for Channel Conformance e2e tests

### DIFF
--- a/test/e2e_new_channel/kafka_channel_upstream_test.go
+++ b/test/e2e_new_channel/kafka_channel_upstream_test.go
@@ -21,6 +21,7 @@ package e2e_new_channel
 
 import (
 	"testing"
+	"time"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/manifest"
@@ -45,6 +46,7 @@ func TestChannelConformance(t *testing.T) {
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
+		environment.WithPollTimings(5*time.Second, 4*time.Minute),
 	)
 
 	channelName := "mychannelimpl"


### PR DESCRIPTION
Recently we see often the `TestChannelConformance/Knative_Channel_Specification_-_Data_Plane/Delivery_Spec_1/Assert/Conformance_Channels_SHOULD_support_various_retry_configuration_parameters:_[the_maximum_number_of_retries]` being very flaky.

Lets use a bit calmer pollings (same as in [eventing-core](https://github.com/knative/eventing/blob/1c920ca1452d391ac8469708855bb7db0e88d3a8/test/rekt/channel_test.go#L57) for the ChannelConformance tests) to give more time to settle in this test.