### PR TITLE
[#4584] reuse existing Vert.x context for KubernetesClients

### DIFF
--- a/data-plane/core/pom.xml
+++ b/data-plane/core/pom.xml
@@ -56,6 +56,10 @@
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-vertx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
       <scope>test</scope>
       <exclusions>

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/AuthProvider.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/AuthProvider.java
@@ -16,7 +16,9 @@
 package dev.knative.eventing.kafka.broker.core.security;
 
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -27,7 +29,10 @@ import io.vertx.core.Vertx;
 public interface AuthProvider {
 
     static AuthProvider kubernetes(final Vertx vertx) {
-        return new KubernetesAuthProvider(vertx, new DefaultKubernetesClient());
+        KubernetesClient kubernetesClient = new KubernetesClientBuilder()
+                .withHttpClientFactory(new VertxHttpClientFactory(vertx))
+                .build();
+        return new KubernetesAuthProvider(vertx, kubernetesClient);
     }
 
     static AuthProvider noAuth() {

--- a/data-plane/receiver/pom.xml
+++ b/data-plane/receiver/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-vertx</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>dev.knative.eventing.kafka.broker</groupId>

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/Main.java
@@ -33,6 +33,7 @@ import dev.knative.eventing.kafka.broker.receiver.impl.auth.OIDCDiscoveryConfigL
 import io.cloudevents.kafka.CloudEventSerializer;
 import io.cloudevents.kafka.PartitionKeyExtensionInterceptor;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Verticle;
@@ -107,7 +108,9 @@ public class Main {
         httpsServerOptions.setPort(env.getIngressTLSPort());
         httpsServerOptions.setTracingPolicy(TracingPolicy.PROPAGATE);
 
-        final var kubernetesClient = new KubernetesClientBuilder().build();
+        final var kubernetesClient = new KubernetesClientBuilder()
+                .withHttpClientFactory(new VertxHttpClientFactory(vertx))
+                .build();
         final var eventTypeClient = kubernetesClient.resources(EventType.class);
         final var eventTypeListerFactory = new EventTypeListerFactory(eventTypeClient);
 


### PR DESCRIPTION
fixes https://github.com/knative-extensions/eventing-kafka-broker/issues/4584

It fixes warning in log

```
WARNING: You're already on a Vert.x context, are you sure you want to create a new Vertx instance?
```

Some details on shared Vert.x instance in KubernetClient in https://github.com/fabric8io/kubernetes-client/commit/ab342028411402bc6b584e03f41023625038b8e2 .
