### PR TITLE
Fix: don't publish pod annotation update failure events.

### DIFF
--- a/control-plane/pkg/reconciler/base/receiver_condition_set.go
+++ b/control-plane/pkg/reconciler/base/receiver_condition_set.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/url"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/apis"
@@ -214,20 +213,6 @@ func (manager *StatusConditionManager) Addressable(address *url.URL) {
 		}})
 	manager.Object.GetConditionSet().Manage(manager.Object.GetStatus()).MarkTrue(ConditionAddressable)
 	manager.ProbesStatusReady()
-}
-
-func (manager *StatusConditionManager) FailedToUpdateDispatcherPodsAnnotation(err error) {
-
-	// We don't set status conditions for dispatcher pods updates.
-
-	// Record the event.
-	manager.Recorder.Eventf(
-		manager.Object,
-		corev1.EventTypeWarning,
-		"failed to update dispatcher pods annotation",
-		"%v",
-		err,
-	)
 }
 
 func (manager *StatusConditionManager) FailedToUpdateReceiverPodsAnnotation(err error) reconciler.Event {

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -247,8 +247,6 @@ func (r *Reconciler) reconcileKind(ctx context.Context, broker *eventing.Broker)
 			"Failed to update dispatcher pod annotation to trigger an immediate config map refresh",
 			zap.Error(err),
 		)
-
-		statusConditionManager.FailedToUpdateDispatcherPodsAnnotation(err)
 	} else {
 		logger.Debug("Updated dispatcher pod annotation")
 	}

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -206,8 +206,6 @@ func (r *Reconciler) reconcileKind(ctx context.Context, trigger *eventing.Trigge
 			"Failed to update dispatcher pod annotation to trigger an immediate config map refresh",
 			zap.Error(err),
 		)
-
-		statusConditionManager.failedToUpdateDispatcherPodsAnnotation(err)
 	} else {
 		logger.Debug("Updated dispatcher pod annotation")
 	}

--- a/control-plane/pkg/reconciler/trigger/trigger_lifecycle.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_lifecycle.go
@@ -109,20 +109,6 @@ func (m *statusConditionManager) failedToResolveTriggerConfig(err error) reconci
 	return fmt.Errorf("failed to resolve trigger config: %w", err)
 }
 
-func (m *statusConditionManager) failedToUpdateDispatcherPodsAnnotation(err error) {
-
-	// We don't set status conditions for dispatcher pods updates.
-
-	// Record the event.
-	m.Recorder.Eventf(
-		m.Trigger,
-		corev1.EventTypeWarning,
-		"Failed to update dispatcher pods annotation",
-		"%v",
-		err,
-	)
-}
-
 func (m *statusConditionManager) subscriberResolved(egress *contract.Egress) {
 	m.Trigger.GetConditionSet().Manage(&m.Trigger.Status).MarkTrueWithReason(
 		eventing.TriggerConditionSubscriberResolved,


### PR DESCRIPTION
Any kind of `Operation cannot be fulfilled on ...: the object has been modified; please apply your changes to the latest version and try again` errors are "normal" with knative controllers. To avoid the errors piling up in the Broker event section the exposure of those events was removed.

The warnings remain visible in the controller logs.

Fixes #4505

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :bug:  Remove `FailedToUpdateDispatcherPodsAnnotation` from `broker.go` and `reciever_condition_set.go`.
- :bug:  Remove `failedToUpdateDispatcherPodsAnnotation` from `trigger.go` and `trigger_lifecycle.go`.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

```release-note
No warnings are listed in the Broker "Events" section when the Kafka controller is restarted and fails to update the dispatcher pod annotations
```

