### PR TITLE
bump andstor/file-existence-action GH action to v3

### DIFF
--- a/.github/workflows/knative-java-test.yaml
+++ b/.github/workflows/knative-java-test.yaml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           cache: 'maven'
           java-version: ${{ matrix.java-version }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Check for .codecov.yaml
         id: codecov-enabled
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v3
         with:
           files: .codecov.yaml
 
@@ -55,7 +55,7 @@ jobs:
 
       - if: steps.codecov-enabled.outputs.files_exists == 'true'
         name: Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          file: ./data-plane/target/jacoco/jacoco.xml
+          files: ./data-plane/target/jacoco/jacoco.xml
           flags: java-unittests


### PR DESCRIPTION
to get rid of the warning in GH actions that could be seen in [Java Test action reports](https://github.com/knative-extensions/eventing-kafka-broker/actions/workflows/knative-java-test.yaml)

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

