### PR TITLE
feat: add KN_VERIFY_CORRELATION_ID CESQL function to EKB dispatcher

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/CeSqlFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/CeSqlFilter.java
@@ -49,7 +49,9 @@ public class CeSqlFilter implements Filter {
         try {
             logger.debug(
                     "Testing event against CESQL expression. Expression {} - Event {}", this.expression, cloudEvent);
-            Object value = this.expression.tryEvaluate(cloudEvent);
+            Object value = this.expression
+                    .evaluate(CeSqlRuntimeManager.getInstance().getRuntime(), cloudEvent)
+                    .value();
             logger.debug(
                     "CESQL evaluation succeeded. Expression {} - Event {} - Result {}", expression, cloudEvent, value);
             Result castedResult =

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/CeSqlRuntimeManager.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/CeSqlRuntimeManager.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.core.filter.subscriptionsapi;
+
+import io.cloudevents.sql.EvaluationRuntime;
+import io.cloudevents.sql.impl.functions.BaseFunction;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.vertx.core.Vertx;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CeSqlRuntimeManager {
+    private static final Logger logger = LoggerFactory.getLogger(CeSqlRuntimeManager.class);
+
+    private static final CeSqlRuntimeManager INSTANCE = new CeSqlRuntimeManager();
+
+    private EvaluationRuntime runtime;
+
+    private CeSqlRuntimeManager() {
+        this.runtime = EvaluationRuntime.builder().build();
+    }
+
+    public static CeSqlRuntimeManager getInstance() {
+        return INSTANCE;
+    }
+
+    public EvaluationRuntime getRuntime() {
+        return runtime;
+    }
+
+    public void registerFunction(BaseFunction function) {
+        logger.info("Registering CeSql function: {}", function.name());
+        this.runtime = EvaluationRuntime.builder().addFunction(function).build();
+    }
+
+    public void registerKnVerifyCorrelationId(Vertx vertx, KubernetesClient kubernetesClient, String systemNamespace) {
+        if (vertx != null && kubernetesClient != null && systemNamespace != null) {
+            registerFunction(new KnVerifyCorrelationId(vertx, kubernetesClient, systemNamespace));
+        }
+    }
+}

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/KnVerifyCorrelationId.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/KnVerifyCorrelationId.java
@@ -1,0 +1,139 @@
+package dev.knative.eventing.kafka.broker.core.filter.subscriptionsapi;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.sql.EvaluationContext;
+import io.cloudevents.sql.EvaluationRuntime;
+import io.cloudevents.sql.Type;
+import io.cloudevents.sql.impl.functions.BaseFunction;
+import io.cloudevents.sql.impl.runtime.EvaluationResult;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.vertx.core.Vertx;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KnVerifyCorrelationId extends BaseFunction {
+    private static final Logger logger = LoggerFactory.getLogger(KnVerifyCorrelationId.class);
+    private final Vertx vertx;
+    private final KubernetesClient kubeClient;
+    private final String systemNamespace;
+    private static final int GCM_NONCE_LENGTH_BYTES = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+
+    public KnVerifyCorrelationId(Vertx vertx, KubernetesClient kubeClient, String systemNamespace) {
+        super("KN_VERIFY_CORRELATION_ID");
+        this.vertx = vertx;
+        this.kubeClient = kubeClient;
+        this.systemNamespace = systemNamespace;
+    }
+
+    @Override
+    public EvaluationResult invoke(
+            EvaluationContext ctx, EvaluationRuntime evaluationRuntime, CloudEvent cloudEvent, List<Object> arguments) {
+        var result = false;
+        try {
+            final String replyId = (String) arguments.get(0);
+            final String name = (String) arguments.get(1);
+            final String namespace = (String) arguments.get(2);
+            final String secretName = (String) arguments.get(3);
+            final Integer podIdx = (Integer) arguments.get(4);
+            final Integer replicaCount = (Integer) arguments.get(5);
+
+            final var actualIdx = getPodIdxFromReplyId(replyId);
+            if (actualIdx % replicaCount != podIdx) {
+                return new EvaluationResult(false);
+            }
+
+            var secret = getSecret(secretName, systemNamespace);
+            result = secret.getData().entrySet().stream()
+                    .filter((k) -> keyIsForResource(k.getKey(), name, namespace))
+                    .anyMatch((k) -> this.isValidReplyId(replyId, k.getValue()));
+        } catch (Exception e) {
+            return new EvaluationResult(
+                    result,
+                    ctx.exceptionFactory()
+                            .functionExecutionError(name(), e)
+                            .create(ctx.expressionInterval(), ctx.expressionText()));
+        }
+
+        return new EvaluationResult(result);
+    }
+
+    @Override
+    public Type typeOfParameter(int i) throws IllegalArgumentException {
+        return switch (i) {
+            case 0, 1, 2, 3 -> Type.STRING;
+            case 4, 5 -> Type.INTEGER;
+            default -> throw new IllegalArgumentException("invalid parameter index");
+        };
+    }
+
+    @Override
+    public Type returnType() {
+        return Type.BOOLEAN;
+    }
+
+    @Override
+    public int arity() {
+        return 6;
+    }
+
+    @Override
+    public boolean isVariadic() {
+        return false;
+    }
+
+    private Secret getSecret(String name, String namespace) {
+        return kubeClient.secrets().inNamespace(namespace).withName(name).get();
+    }
+
+    private int getPodIdxFromReplyId(String replyId) throws IllegalArgumentException {
+        var parts = replyId.split(":");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("invalid reply id");
+        }
+
+        return Integer.parseInt(parts[2]);
+    }
+
+    private boolean keyIsForResource(String key, String name, String namespace) {
+        return key.startsWith(namespace + "." + name + ".");
+    }
+
+    private boolean isValidReplyId(String replyId, String aesKey) {
+        List<String> parts = Arrays.asList(replyId.split(":"));
+        String originalId = parts.get(0);
+        String encryptedIdBase64 = parts.get(1);
+
+        try {
+            byte[] encryptedBytes = Base64.getDecoder().decode(encryptedIdBase64);
+            if (encryptedBytes.length < GCM_NONCE_LENGTH_BYTES) {
+                throw new IllegalArgumentException("encrypted data is too short");
+            }
+
+            byte[] nonceBytes = Arrays.copyOfRange(encryptedBytes, 0, GCM_NONCE_LENGTH_BYTES);
+            byte[] cipherText = Arrays.copyOfRange(encryptedBytes, GCM_NONCE_LENGTH_BYTES, encryptedBytes.length);
+
+            final Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            SecretKeySpec keySpec = new SecretKeySpec(aesKey.getBytes(StandardCharsets.UTF_8), "AES");
+            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH_BITS, nonceBytes);
+
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmParameterSpec);
+
+            byte[] decryptedBytes = cipher.doFinal(cipherText);
+
+            String decryptedId = new String(decryptedBytes, StandardCharsets.UTF_8);
+            return decryptedId.equals(originalId);
+        } catch (Exception e) {
+            logger.error("Failed to verify KN_VERIFY_CORRELATION_ID", e);
+            return false;
+        }
+    }
+}

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/CeSqlFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/CeSqlFilterTest.java
@@ -16,18 +16,45 @@
 package dev.knative.eventing.kafka.broker.core.filter.subscriptionsapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class CeSqlFilterTest {
+
+    private static final String SYSTEM_NAMESPACE = "knative-eventing";
+    private static final String SECRET_NAME = "test-secret";
+    private static final String RESOURCE_NAME = "test-resource";
+    private static final String RESOURCE_NAMESPACE = "test-namespace";
+    private static final String AES_KEY = "passphrasewhichneedstobe32bytes!"; // 32 bytes for AES-256
+    private static final int GCM_NONCE_LENGTH_BYTES = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
 
     static final CloudEvent event = CloudEventBuilder.v1()
             .withId("123-42")
@@ -54,5 +81,107 @@ public class CeSqlFilterTest {
                 Arguments.of(event, "1", true),
                 Arguments.of(event, "id LIKE '123%'", true),
                 Arguments.of(event, "NOT(id LIKE '123%')", false));
+    }
+
+    @BeforeAll
+    static void setupCesqlRuntime() {
+        Vertx vertx = mock(Vertx.class);
+        KubernetesClient kubernetesClient = mock(KubernetesClient.class);
+        MixedOperation secretsOperation = mock(MixedOperation.class);
+        NonNamespaceOperation namespacedSecretsOperation = mock(NonNamespaceOperation.class);
+        Resource<Secret> secretResource = mock(Resource.class);
+        when(kubernetesClient.secrets()).thenReturn(secretsOperation);
+        when(secretsOperation.inNamespace(SYSTEM_NAMESPACE)).thenReturn(namespacedSecretsOperation);
+        when(namespacedSecretsOperation.withName(SECRET_NAME)).thenReturn(secretResource);
+        Map<String, String> secretData = new HashMap<>();
+        secretData.put(RESOURCE_NAMESPACE + "." + RESOURCE_NAME + ".key", AES_KEY);
+
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                .withName(SECRET_NAME)
+                .withNamespace(SYSTEM_NAMESPACE)
+                .endMetadata()
+                .withData(secretData)
+                .build();
+
+        when(secretResource.get()).thenReturn(secret);
+
+        // Register the function
+        CeSqlRuntimeManager.getInstance().registerKnVerifyCorrelationId(vertx, kubernetesClient, SYSTEM_NAMESPACE);
+    }
+
+    @Test
+    void testKnVerifyCorrelationIdFunctionRegistration() throws Exception {
+        // Create test data
+        String originalId = "test-correlation-id";
+        int podIdx = 1;
+        int replicaCount = 3;
+        String encryptedData = encryptData(originalId, AES_KEY);
+        String replyId = originalId + ":" + encryptedData + ":" + podIdx;
+
+        // Create a CloudEvent with the reply ID as an extension
+        CloudEvent testEvent = CloudEventBuilder.v1()
+                .withId("test-id")
+                .withSource(URI.create("/test"))
+                .withType("test.type")
+                .withExtension("knativereplyid", replyId)
+                .build();
+
+        // Test the function through CeSql filter - should return true for correct pod index
+        String expression = String.format(
+                "KN_VERIFY_CORRELATION_ID(knativereplyid, '%s', '%s', '%s', %d, %d)",
+                RESOURCE_NAME, RESOURCE_NAMESPACE, SECRET_NAME, podIdx, replicaCount);
+
+        CeSqlFilter filter = new CeSqlFilter(expression);
+        boolean result = filter.test(testEvent);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void testKnVerifyCorrelationIdFunctionWithWrongPodIndex() throws Exception {
+        // Create test data with wrong pod index
+        String originalId = "test-correlation-id";
+        int actualPodIdx = 2;
+        int expectedPodIdx = 1; // Different from actual
+        int replicaCount = 3;
+        String encryptedData = encryptData(originalId, AES_KEY);
+        String replyId = originalId + ":" + encryptedData + ":" + actualPodIdx;
+
+        // Create a CloudEvent with the reply ID as an extension
+        CloudEvent testEvent = CloudEventBuilder.v1()
+                .withId("test-id")
+                .withSource(URI.create("/test"))
+                .withType("test.type")
+                .withExtension("knativereplyid", replyId)
+                .build();
+
+        // Test the function through CeSql filter - should return false for wrong pod index
+        String expression = String.format(
+                "KN_VERIFY_CORRELATION_ID(knativereplyid, '%s', '%s', '%s', %d, %d)",
+                RESOURCE_NAME, RESOURCE_NAMESPACE, SECRET_NAME, expectedPodIdx, replicaCount);
+
+        CeSqlFilter filter = new CeSqlFilter(expression);
+        boolean result = filter.test(testEvent);
+
+        assertThat(result).isFalse();
+    }
+
+    private String encryptData(String data, String key) throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
+
+        byte[] nonce = new byte[GCM_NONCE_LENGTH_BYTES];
+        Arrays.fill(nonce, (byte) 0x01);
+
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH_BITS, nonce);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmParameterSpec);
+
+        byte[] encryptedBytes = cipher.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        byte[] result = new byte[nonce.length + encryptedBytes.length];
+        System.arraycopy(nonce, 0, result, 0, nonce.length);
+        System.arraycopy(encryptedBytes, 0, result, nonce.length, encryptedBytes.length);
+
+        return Base64.getEncoder().encodeToString(result);
     }
 }

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/KnVerifyCorrelationIdTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/KnVerifyCorrelationIdTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.core.filter.subscriptionsapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.sql.EvaluationContext;
+import io.cloudevents.sql.EvaluationRuntime;
+import io.cloudevents.sql.Type;
+import io.cloudevents.sql.impl.ExceptionFactoryImpl;
+import io.cloudevents.sql.impl.runtime.EvaluationContextImpl;
+import io.cloudevents.sql.impl.runtime.EvaluationResult;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.antlr.v4.runtime.misc.Interval;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class KnVerifyCorrelationIdTest {
+
+    private static final String SYSTEM_NAMESPACE = "knative-eventing";
+    private static final String SECRET_NAME = "test-secret";
+    private static final String RESOURCE_NAME = "test-resource";
+    private static final String RESOURCE_NAMESPACE = "test-namespace";
+    private static final String AES_KEY = "passphrasewhichneedstobe32bytes!"; // 32 bytes for AES-256
+    private static final String OTHER_KEY = "passphrasewhichneedstobe32bytes?"; // 32 bytes for AES-256
+    private static final int GCM_NONCE_LENGTH_BYTES = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+
+    @Mock
+    private Vertx vertx;
+
+    @Mock
+    private KubernetesClient kubernetesClient;
+
+    @Mock
+    private MixedOperation secretsOperation;
+
+    @Mock
+    private NonNamespaceOperation namespacedSecretsOperation;
+
+    @Mock
+    private Resource<Secret> secretResource;
+
+    private KnVerifyCorrelationId function;
+    private EvaluationContext evaluationContext;
+    private EvaluationRuntime evaluationRuntime;
+    private CloudEvent cloudEvent;
+
+    @BeforeEach
+    void setUp() {
+        function = new KnVerifyCorrelationId(vertx, kubernetesClient, SYSTEM_NAMESPACE);
+        evaluationContext = new EvaluationContextImpl(new Interval(0, 10), "test", new ExceptionFactoryImpl(true));
+        evaluationRuntime = mock(EvaluationRuntime.class);
+        cloudEvent = CloudEventBuilder.v1()
+                .withId("test-id")
+                .withSource(URI.create("/test"))
+                .withType("test.type")
+                .build();
+
+        // Set up basic mocking structure - will be configured per test as needed
+        when(kubernetesClient.secrets()).thenReturn(secretsOperation);
+        when(secretsOperation.inNamespace(SYSTEM_NAMESPACE)).thenReturn(namespacedSecretsOperation);
+        when(namespacedSecretsOperation.withName(SECRET_NAME)).thenReturn(secretResource);
+    }
+
+    @Test
+    void testValidReplyIdWithCorrectPodIndex() throws Exception {
+        String originalId = "test-correlation-id";
+        int podIdx = 1;
+        int replicaCount = 3;
+        String encryptedData = encryptData(originalId, AES_KEY);
+        String replyId = originalId + ":" + encryptedData + ":" + podIdx;
+
+        Map<String, String> secretData = new HashMap<>();
+        secretData.put(RESOURCE_NAMESPACE + "." + RESOURCE_NAME + ".key", AES_KEY);
+
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                .withName(SECRET_NAME)
+                .withNamespace(SYSTEM_NAMESPACE)
+                .endMetadata()
+                .withData(secretData)
+                .build();
+
+        when(secretResource.get()).thenReturn(secret);
+
+        List<Object> arguments =
+                Arrays.asList(replyId, RESOURCE_NAME, RESOURCE_NAMESPACE, SECRET_NAME, podIdx, replicaCount);
+
+        EvaluationResult result = function.invoke(evaluationContext, evaluationRuntime, cloudEvent, arguments);
+
+        assertThat(result.value()).isEqualTo(true);
+    }
+
+    @Test
+    void testValidReplyIdWithIncorrectPodIndex() throws Exception {
+        String originalId = "test-correlation-id";
+        int actualPodIdx = 2;
+        int expectedPodIdx = 1;
+        int replicaCount = 3;
+        String encryptedData = encryptData(originalId, AES_KEY);
+        String replyId = originalId + ":" + encryptedData + ":" + actualPodIdx;
+
+        Map<String, String> secretData = new HashMap<>();
+        secretData.put(RESOURCE_NAMESPACE + "." + RESOURCE_NAME + ".key", AES_KEY);
+
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                .withName(SECRET_NAME)
+                .withNamespace(SYSTEM_NAMESPACE)
+                .endMetadata()
+                .withData(secretData)
+                .build();
+
+        when(secretResource.get()).thenReturn(secret);
+
+        List<Object> arguments =
+                Arrays.asList(replyId, RESOURCE_NAME, RESOURCE_NAMESPACE, SECRET_NAME, expectedPodIdx, replicaCount);
+
+        EvaluationResult result = function.invoke(evaluationContext, evaluationRuntime, cloudEvent, arguments);
+
+        assertThat(result.value()).isEqualTo(false);
+    }
+
+    @Test
+    void testInvalidReplyIdFormat() {
+        String invalidReplyId = "invalid-format";
+        int podIdx = 1;
+        int replicaCount = 3;
+
+        List<Object> arguments =
+                Arrays.asList(invalidReplyId, RESOURCE_NAME, RESOURCE_NAMESPACE, SECRET_NAME, podIdx, replicaCount);
+
+        // This should throw an EvaluationException due to invalid format
+        assertThatThrownBy(() -> function.invoke(evaluationContext, evaluationRuntime, cloudEvent, arguments))
+                .isInstanceOf(io.cloudevents.sql.EvaluationException.class)
+                .hasMessageContaining("invalid reply id");
+    }
+
+    @Test
+    void testNoMatchingSecretKey() throws Exception {
+        String originalId = "test-correlation-id";
+        int podIdx = 1;
+        int replicaCount = 3;
+        String encryptedData = encryptData(originalId, AES_KEY);
+        String replyId = originalId + ":" + encryptedData + ":" + podIdx;
+
+        Map<String, String> secretData = new HashMap<>();
+        secretData.put("other.resource.key", AES_KEY);
+
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                .withName(SECRET_NAME)
+                .withNamespace(SYSTEM_NAMESPACE)
+                .endMetadata()
+                .withData(secretData)
+                .build();
+
+        when(secretResource.get()).thenReturn(secret);
+
+        List<Object> arguments =
+                Arrays.asList(replyId, RESOURCE_NAME, RESOURCE_NAMESPACE, SECRET_NAME, podIdx, replicaCount);
+
+        EvaluationResult result = function.invoke(evaluationContext, evaluationRuntime, cloudEvent, arguments);
+
+        assertThat(result.value()).isEqualTo(false);
+    }
+
+    @Test
+    void testWrongEncryptionKey() throws Exception {
+        String originalId = "test-correlation-id";
+        int podIdx = 1;
+        int replicaCount = 3;
+        String encryptedData = encryptData(originalId, AES_KEY);
+        String replyId = originalId + ":" + encryptedData + ":" + podIdx;
+
+        Map<String, String> secretData = new HashMap<>();
+        secretData.put(RESOURCE_NAMESPACE + "." + RESOURCE_NAME + ".key", OTHER_KEY);
+
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                .withName(SECRET_NAME)
+                .withNamespace(SYSTEM_NAMESPACE)
+                .endMetadata()
+                .withData(secretData)
+                .build();
+
+        when(secretResource.get()).thenReturn(secret);
+
+        List<Object> arguments =
+                Arrays.asList(replyId, RESOURCE_NAME, RESOURCE_NAMESPACE, SECRET_NAME, podIdx, replicaCount);
+
+        EvaluationResult result = function.invoke(evaluationContext, evaluationRuntime, cloudEvent, arguments);
+
+        assertThat(result.value()).isEqualTo(false);
+    }
+
+    @Test
+    void testFunctionMetadata() {
+        assertThat(function.name()).isEqualTo("KN_VERIFY_CORRELATION_ID");
+        assertThat(function.arity()).isEqualTo(6);
+        assertThat(function.isVariadic()).isFalse();
+        assertThat(function.returnType()).isEqualTo(Type.BOOLEAN);
+
+        assertThat(function.typeOfParameter(0)).isEqualTo(Type.STRING);
+        assertThat(function.typeOfParameter(1)).isEqualTo(Type.STRING);
+        assertThat(function.typeOfParameter(2)).isEqualTo(Type.STRING);
+        assertThat(function.typeOfParameter(3)).isEqualTo(Type.STRING);
+        assertThat(function.typeOfParameter(4)).isEqualTo(Type.INTEGER);
+        assertThat(function.typeOfParameter(5)).isEqualTo(Type.INTEGER);
+    }
+
+    @Test
+    void testInvalidParameterIndex() {
+        assertThatThrownBy(() -> function.typeOfParameter(6))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid parameter index");
+        assertThatThrownBy(() -> function.typeOfParameter(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid parameter index");
+    }
+
+    private String encryptData(String data, String key) throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
+
+        byte[] nonce = new byte[GCM_NONCE_LENGTH_BYTES];
+        Arrays.fill(nonce, (byte) 0x01);
+
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH_BITS, nonce);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmParameterSpec);
+
+        byte[] encryptedBytes = cipher.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        byte[] result = new byte[nonce.length + encryptedBytes.length];
+        System.arraycopy(nonce, 0, result, 0, nonce.length);
+        System.arraycopy(encryptedBytes, 0, result, nonce.length, encryptedBytes.length);
+
+        return Base64.getEncoder().encodeToString(result);
+    }
+}

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/DispatcherEnv.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/DispatcherEnv.java
@@ -31,12 +31,16 @@ public class DispatcherEnv extends BaseEnv {
     public static final String EGRESSES_INITIAL_CAPACITY = "EGRESSES_INITIAL_CAPACITY";
     private final int egressesInitialCapacity;
 
+    public static final String SERVICE_NAMESPACE = "SERVICE_NAMESPACE";
+    private final String serviceNamespace;
+
     public DispatcherEnv(Function<String, String> envProvider) {
         super(envProvider);
 
         this.consumerConfigFilePath = requireNonNull(envProvider.apply(CONSUMER_CONFIG_FILE_PATH));
         this.webClientConfigFilePath = requireNonNull(envProvider.apply(WEBCLIENT_CONFIG_FILE_PATH));
         this.egressesInitialCapacity = Integer.parseInt(requireNonNull(envProvider.apply(EGRESSES_INITIAL_CAPACITY)));
+        this.serviceNamespace = requireNonNull(envProvider.apply(SERVICE_NAMESPACE));
     }
 
     public String getConsumerConfigFilePath() {
@@ -49,6 +53,10 @@ public class DispatcherEnv extends BaseEnv {
 
     public int getEgressesInitialCapacity() {
         return egressesInitialCapacity;
+    }
+
+    public String getServiceNamespace() {
+        return serviceNamespace;
     }
 
     @Override

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
@@ -26,6 +26,8 @@ import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeCreator;
 import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeCreatorImpl;
 import dev.knative.eventing.kafka.broker.core.eventtype.EventTypeListerFactory;
 import dev.knative.eventing.kafka.broker.core.file.FileWatcher;
+import dev.knative.eventing.kafka.broker.core.filter.subscriptionsapi.CeSqlRuntimeManager;
+import dev.knative.eventing.kafka.broker.core.filter.subscriptionsapi.KnVerifyCorrelationId;
 import dev.knative.eventing.kafka.broker.core.observability.ObservabilityConfig;
 import dev.knative.eventing.kafka.broker.core.observability.metrics.Metrics;
 import dev.knative.eventing.kafka.broker.core.observability.tracing.TracingProvider;
@@ -125,6 +127,9 @@ public class Main {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
+
+        CeSqlRuntimeManager.getInstance()
+                .registerFunction(new KnVerifyCorrelationId(vertx, kubernetesClient, env.getServiceNamespace()));
 
         final var eventTypeListerFactory = new EventTypeListerFactory(eventTypeClient);
 


### PR DESCRIPTION
Note that the tests were added with the help of Claude Code.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This adds the `KN_VERIFY_CORRELATION_ID` CESQL function so that the RequestReply resource will work with EKB

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add KN_VERIFY_CORRELATION_ID CESQL function
- Create CesqlRuntimeManager class so that we can manage/register functions to the CESQL runtime, instead of using the default runtime.
