### PR TITLE
Fix: add 'clean' to maven package command and fix profiler.

### DIFF
--- a/data-plane/profiler/run.sh
+++ b/data-plane/profiler/run.sh
@@ -52,7 +52,7 @@ echo "Async profiler URL: ${ASYNC_PROFILER_URL}"
 echo "Kafka URL: ${KAFKA_URL}"
 
 # Build the data plane.
-cd "${PROJECT_ROOT_DIR}" && ./mvnw package -DskipTests -Dlicense.skip -B -U --no-transfer-progress && cd - || exit 1
+cd "${PROJECT_ROOT_DIR}" && ./mvnw clean package -DskipTests -Dlicense.skip -B -U --no-transfer-progress && cd - || exit 1
 
 # Download async profiler.
 rm -rf async-profiler
@@ -88,7 +88,7 @@ export CONSUMER_CONFIG_FILE_PATH=${RESOURCES_DIR}/config-kafka-broker-consumer.p
 export HTTPSERVER_CONFIG_FILE_PATH=${RESOURCES_DIR}/config-kafka-broker-httpserver.properties
 export WEBCLIENT_CONFIG_FILE_PATH=${RESOURCES_DIR}/config-kafka-broker-webclient.properties
 export DATA_PLANE_CONFIG_FILE_PATH=${RESOURCES_DIR}/ingress.json
-export CONFIG_TRACING_PATH=${RESOURCES_DIR}/tracing
+export CONFIG_OBSERVABILITY_PATH=${RESOURCES_DIR}/observability
 export LIVENESS_PROBE_PATH=/healthz
 export READINESS_PROBE_PATH=/readyz
 export METRICS_PATH=/metrics


### PR DESCRIPTION
This fixes the shaded build with current Quarkus version. The same was done for data plane unit tests in https://github.com/knative-extensions/eventing-kafka-broker/pull/4453.


<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #4567

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :bug: Add `clean` to `mvnw package` command in profiler script

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->
/cc @Cali0707 @creydr @gauron99 @dsimansk 
