### PR TITLE
Fix ignored `DISPATCHERS_MIN_REPLICAS` environment variable.

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/controller.go
+++ b/control-plane/pkg/reconciler/consumergroup/controller.go
@@ -373,6 +373,7 @@ func createKafkaScheduler(ctx context.Context, c SchedulerConfig, ssName string,
 			StatefulSetName: ssName,
 			RefreshPeriod:   c.RefreshPeriod,
 			Capacity:        c.Capacity,
+			MinReplicas:     c.MinReplicas,
 		},
 		func() ([]scheduler.VPod, error) {
 			consumerGroups, err := lister.List(labels.SelectorFromSet(getSelectorLabel(ssName)))
@@ -390,20 +391,19 @@ func createKafkaScheduler(ctx context.Context, c SchedulerConfig, ssName string,
 }
 
 func getSelectorLabel(ssName string) map[string]string {
-	//TODO remove hardcoded kinds
 	var selectorLabel map[string]string
 	switch ssName {
 	case kafkainternals.SourceStatefulSetName:
 		selectorLabel = map[string]string{
-			kafkainternals.UserFacingResourceLabelSelector: "kafkasource",
+			kafkainternals.UserFacingResourceLabelSelector: KafkaSourceScheduler,
 		}
 	case kafkainternals.BrokerStatefulSetName:
 		selectorLabel = map[string]string{
-			kafkainternals.UserFacingResourceLabelSelector: "trigger",
+			kafkainternals.UserFacingResourceLabelSelector: KafkaTriggerScheduler,
 		}
 	case kafkainternals.ChannelStatefulSetName:
 		selectorLabel = map[string]string{
-			kafkainternals.UserFacingResourceLabelSelector: "kafkachannel",
+			kafkainternals.UserFacingResourceLabelSelector: KafkaChannelScheduler,
 		}
 	}
 	return selectorLabel


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #4542.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add `MinReplicas` to copied config in `createKafkaScheduler`.
- Cover bug with test.
- Extract duplicated test setup code into function and replace.
- Remove `// Todo ...` => replace strings with existing constants.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The DISPATCHERS_MIN_REPLICAS environment variable can now be used to control the dispatcher replicas
```
