### PR TITLE
Add volume template to kafka-*-dispatcher statefulsets for contract-resources volume 

### DIFF
--- a/data-plane/config/broker/500-dispatcher.yaml
+++ b/data-plane/config/broker/500-dispatcher.yaml
@@ -171,6 +171,9 @@ spec:
         - name: config-observability
           configMap:
             name: config-observability
+        - name: contract-resources
+          # only a placeholder. Will be replaced later by our pod defaulting webhook
+          emptyDir: {}
       restartPolicy: Always
       dnsConfig:
         options:

--- a/data-plane/config/channel/500-dispatcher.yaml
+++ b/data-plane/config/channel/500-dispatcher.yaml
@@ -171,6 +171,9 @@ spec:
         - name: config-observability
           configMap:
             name: config-observability
+        - name: contract-resources
+          # only a placeholder. Will be replaced later by our pod defaulting webhook
+          emptyDir: {}
       restartPolicy: Always
       dnsConfig:
         options:

--- a/data-plane/config/source/500-dispatcher.yaml
+++ b/data-plane/config/source/500-dispatcher.yaml
@@ -171,6 +171,9 @@ spec:
         - name: config-observability
           configMap:
             name: config-observability
+        - name: contract-resources
+          # only a placeholder. Will be replaced later by our pod defaulting webhook
+          emptyDir: {}
       restartPolicy: Always
       dnsConfig:
         options:


### PR DESCRIPTION
Fixes #4545

## Proposed Changes

- :bug: adding a volume placeholder in the statefulset for the contract-resources volume. The volumes will later be adjusted by the [pod defaulting webhook](https://github.com/knative-extensions/eventing-kafka-broker/blob/4f1d472577fc317aa35b6d8170a422468c14bfc6/control-plane/pkg/apis/core/pod_defaulting.go#L45)

**Release Note**
```release-note
Add placeholder for contract-resources volume to make k8s validation webhook happy
```