### PR TITLE
[#4582] drop explicit fabric8 httpclient dependencies

### DIFF
--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -1,5 +1,5 @@
 
-Lists of 291 third-party dependencies.
+Lists of 290 third-party dependencies.
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.5.18 - http://logback.qos.ch/logback-classic)
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.5.18 - http://logback.qos.ch/logback-core)
      (The Apache Software License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.20 - https://github.com/FasterXML/jackson)
@@ -53,7 +53,6 @@ Lists of 291 third-party dependencies.
      (Apache License 2.0) Metrics Core (io.dropwizard.metrics:metrics-core:4.1.12.1 - https://metrics.dropwizard.io/metrics-core)
      (Apache License, Version 2.0) Fabric8 :: Kubernetes :: Java Client (io.fabric8:kubernetes-client:7.3.1 - https://github.com/fabric8io/kubernetes-client/kubernetes-client)
      (Apache License, Version 2.0) Fabric8 :: Kubernetes :: Java Client API (io.fabric8:kubernetes-client-api:7.3.1 - https://github.com/fabric8io/kubernetes-client/kubernetes-client-api)
-     (Apache License, Version 2.0) Fabric8 :: Kubernetes :: HttpClient :: JDK (io.fabric8:kubernetes-httpclient-jdk:7.3.1 - https://github.com/fabric8io/kubernetes-client/kubernetes-httpclient-jdk)
      (Apache License, Version 2.0) Fabric8 :: Kubernetes :: HttpClient :: Vert.x (io.fabric8:kubernetes-httpclient-vertx:7.4.0 - https://github.com/fabric8io/kubernetes-client/kubernetes-httpclient-vertx)
      (Apache License, Version 2.0) Fabric8 :: Kubernetes Model :: Admission Registration, Authentication and Authorization (io.fabric8:kubernetes-model-admissionregistration:7.4.0 - https://github.com/fabric8io/kubernetes-client/kubernetes-model-generator/kubernetes-model-admissionregistration)
      (Apache License, Version 2.0) Fabric8 :: Kubernetes Model :: API Extensions (io.fabric8:kubernetes-model-apiextensions:7.4.0 - https://github.com/fabric8io/kubernetes-client/kubernetes-model-generator/kubernetes-model-apiextensions)

--- a/data-plane/core/pom.xml
+++ b/data-plane/core/pom.xml
@@ -43,16 +43,6 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.fabric8</groupId>
-          <artifactId>kubernetes-httpclient-okhttp</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-httpclient-jdk</artifactId>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>


### PR DESCRIPTION
fixes https://github.com/knative-extensions/eventing-kafka-broker/issues/4582

kubernetes-client uses Vert.x httpclient by default since version 7.0.0 (https://github.com/fabric8io/kubernetes-client/issues/6470).

It fixes warning in logs

```
12:52:22.500 [main] WARN io.fabric8.kubernetes.client.utils.HttpClientUtils -- The following httpclient factories were detected on your classpath: [io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory, io.fabric8.kubernetes.client.jdkhttp.JdkHttpClientFactory], multiple of which had the same priority (0) so one was chosen randomly. You should exclude dependencies that aren't needed or use an explicit association of the HttpClient.Factory.
12:52:22.500 [main] DEBUG io.fabric8.kubernetes.client.utils.HttpClientUtils -- Using httpclient io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory factory
```