### PR TITLE
[Release 1.19] update quarkus to resolve CVEs

### DIFF
--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -60,7 +60,7 @@
     <kafka.version>3.9.1</kafka.version>
     <debezium.version>3.0.7.Final</debezium.version>
     <jib.version>3.4.5</jib.version>
-    <quarkus.version>3.25.0</quarkus.version>
+    <quarkus.version>3.26.3</quarkus.version>
     <antlr.version>4.9.2
     </antlr.version> <!-- Overwritting quarkus's antlr version. Reminder: antlr4-maven-plugin,antlr4-runtime, antlr4 need to have the same version -->
     <palantirJavaFormat.version>2.38.0</palantirJavaFormat.version>


### PR DESCRIPTION
Ports the quarkus update from https://github.com/knative-extensions/eventing-kafka-broker/pull/4562 to the 1.19 branch as well.  (All other changes in that PR were already present on this branch.)

## Proposed Changes

- Upgrades quarkus-vertx to 3.26.3, which pulls in updated netty-codec, netty-codec-http, and netty-codec-http2 versions to resolve CVE-2025-58057, CVE-2025-58056, and CVE-2025-55163.  