### PR TITLE
KEDA auth using externally managed TriggerAuthentication resource

### DIFF
--- a/control-plane/pkg/autoscaler/autoscaler_api.go
+++ b/control-plane/pkg/autoscaler/autoscaler_api.go
@@ -49,6 +49,19 @@ const (
 	// current consumer group that's used for activation (0<->1)
 	AutoscalingActivationLagThreshold = Autoscaling + "/activation-lag-threshold"
 
+	// AutoscalingAuthenticationName is the annotation that refers to the name of the TriggerAuthentication
+	// or ClusterTriggerAuthentication that's used to authenticate the ScaledObject.
+	AutoscalingAuthenticationName = Autoscaling + "/authentication-name"
+
+	// AutoscalingAuthenticationKind is the annotation that refers to the kind of the TriggerAuthentication
+	// or ClusterTriggerAuthentication that's used to authenticate the ScaledObject.
+	AutoscalingAuthenticationKind = Autoscaling + "/authentication-kind"
+
+	// AutoscalingAwsRegion is the annotation that refers to the AWS region of the MSK cluster.
+	// KEDA requires this to be set when using AWS IAM authentication as an explicit property
+	// in the trigger.metadata section.
+	AutoscalingAwsRegion = Autoscaling + "/aws-region"
+
 	// DefaultPollingInterval is the default value for AutoscalingPollingIntervalAnnotation.
 	DefaultPollingInterval = 10
 	// DefaultCooldownPeriod is the default value for AutoscalingCooldownPeriodAnnotation.
@@ -59,4 +72,10 @@ const (
 	DefaultMaxReplicaCount = 50
 	// DefaultLagThreshold is the default value for AutoscalingLagThreshold.
 	DefaultLagThreshold = 100
+	// DefaultAuthenticationName is the default value for AutoscalingAuthenticationName.
+	DefaultAuthenticationName = ""
+	// DefaultAuthenticationKind is the default value for AutoscalingAuthenticationKind.
+	DefaultAuthenticationKind = ""
+	// DefaultAwsRegion is the default value for AutoscalingAwsRegion.
+	DefaultAwsRegion = ""
 )

--- a/control-plane/pkg/autoscaler/config.go
+++ b/control-plane/pkg/autoscaler/config.go
@@ -23,8 +23,9 @@ import (
 
 // AutoscalerConfig contains the defaults defined in the autoscaler ConfigMap.
 type AutoscalerConfig struct {
-	AutoscalerClass    map[string]string
-	AutoscalerDefaults map[string]int32
+	AutoscalerClass          map[string]string
+	AutoscalerDefaults       map[string]int32
+	AutoscalerAuthentication map[string]string
 }
 
 func defaultConfig() *AutoscalerConfig {
@@ -38,6 +39,11 @@ func defaultConfig() *AutoscalerConfig {
 			AutoscalingPollingIntervalAnnotation: DefaultPollingInterval,
 			AutoscalingCooldownPeriodAnnotation:  DefaultCooldownPeriod,
 			AutoscalingLagThreshold:              DefaultLagThreshold,
+		},
+		AutoscalerAuthentication: map[string]string{
+			AutoscalingAuthenticationName: DefaultAuthenticationName,
+			AutoscalingAuthenticationKind: DefaultAuthenticationKind,
+			AutoscalingAwsRegion:          DefaultAwsRegion,
 		},
 	}
 }
@@ -53,9 +59,12 @@ func NewConfigFromMap(data map[string]string) (*AutoscalerConfig, error) {
 	for key, val := range data {
 		key = convertConfigKeyToAutoscalingAnnotation(key)
 
-		if key == AutoscalingClassAnnotation {
+		switch key {
+		case AutoscalingClassAnnotation:
 			ac.AutoscalerClass[AutoscalingClassAnnotation] = val
-		} else {
+		case AutoscalingAuthenticationName, AutoscalingAuthenticationKind, AutoscalingAwsRegion:
+			ac.AutoscalerAuthentication[key] = val
+		default:
 			i, err := strconv.ParseInt(val, 10, 32)
 			if err != nil {
 				return nil, fmt.Errorf("Expected value for autoscaling annotation: "+key+" should be integer but got "+val, err)

--- a/control-plane/pkg/autoscaler/config_test.go
+++ b/control-plane/pkg/autoscaler/config_test.go
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2025 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package autoscaler
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	config := defaultConfig()
+
+	// Test AutoscalerClass defaults
+	expectedClass := map[string]string{
+		AutoscalingClassAnnotation: AutoscalingClassDisabledAnnotationValue,
+	}
+	if !reflect.DeepEqual(config.AutoscalerClass, expectedClass) {
+		t.Errorf("Expected AutoscalerClass %v, got %v", expectedClass, config.AutoscalerClass)
+	}
+
+	// Test AutoscalerDefaults
+	expectedDefaults := map[string]int32{
+		AutoscalingMinScaleAnnotation:        DefaultMinReplicaCount,
+		AutoscalingMaxScaleAnnotation:        DefaultMaxReplicaCount,
+		AutoscalingPollingIntervalAnnotation: DefaultPollingInterval,
+		AutoscalingCooldownPeriodAnnotation:  DefaultCooldownPeriod,
+		AutoscalingLagThreshold:              DefaultLagThreshold,
+	}
+	if !reflect.DeepEqual(config.AutoscalerDefaults, expectedDefaults) {
+		t.Errorf("Expected AutoscalerDefaults %v, got %v", expectedDefaults, config.AutoscalerDefaults)
+	}
+
+	// Test AutoscalerAuthentication defaults
+	expectedAuth := map[string]string{
+		AutoscalingAuthenticationName: DefaultAuthenticationName,
+		AutoscalingAuthenticationKind: DefaultAuthenticationKind,
+		AutoscalingAwsRegion:          DefaultAwsRegion,
+	}
+	if !reflect.DeepEqual(config.AutoscalerAuthentication, expectedAuth) {
+		t.Errorf("Expected AutoscalerAuthentication %v, got %v", expectedAuth, config.AutoscalerAuthentication)
+	}
+}
+
+func TestNewConfigFromMap_EmptyMap(t *testing.T) {
+	config, err := NewConfigFromMap(map[string]string{})
+	if err != nil {
+		t.Errorf("Expected no error for empty map, got %v", err)
+	}
+
+	// Should return default config
+	expectedConfig := defaultConfig()
+	if !reflect.DeepEqual(config, expectedConfig) {
+		t.Errorf("Expected default config for empty map, got %v", config)
+	}
+}
+
+func TestNewConfigFromMap_DisabledClass(t *testing.T) {
+	data := map[string]string{
+		"class":            "disabled",
+		"min-scale":        "5",
+		"max-scale":        "100",
+		"polling-interval": "20",
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error for disabled class, got %v", err)
+	}
+
+	// When class is disabled, should return default config and ignore other values
+	expectedConfig := defaultConfig()
+	if !reflect.DeepEqual(config, expectedConfig) {
+		t.Errorf("Expected default config for disabled class, got %v", config)
+	}
+}
+
+func TestNewConfigFromMap_ValidIntegerValues(t *testing.T) {
+	data := map[string]string{
+		"class":            "keda",
+		"min-scale":        "2",
+		"max-scale":        "20",
+		"polling-interval": "15",
+		"cooldown-period":  "45",
+		"lag-threshold":    "200",
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error for valid config, got %v", err)
+	}
+
+	// Test class annotation
+	expectedClass := "keda"
+	if config.AutoscalerClass[AutoscalingClassAnnotation] != expectedClass {
+		t.Errorf("Expected class %s, got %s", expectedClass, config.AutoscalerClass[AutoscalingClassAnnotation])
+	}
+
+	// Test integer values
+	expectedValues := map[string]int32{
+		AutoscalingMinScaleAnnotation:        2,
+		AutoscalingMaxScaleAnnotation:        20,
+		AutoscalingPollingIntervalAnnotation: 15,
+		AutoscalingCooldownPeriodAnnotation:  45,
+		AutoscalingLagThreshold:              200,
+	}
+
+	for key, expected := range expectedValues {
+		if config.AutoscalerDefaults[key] != expected {
+			t.Errorf("Expected %s = %d, got %d", key, expected, config.AutoscalerDefaults[key])
+		}
+	}
+}
+
+func TestNewConfigFromMap_AuthenticationValues(t *testing.T) {
+	data := map[string]string{
+		"authentication-name": "my-auth",
+		"authentication-kind": "TriggerAuthentication",
+		"aws-region":          "us-west-2",
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error for authentication config, got %v", err)
+	}
+
+	expectedAuth := map[string]string{
+		AutoscalingAuthenticationName: "my-auth",
+		AutoscalingAuthenticationKind: "TriggerAuthentication",
+		AutoscalingAwsRegion:          "us-west-2",
+	}
+
+	for key, expected := range expectedAuth {
+		if config.AutoscalerAuthentication[key] != expected {
+			t.Errorf("Expected %s = %s, got %s", key, expected, config.AutoscalerAuthentication[key])
+		}
+	}
+}
+
+func TestNewConfigFromMap_MixedValues(t *testing.T) {
+	data := map[string]string{
+		"class":               "keda",
+		"min-scale":           "1",
+		"max-scale":           "10",
+		"authentication-name": "kafka-auth",
+		"authentication-kind": "ClusterTriggerAuthentication",
+		"aws-region":          "eu-central-1",
+		"polling-interval":    "5",
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error for mixed config, got %v", err)
+	}
+
+	// Verify class
+	if config.AutoscalerClass[AutoscalingClassAnnotation] != "keda" {
+		t.Errorf("Expected class keda, got %s", config.AutoscalerClass[AutoscalingClassAnnotation])
+	}
+
+	// Verify integer defaults
+	if config.AutoscalerDefaults[AutoscalingMinScaleAnnotation] != 1 {
+		t.Errorf("Expected min-scale 1, got %d", config.AutoscalerDefaults[AutoscalingMinScaleAnnotation])
+	}
+	if config.AutoscalerDefaults[AutoscalingMaxScaleAnnotation] != 10 {
+		t.Errorf("Expected max-scale 10, got %d", config.AutoscalerDefaults[AutoscalingMaxScaleAnnotation])
+	}
+	if config.AutoscalerDefaults[AutoscalingPollingIntervalAnnotation] != 5 {
+		t.Errorf("Expected polling-interval 5, got %d", config.AutoscalerDefaults[AutoscalingPollingIntervalAnnotation])
+	}
+
+	// Verify authentication
+	if config.AutoscalerAuthentication[AutoscalingAuthenticationName] != "kafka-auth" {
+		t.Errorf("Expected authentication-name kafka-auth, got %s", config.AutoscalerAuthentication[AutoscalingAuthenticationName])
+	}
+	if config.AutoscalerAuthentication[AutoscalingAuthenticationKind] != "ClusterTriggerAuthentication" {
+		t.Errorf("Expected authentication-kind ClusterTriggerAuthentication, got %s", config.AutoscalerAuthentication[AutoscalingAuthenticationKind])
+	}
+	if config.AutoscalerAuthentication[AutoscalingAwsRegion] != "eu-central-1" {
+		t.Errorf("Expected aws-region eu-central-1, got %s", config.AutoscalerAuthentication[AutoscalingAwsRegion])
+	}
+}
+
+func TestNewConfigFromMap_InvalidIntegerValue(t *testing.T) {
+	data := map[string]string{
+		"min-scale": "invalid",
+	}
+
+	_, err := NewConfigFromMap(data)
+	if err == nil {
+		t.Error("Expected error for invalid integer value, got nil")
+	}
+
+	// Error should not be empty
+	if err != nil && err.Error() == "" {
+		t.Error("Error message should not be empty")
+	}
+}
+
+func TestNewConfigFromMap_NegativeIntegerValue(t *testing.T) {
+	data := map[string]string{
+		"min-scale": "-5",
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error for negative integer, got %v", err)
+	}
+
+	// Should accept negative values as they are valid int32
+	if config.AutoscalerDefaults[AutoscalingMinScaleAnnotation] != -5 {
+		t.Errorf("Expected min-scale -5, got %d", config.AutoscalerDefaults[AutoscalingMinScaleAnnotation])
+	}
+}
+
+func TestNewConfigFromMap_ZeroValues(t *testing.T) {
+	data := map[string]string{
+		"min-scale":        "0",
+		"max-scale":        "0",
+		"polling-interval": "0",
+		"cooldown-period":  "0",
+		"lag-threshold":    "0",
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error for zero values, got %v", err)
+	}
+
+	expectedValues := map[string]int32{
+		AutoscalingMinScaleAnnotation:        0,
+		AutoscalingMaxScaleAnnotation:        0,
+		AutoscalingPollingIntervalAnnotation: 0,
+		AutoscalingCooldownPeriodAnnotation:  0,
+		AutoscalingLagThreshold:              0,
+	}
+
+	for key, expected := range expectedValues {
+		if config.AutoscalerDefaults[key] != expected {
+			t.Errorf("Expected %s = %d, got %d", key, expected, config.AutoscalerDefaults[key])
+		}
+	}
+}
+
+func TestNewConfigFromMap_LargeIntegerValues(t *testing.T) {
+	data := map[string]string{
+		"max-scale": "2147483647", // Max int32 value
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error for max int32 value, got %v", err)
+	}
+
+	if config.AutoscalerDefaults[AutoscalingMaxScaleAnnotation] != 2147483647 {
+		t.Errorf("Expected max-scale 2147483647, got %d", config.AutoscalerDefaults[AutoscalingMaxScaleAnnotation])
+	}
+}
+
+func TestNewConfigFromMap_IntegerOverflow(t *testing.T) {
+	data := map[string]string{
+		"max-scale": "9223372036854775808", // Greater than max int64
+	}
+
+	_, err := NewConfigFromMap(data)
+	if err == nil {
+		t.Error("Expected error for integer overflow, got nil")
+	}
+}
+
+func TestNewConfigFromMap_UnknownKey(t *testing.T) {
+	data := map[string]string{
+		"unknown-key": "123",
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error for unknown key, got %v", err)
+	}
+
+	// Unknown keys should be treated as integer defaults
+	unknownAnnotation := convertConfigKeyToAutoscalingAnnotation("unknown-key")
+	if config.AutoscalerDefaults[unknownAnnotation] != 123 {
+		t.Errorf("Expected unknown-key to be stored as integer 123, got %d", config.AutoscalerDefaults[unknownAnnotation])
+	}
+}
+
+func TestNewConfigFromMap_EmptyStringValues(t *testing.T) {
+	data := map[string]string{
+		"authentication-name": "",
+		"authentication-kind": "",
+		"aws-region":          "",
+		"class":               "",
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error for empty string values, got %v", err)
+	}
+
+	// Empty strings should be accepted for authentication fields and class
+	if config.AutoscalerAuthentication[AutoscalingAuthenticationName] != "" {
+		t.Errorf("Expected empty authentication-name, got %s", config.AutoscalerAuthentication[AutoscalingAuthenticationName])
+	}
+	if config.AutoscalerAuthentication[AutoscalingAuthenticationKind] != "" {
+		t.Errorf("Expected empty authentication-kind, got %s", config.AutoscalerAuthentication[AutoscalingAuthenticationKind])
+	}
+	if config.AutoscalerAuthentication[AutoscalingAwsRegion] != "" {
+		t.Errorf("Expected empty aws-region, got %s", config.AutoscalerAuthentication[AutoscalingAwsRegion])
+	}
+	if config.AutoscalerClass[AutoscalingClassAnnotation] != "" {
+		t.Errorf("Expected empty class, got %s", config.AutoscalerClass[AutoscalingClassAnnotation])
+	}
+}
+
+func TestConvertConfigKeyToAutoscalingAnnotation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"class", "autoscaling.eventing.knative.dev/class"},
+		{"min-scale", "autoscaling.eventing.knative.dev/min-scale"},
+		{"max-scale", "autoscaling.eventing.knative.dev/max-scale"},
+		{"polling-interval", "autoscaling.eventing.knative.dev/polling-interval"},
+		{"cooldown-period", "autoscaling.eventing.knative.dev/cooldown-period"},
+		{"lag-threshold", "autoscaling.eventing.knative.dev/lag-threshold"},
+		{"authentication-name", "autoscaling.eventing.knative.dev/authentication-name"},
+		{"authentication-kind", "autoscaling.eventing.knative.dev/authentication-kind"},
+		{"aws-region", "autoscaling.eventing.knative.dev/aws-region"},
+		{"custom-key", "autoscaling.eventing.knative.dev/custom-key"},
+		{"", "autoscaling.eventing.knative.dev/"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result := convertConfigKeyToAutoscalingAnnotation(test.input)
+			if result != test.expected {
+				t.Errorf("Expected %s, got %s", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestNewConfigFromMap_PreservesUnmodifiedDefaults(t *testing.T) {
+	data := map[string]string{
+		"min-scale": "5",
+		// Only set min-scale, others should remain default
+	}
+
+	config, err := NewConfigFromMap(data)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Modified value
+	if config.AutoscalerDefaults[AutoscalingMinScaleAnnotation] != 5 {
+		t.Errorf("Expected min-scale 5, got %d", config.AutoscalerDefaults[AutoscalingMinScaleAnnotation])
+	}
+
+	// Unmodified defaults should remain
+	if config.AutoscalerDefaults[AutoscalingMaxScaleAnnotation] != DefaultMaxReplicaCount {
+		t.Errorf("Expected default max-scale %d, got %d", DefaultMaxReplicaCount, config.AutoscalerDefaults[AutoscalingMaxScaleAnnotation])
+	}
+	if config.AutoscalerDefaults[AutoscalingPollingIntervalAnnotation] != DefaultPollingInterval {
+		t.Errorf("Expected default polling-interval %d, got %d", DefaultPollingInterval, config.AutoscalerDefaults[AutoscalingPollingIntervalAnnotation])
+	}
+	if config.AutoscalerDefaults[AutoscalingCooldownPeriodAnnotation] != DefaultCooldownPeriod {
+		t.Errorf("Expected default cooldown-period %d, got %d", DefaultCooldownPeriod, config.AutoscalerDefaults[AutoscalingCooldownPeriodAnnotation])
+	}
+	if config.AutoscalerDefaults[AutoscalingLagThreshold] != DefaultLagThreshold {
+		t.Errorf("Expected default lag-threshold %d, got %d", DefaultLagThreshold, config.AutoscalerDefaults[AutoscalingLagThreshold])
+	}
+}

--- a/control-plane/pkg/autoscaler/keda/keda_test.go
+++ b/control-plane/pkg/autoscaler/keda/keda_test.go
@@ -1,0 +1,571 @@
+/*
+ * Copyright 2025 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keda
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+
+	kafkainternals "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internalskafkaeventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/autoscaler"
+	kedav1alpha1 "knative.dev/eventing-kafka-broker/third_party/pkg/apis/keda/v1alpha1"
+)
+
+// Helper function to create a base ConsumerGroup with default values
+func createTestConsumerGroup(name, namespace string, annotations map[string]string, topics []string) *kafkainternals.ConsumerGroup {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if topics == nil {
+		topics = []string{"test-topic"}
+	}
+
+	return &kafkainternals.ConsumerGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: kafkainternals.ConsumerGroupSpec{
+			Template: kafkainternals.ConsumerTemplateSpec{
+				Spec: kafkainternals.ConsumerSpec{
+					Topics: topics,
+					Configs: kafkainternals.ConsumerConfigs{
+						Configs: map[string]string{
+							"bootstrap.servers": "localhost:9092",
+							"group.id":          "test-group",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Helper function to create a ConsumerGroup with custom configs
+func createTestConsumerGroupWithConfigs(name, namespace string, annotations map[string]string, topics []string, configs map[string]string) *kafkainternals.ConsumerGroup {
+	cg := createTestConsumerGroup(name, namespace, annotations, topics)
+	cg.Spec.Template.Spec.Configs.Configs = configs
+	return cg
+}
+
+// Helper function to create a default autoscaler config
+func createDefaultAutoscalerConfig() autoscaler.AutoscalerConfig {
+	return autoscaler.AutoscalerConfig{
+		AutoscalerDefaults: map[string]int32{
+			autoscaler.AutoscalingLagThreshold: 100,
+		},
+		AutoscalerAuthentication: map[string]string{
+			autoscaler.AutoscalingAuthenticationName: "",
+			autoscaler.AutoscalingAuthenticationKind: "",
+			autoscaler.AutoscalingAwsRegion:          "",
+		},
+	}
+}
+
+// Helper function to create expected trigger with default metadata
+func createExpectedTrigger(topic string, metadata map[string]string, authRef *kedav1alpha1.ScaledObjectAuthRef) kedav1alpha1.ScaleTriggers {
+	defaultMetadata := map[string]string{
+		"bootstrapServers":   "localhost:9092",
+		"consumerGroup":      "test-group",
+		"topic":              topic,
+		"lagThreshold":       "100",
+		"allowIdleConsumers": "false",
+	}
+
+	// Merge custom metadata with defaults
+	for key, value := range metadata {
+		defaultMetadata[key] = value
+	}
+
+	trigger := kedav1alpha1.ScaleTriggers{
+		Type:     "kafka",
+		Metadata: defaultMetadata,
+	}
+
+	if authRef != nil {
+		trigger.AuthenticationRef = authRef
+	}
+
+	return trigger
+}
+
+// Helper function to create multiple expected triggers for multiple topics
+func createExpectedTriggersForTopics(topics []string, metadata map[string]string, authRef *kedav1alpha1.ScaledObjectAuthRef) []kedav1alpha1.ScaleTriggers {
+	triggers := make([]kedav1alpha1.ScaleTriggers, len(topics))
+	for i, topic := range topics {
+		triggers[i] = createExpectedTrigger(topic, metadata, authRef)
+	}
+	return triggers
+}
+
+func TestGenerateScaleTriggers(t *testing.T) {
+	tests := []struct {
+		name                   string
+		consumerGroup          *kafkainternals.ConsumerGroup
+		triggerAuthentication  *kedav1alpha1.TriggerAuthentication
+		autoscalerConfig       autoscaler.AutoscalerConfig
+		expectedTriggers       []kedav1alpha1.ScaleTriggers
+		expectedError          bool
+		expectedErrorSubstring string
+	}{
+		{
+			name:                  "single topic with default values",
+			consumerGroup:         createTestConsumerGroup("test-cg", "test-ns", nil, nil),
+			triggerAuthentication: nil,
+			autoscalerConfig:      createDefaultAutoscalerConfig(),
+			expectedTriggers:      []kedav1alpha1.ScaleTriggers{createExpectedTrigger("test-topic", nil, nil)},
+			expectedError:         false,
+		},
+		{
+			name: "multiple topics with default values",
+			consumerGroup: createTestConsumerGroupWithConfigs("test-cg", "test-ns", nil, []string{"topic1", "topic2", "topic3"}, map[string]string{
+				"bootstrap.servers": "broker1:9092,broker2:9092",
+				"group.id":          "multi-topic-group",
+			}),
+			triggerAuthentication: nil,
+			autoscalerConfig: autoscaler.AutoscalerConfig{
+				AutoscalerDefaults: map[string]int32{
+					autoscaler.AutoscalingLagThreshold: 50,
+				},
+				AutoscalerAuthentication: map[string]string{
+					autoscaler.AutoscalingAuthenticationName: "",
+					autoscaler.AutoscalingAuthenticationKind: "",
+					autoscaler.AutoscalingAwsRegion:          "",
+				},
+			},
+			expectedTriggers: createExpectedTriggersForTopics([]string{"topic1", "topic2", "topic3"}, map[string]string{
+				"bootstrapServers": "broker1:9092,broker2:9092",
+				"consumerGroup":    "multi-topic-group",
+				"lagThreshold":     "50",
+			}, nil),
+			expectedError: false,
+		},
+		{
+			name: "with custom lag threshold annotation",
+			consumerGroup: createTestConsumerGroup("test-cg", "test-ns", map[string]string{
+				autoscaler.AutoscalingLagThreshold: "200",
+			}, nil),
+			triggerAuthentication: nil,
+			autoscalerConfig:      createDefaultAutoscalerConfig(),
+			expectedTriggers: []kedav1alpha1.ScaleTriggers{createExpectedTrigger("test-topic", map[string]string{
+				"lagThreshold": "200",
+			}, nil)},
+			expectedError: false,
+		},
+		{
+			name: "with placements (allowIdleConsumers true)",
+			consumerGroup: func() *kafkainternals.ConsumerGroup {
+				cg := createTestConsumerGroup("test-cg", "test-ns", nil, nil)
+				cg.Status = kafkainternals.ConsumerGroupStatus{
+					PlaceableStatus: eventingduckv1alpha1.PlaceableStatus{
+						Placeable: eventingduckv1alpha1.Placeable{
+							Placements: []eventingduckv1alpha1.Placement{
+								{
+									PodName:   "pod1",
+									VReplicas: 1,
+								},
+							},
+						},
+					},
+				}
+				return cg
+			}(),
+			triggerAuthentication: nil,
+			autoscalerConfig:      createDefaultAutoscalerConfig(),
+			expectedTriggers: []kedav1alpha1.ScaleTriggers{createExpectedTrigger("test-topic", map[string]string{
+				"allowIdleConsumers": "true",
+			}, nil)},
+			expectedError: false,
+		},
+		{
+			name:          "with trigger authentication provided",
+			consumerGroup: createTestConsumerGroup("test-cg", "test-ns", nil, nil),
+			triggerAuthentication: &kedav1alpha1.TriggerAuthentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-trigger-auth",
+					Namespace: "test-ns",
+				},
+			},
+			autoscalerConfig: createDefaultAutoscalerConfig(),
+			expectedTriggers: []kedav1alpha1.ScaleTriggers{createExpectedTrigger("test-topic", nil, &kedav1alpha1.ScaledObjectAuthRef{
+				Name: "test-trigger-auth",
+			})},
+			expectedError: false,
+		},
+		{
+			name: "with authentication name annotation",
+			consumerGroup: createTestConsumerGroup("test-cg", "test-ns", map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-auth",
+			}, nil),
+			triggerAuthentication: nil,
+			autoscalerConfig:      createDefaultAutoscalerConfig(),
+			expectedTriggers: []kedav1alpha1.ScaleTriggers{createExpectedTrigger("test-topic", nil, &kedav1alpha1.ScaledObjectAuthRef{
+				Name: "my-auth",
+			})},
+			expectedError: false,
+		},
+		{
+			name: "with authentication name and kind annotations",
+			consumerGroup: createTestConsumerGroup("test-cg", "test-ns", map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-cluster-auth",
+				autoscaler.AutoscalingAuthenticationKind: "ClusterTriggerAuthentication",
+			}, nil),
+			triggerAuthentication: nil,
+			autoscalerConfig:      createDefaultAutoscalerConfig(),
+			expectedTriggers: []kedav1alpha1.ScaleTriggers{createExpectedTrigger("test-topic", nil, &kedav1alpha1.ScaledObjectAuthRef{
+				Name: "my-cluster-auth",
+				Kind: "ClusterTriggerAuthentication",
+			})},
+			expectedError: false,
+		},
+		{
+			name: "with aws region annotation",
+			consumerGroup: createTestConsumerGroup("test-cg", "test-ns", map[string]string{
+				autoscaler.AutoscalingAwsRegion: "us-west-2",
+			}, nil),
+			triggerAuthentication: nil,
+			autoscalerConfig:      createDefaultAutoscalerConfig(),
+			expectedTriggers: []kedav1alpha1.ScaleTriggers{createExpectedTrigger("test-topic", map[string]string{
+				"awsRegion": "us-west-2",
+			}, nil)},
+			expectedError: false,
+		},
+		{
+			name:                  "with aws region from config default",
+			consumerGroup:         createTestConsumerGroup("test-cg", "test-ns", nil, nil),
+			triggerAuthentication: nil,
+			autoscalerConfig: autoscaler.AutoscalerConfig{
+				AutoscalerDefaults: map[string]int32{
+					autoscaler.AutoscalingLagThreshold: 100,
+				},
+				AutoscalerAuthentication: map[string]string{
+					autoscaler.AutoscalingAuthenticationName: "",
+					autoscaler.AutoscalingAuthenticationKind: "",
+					autoscaler.AutoscalingAwsRegion:          "eu-central-1",
+				},
+			},
+			expectedTriggers: []kedav1alpha1.ScaleTriggers{createExpectedTrigger("test-topic", map[string]string{
+				"awsRegion": "eu-central-1",
+			}, nil)},
+			expectedError: false,
+		},
+		{
+			name:                  "empty topics slice",
+			consumerGroup:         createTestConsumerGroup("test-cg", "test-ns", nil, []string{}),
+			triggerAuthentication: nil,
+			autoscalerConfig:      createDefaultAutoscalerConfig(),
+			expectedTriggers:      []kedav1alpha1.ScaleTriggers{},
+			expectedError:         false,
+		},
+		{
+			name: "invalid lag threshold annotation",
+			consumerGroup: createTestConsumerGroup("test-cg", "test-ns", map[string]string{
+				autoscaler.AutoscalingLagThreshold: "invalid",
+			}, nil),
+			triggerAuthentication:  nil,
+			autoscalerConfig:       createDefaultAutoscalerConfig(),
+			expectedTriggers:       nil,
+			expectedError:          true,
+			expectedErrorSubstring: "Expected value for annotation",
+		},
+		{
+			name: "trigger authentication takes precedence over annotations",
+			consumerGroup: createTestConsumerGroup("test-cg", "test-ns", map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "annotation-auth",
+				autoscaler.AutoscalingAuthenticationKind: "TriggerAuthentication",
+			}, nil),
+			triggerAuthentication: &kedav1alpha1.TriggerAuthentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "priority-auth",
+					Namespace: "test-ns",
+				},
+			},
+			autoscalerConfig: createDefaultAutoscalerConfig(),
+			expectedTriggers: []kedav1alpha1.ScaleTriggers{createExpectedTrigger("test-topic", nil, &kedav1alpha1.ScaledObjectAuthRef{
+				Name: "priority-auth",
+			})},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			triggers, err := GenerateScaleTriggers(tt.consumerGroup, tt.triggerAuthentication, tt.autoscalerConfig)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if tt.expectedErrorSubstring != "" && !contains(err.Error(), tt.expectedErrorSubstring) {
+					t.Errorf("Expected error to contain '%s', but got: %v", tt.expectedErrorSubstring, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if len(triggers) != len(tt.expectedTriggers) {
+				t.Errorf("Expected %d triggers, got %d", len(tt.expectedTriggers), len(triggers))
+				return
+			}
+
+			for i, expectedTrigger := range tt.expectedTriggers {
+				if i >= len(triggers) {
+					t.Errorf("Missing trigger at index %d", i)
+					continue
+				}
+
+				actualTrigger := triggers[i]
+
+				// Check type
+				if actualTrigger.Type != expectedTrigger.Type {
+					t.Errorf("Trigger %d: expected type %s, got %s", i, expectedTrigger.Type, actualTrigger.Type)
+				}
+
+				// Check metadata
+				if !reflect.DeepEqual(actualTrigger.Metadata, expectedTrigger.Metadata) {
+					t.Errorf("Trigger %d: expected metadata %v, got %v", i, expectedTrigger.Metadata, actualTrigger.Metadata)
+				}
+
+				// Check authentication ref
+				if !reflect.DeepEqual(actualTrigger.AuthenticationRef, expectedTrigger.AuthenticationRef) {
+					t.Errorf("Trigger %d: expected AuthenticationRef %v, got %v", i, expectedTrigger.AuthenticationRef, actualTrigger.AuthenticationRef)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateTriggerAuthentication(t *testing.T) {
+	tests := []struct {
+		name                   string
+		consumerGroup          *kafkainternals.ConsumerGroup
+		secretData             map[string][]byte
+		autoscalerConfig       autoscaler.AutoscalerConfig
+		expectedTriggerAuth    *kedav1alpha1.TriggerAuthentication
+		expectedSecret         *corev1.Secret
+		expectedError          bool
+		expectedErrorSubstring string
+	}{
+		{
+			name: "authenticationName annotation has non-empty value",
+			consumerGroup: createTestConsumerGroup("test-cg", "test-ns", map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "existing-auth",
+			}, nil),
+			secretData:          nil,
+			autoscalerConfig:    createDefaultAutoscalerConfig(),
+			expectedTriggerAuth: nil,
+			expectedSecret:      nil,
+			expectedError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			triggerAuth, secret, err := GenerateTriggerAuthentication(tt.consumerGroup, tt.secretData, tt.autoscalerConfig)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if tt.expectedErrorSubstring != "" && !contains(err.Error(), tt.expectedErrorSubstring) {
+					t.Errorf("Expected error to contain '%s', but got: %v", tt.expectedErrorSubstring, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if !reflect.DeepEqual(triggerAuth, tt.expectedTriggerAuth) {
+				t.Errorf("Expected TriggerAuthentication %v, got %v", tt.expectedTriggerAuth, triggerAuth)
+			}
+
+			if !reflect.DeepEqual(secret, tt.expectedSecret) {
+				t.Errorf("Expected Secret %v, got %v", tt.expectedSecret, secret)
+			}
+		})
+	}
+}
+
+func TestSetAutoscalingAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		objAnnotations      map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "with authentication name annotation",
+			objAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-auth",
+				"some.other.annotation":                  "other-value",
+			},
+			expectedAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-auth",
+			},
+		},
+		{
+			name: "with authentication kind annotation",
+			objAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationKind: "ClusterTriggerAuthentication",
+				"some.other.annotation":                  "other-value",
+			},
+			expectedAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationKind: "ClusterTriggerAuthentication",
+			},
+		},
+		{
+			name: "with aws region annotation",
+			objAnnotations: map[string]string{
+				autoscaler.AutoscalingAwsRegion: "us-west-2",
+				"some.other.annotation":         "other-value",
+			},
+			expectedAnnotations: map[string]string{
+				autoscaler.AutoscalingAwsRegion: "us-west-2",
+			},
+		},
+		{
+			name: "with all three authentication annotations",
+			objAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-auth",
+				autoscaler.AutoscalingAuthenticationKind: "TriggerAuthentication",
+				autoscaler.AutoscalingAwsRegion:          "eu-central-1",
+				"some.other.annotation":                  "other-value",
+			},
+			expectedAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-auth",
+				autoscaler.AutoscalingAuthenticationKind: "TriggerAuthentication",
+				autoscaler.AutoscalingAwsRegion:          "eu-central-1",
+			},
+		},
+		{
+			name: "with empty authentication name annotation",
+			objAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "",
+				autoscaler.AutoscalingAwsRegion:          "us-east-1",
+				"some.other.annotation":                  "other-value",
+			},
+			expectedAnnotations: map[string]string{
+				autoscaler.AutoscalingAwsRegion: "us-east-1",
+			},
+		},
+		{
+			name: "with empty authentication kind annotation",
+			objAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-auth",
+				autoscaler.AutoscalingAuthenticationKind: "",
+				"some.other.annotation":                  "other-value",
+			},
+			expectedAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-auth",
+			},
+		},
+		{
+			name: "with empty aws region annotation",
+			objAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-auth",
+				autoscaler.AutoscalingAwsRegion:          "",
+				"some.other.annotation":                  "other-value",
+			},
+			expectedAnnotations: map[string]string{
+				autoscaler.AutoscalingAuthenticationName: "my-auth",
+			},
+		},
+		{
+			name: "with no target annotations",
+			objAnnotations: map[string]string{
+				"some.other.annotation": "other-value",
+				"another.annotation":    "another-value",
+			},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name:                "with nil annotations",
+			objAnnotations:      nil,
+			expectedAnnotations: nil,
+		},
+		{
+			name:                "with empty annotations map",
+			objAnnotations:      map[string]string{},
+			expectedAnnotations: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SetAutoscalingAnnotations(tt.objAnnotations)
+
+			if tt.expectedAnnotations == nil {
+				if result != nil {
+					t.Errorf("Expected nil result, got %v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Errorf("Expected non-nil result, got nil")
+				return
+			}
+
+			// Check that only the expected annotations are present
+			if len(result) != len(tt.expectedAnnotations) {
+				t.Errorf("Expected %d annotations, got %d", len(tt.expectedAnnotations), len(result))
+			}
+
+			// Check each expected annotation
+			for key, expectedValue := range tt.expectedAnnotations {
+				actualValue, ok := result[key]
+				if !ok {
+					t.Errorf("Expected annotation %s not found in result", key)
+					continue
+				}
+				if actualValue != expectedValue {
+					t.Errorf("For annotation %s, expected value %s, got %s", key, expectedValue, actualValue)
+				}
+			}
+
+			// Check that no unexpected annotations are present
+			for key := range result {
+				if _, ok := tt.expectedAnnotations[key]; !ok {
+					t.Errorf("Unexpected annotation %s found in result", key)
+				}
+			}
+		})
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/control-plane/pkg/autoscaler/keda/resources.go
+++ b/control-plane/pkg/autoscaler/keda/resources.go
@@ -85,3 +85,14 @@ func GetInt32ValueFromMap(dict map[string]string, key string, defaultValue int32
 	i32 := int32(i)
 	return &i32, nil
 }
+
+func GetStringValueFromMap(dict map[string]string, key string, defaultValue string) (*string, error) {
+	val, ok := dict[key]
+	if !ok {
+		return &defaultValue, nil
+	}
+	if val == "" {
+		return nil, nil
+	}
+	return &val, nil
+}

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -613,7 +613,7 @@ func (r *Reconciler) reconcileKedaObjects(ctx context.Context, cg *kafkainternal
 			return err
 		}
 
-		triggerAuthentication, secret, err = keda.GenerateTriggerAuthentication(cg, secretData)
+		triggerAuthentication, secret, err = keda.GenerateTriggerAuthentication(cg, secretData, *autoscalerDefaults)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Follow up for #4516 [comment](https://github.com/knative-extensions/eventing-kafka-broker/pull/4516#discussion_r2364547984)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
New Feature
Add optional KEDA autoscaler configuration to specify externally managed TriggerAuthentication or ClusterTriggerAuthentication resource. These are specified through the `config-kafka-autoscaler` ConfigMap or annotations on the scaled resource.

The annotation names:
- `autoscaling.eventing.knative.dev/authentication-name`: The name of the KEDA resource.
- `autoscaling.eventing.knative.dev/authentication-kind`: TriggerAuthentication or ClusterTriggerAuthentication. Only required if the KEDA resource is ClusterTriggerAuthentication.
- `autoscaling.eventing.knative.dev/aws-region`: Required if using AWS IAM authentication for MSK. The KEDA Kafka source requires this property to be defined in the `trigger.metadata`. KEDA does not recognize this property in the authentication resource as it does with properties like `sasl`.

The primary use case for this feature is to support KEDA autoscaling when using AWS IAM authentication for MSK. This allows a different role to be used for the KEDA operator with a different set of permissions from the KNative Eventing services. By allowing the user to supply an externally managed resource, the complexity of configuring this KEDA authentication is removed from the KNative code and gives more flexibility to the user. 


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Add optional autoscaler configurations to specify an externally managed KEDA TriggerAuthentication or ClusterTriggerAuthentication resource to be used by the KNative managed KEDA ScaledObject resource.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
WIP