### PR TITLE
Add knativekafkatopic extension

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutator.java
@@ -39,7 +39,7 @@ public class CloudEventOverridesMutator implements CloudEventMutator {
             return record.value();
         }
         final var builder = CloudEventBuilder.from(record.value());
-        applyKafkaMetadata(builder, record.partition(), record.offset());
+        applyKafkaMetadata(builder, record.partition(), record.offset(), record.topic());
         applyCloudEventOverrides(builder);
         return builder.build();
     }
@@ -48,8 +48,9 @@ public class CloudEventOverridesMutator implements CloudEventMutator {
         cloudEventOverrides.getExtensionsMap().forEach(builder::withExtension);
     }
 
-    private void applyKafkaMetadata(CloudEventBuilder builder, Number partition, Number offset) {
+    private void applyKafkaMetadata(CloudEventBuilder builder, Number partition, Number offset, String topic) {
         builder.withExtension("knativekafkapartition", partition);
         builder.withExtension("knativekafkaoffset", offset);
+        builder.withExtension("knativekafkatopic", topic);
     }
 }

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutatorTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventOverridesMutatorTest.java
@@ -52,6 +52,7 @@ public class CloudEventOverridesMutatorTest {
         extensions.forEach(expected::withExtension);
         expected.withExtension("knativekafkaoffset", 1L);
         expected.withExtension("knativekafkapartition", 1);
+        expected.withExtension("knativekafkatopic", "test-topic");
 
         final var got = mutator.apply(new ConsumerRecord<>("test-topic", 1, 1, "key", given));
 
@@ -100,6 +101,7 @@ public class CloudEventOverridesMutatorTest {
         final var expected = CloudEventBuilder.from(given)
                 .withExtension("knativekafkaoffset", 1L)
                 .withExtension("knativekafkapartition", 1)
+                .withExtension("knativekafkatopic", "test-topic")
                 .build();
 
         final var got = mutator.apply(new ConsumerRecord<>("test-topic", 1, 1, "key", given));

--- a/test/rekt/features/ce_extensions.go
+++ b/test/rekt/features/ce_extensions.go
@@ -76,7 +76,7 @@ func brokerAddsKnativeKafkaCEExtensions() *feature.Feature {
 
 	f.Alpha("broker").
 		Must("must add Knative Kafka CE extensions", eventasssert.OnStore(sinkName).
-			MatchEvent(test.ContainsExtensions("knativekafkapartition", "knativekafkaoffset")).
+			MatchEvent(test.ContainsExtensions("knativekafkapartition", "knativekafkaoffset", "knativekafkatopic")).
 			Exact(1))
 	return f
 }
@@ -118,7 +118,7 @@ func channelAddsKnativeKafkaCEExtensions() *feature.Feature {
 
 	f.Alpha("channel").
 		Must("add Knative Kafka CE extensions", eventasssert.OnStore(sinkName).
-			MatchEvent(test.ContainsExtensions("knativekafkapartition", "knativekafkaoffset")).
+			MatchEvent(test.ContainsExtensions("knativekafkapartition", "knativekafkaoffset", "knativekafkatopic")).
 			Exact(1))
 	return f
 }
@@ -161,7 +161,7 @@ func sourceAddsKnativeKafkaCEExtensions() *feature.Feature {
 
 	f.Alpha("source").
 		Must("add Knative Kafka CE extensions", eventasssert.OnStore(sinkName).
-			MatchEvent(test.ContainsExtensions("knativekafkapartition", "knativekafkaoffset")).
+			MatchEvent(test.ContainsExtensions("knativekafkapartition", "knativekafkaoffset", "knativekafkatopic")).
 			Exact(1))
 	return f
 }


### PR DESCRIPTION
If using CloudEvents with a prefilled source field, there is no way for sinks to know the source topic. This change fixes it by adding an extension containing the source topic.

Release Notes:
Added the field knativekafkatopic so users can know the source Kafka topic if they use CloudEvents
