### PR TITLE
Set rules in pods.defaulting webhook already during creation

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-webhook/400-webhook-pod-defaulting.yaml
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/version: devel
 webhooks:
   # Dispatcher pods webhook config.
-  - admissionReviewVersions: [ "v1", "v1beta1" ]
+  - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: kafka-webhook-eventing
@@ -37,3 +37,15 @@ webhooks:
     objectSelector:
       matchLabels:
         app.kubernetes.io/kind: kafka-dispatcher
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+          - pods/status
+        scope: "*"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -202,6 +202,8 @@ function install_latest_release() {
   ko apply ${KO_FLAGS} -f ./test/config/ || fail_test "Failed to apply test configurations"
 
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
+  # The next apply needs the webhook rules to be populated to properly validate/mutate the resources
+  kubectl wait --for=jsonpath='{.webhooks[0].rules[0]}' mutatingwebhookconfiguration/pods.defaulting.webhook.kafka.eventing.knative.dev --timeout=60s
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_BROKER_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SINK_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SOURCE_ARTIFACT}" || return $?
@@ -215,6 +217,8 @@ function install_head() {
   echo "Installing head"
 
   kubectl apply -f "${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
+  # The next apply needs the webhook rules to be populated to properly validate/mutate the resources
+  kubectl wait --for=jsonpath='{.webhooks[0].rules[0]}' mutatingwebhookconfiguration/pods.defaulting.webhook.kafka.eventing.knative.dev --timeout=60s
   kubectl apply -f "${EVENTING_KAFKA_SOURCE_ARTIFACT}" || return $?
   kubectl apply -f "${EVENTING_KAFKA_BROKER_ARTIFACT}" || return $?
   kubectl apply -f "${EVENTING_KAFKA_SINK_ARTIFACT}" || return $?
@@ -235,7 +239,7 @@ function install_control_plane_from_source() {
 
   # Restore test config.
   kubectl replace -f ./test/config/100-config-kafka-features.yaml
-  
+
 }
 
 function install_latest_release_source() {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set `rules` already in the `pods.defaulting` MWC resource to avoid pods slipping through
  - `rules` are also set by the `kafka-webhook-eventing` but if e.g. the StatefulSet `kafka-source-dispatcher` is created before that its pods would be created without being modified by this MWC

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Set `rules` already in the `pods.defaulting` MWC resource to avoid pods slipping through
  - `rules` are also set by the `kafka-webhook-eventing` but if e.g. the StatefulSet `kafka-source-dispatcher` is created before that its pods would be created without being modified by this MWC
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/cc @gauron99 
/cc @creydr 

/hold until kn-plugin-source-kafka is released (just to make sure releasability is no blocker)