### PR TITLE
Kafka broker receiver with http/protobuf metrics crashes #4566 

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/observability/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/observability/metrics/Metrics.java
@@ -235,11 +235,13 @@ public class Metrics {
                     public String get(String key) {
                         return switch (key) {
                             case "otlp.url" -> {
-                                String endpoint = observabilityConfig.getMetricsConfig().endpoint();
+                                String endpoint =
+                                        observabilityConfig.getMetricsConfig().endpoint();
                                 yield isNullOrBlank(endpoint) ? null : endpoint.trim();
                             }
                             case "otlp.step" -> {
-                                String interval = observabilityConfig.getMetricsConfig().exportInterval();
+                                String interval =
+                                        observabilityConfig.getMetricsConfig().exportInterval();
                                 yield convertToMicrometerDuration(interval);
                             }
                             default -> null; // Return null so Micrometer uses its built-in defaults

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/metrics/MetricsTest.java
@@ -70,10 +70,7 @@ public class MetricsTest {
         final var metricsOptions = Metrics.getOptions(
                 new BaseEnv(s -> "1"),
                 new ObservabilityConfig(
-                        new ObservabilityConfig.MetricsConfig(
-                                ObservabilityConfig.MetricsProtocol.OTLP_HTTP,
-                                "",
-                                "60s"),
+                        new ObservabilityConfig.MetricsConfig(ObservabilityConfig.MetricsProtocol.OTLP_HTTP, "", "60s"),
                         new ObservabilityConfig.TracingConfig(ObservabilityConfig.TracingProtocol.NONE, "", 0F)));
         assertThat(metricsOptions.isEnabled()).isTrue();
     }
@@ -84,9 +81,7 @@ public class MetricsTest {
                 new BaseEnv(s -> "1"),
                 new ObservabilityConfig(
                         new ObservabilityConfig.MetricsConfig(
-                                ObservabilityConfig.MetricsProtocol.OTLP_HTTP,
-                                null,
-                                "60s"),
+                                ObservabilityConfig.MetricsProtocol.OTLP_HTTP, null, "60s"),
                         new ObservabilityConfig.TracingConfig(ObservabilityConfig.TracingProtocol.NONE, "", 0F)));
         assertThat(metricsOptions.isEnabled()).isTrue();
     }
@@ -122,10 +117,7 @@ public class MetricsTest {
         final var metricsOptions = Metrics.getOptions(
                 new BaseEnv(s -> "1"),
                 new ObservabilityConfig(
-                        new ObservabilityConfig.MetricsConfig(
-                                ObservabilityConfig.MetricsProtocol.OTLP_HTTP,
-                                "",
-                                ""),
+                        new ObservabilityConfig.MetricsConfig(ObservabilityConfig.MetricsProtocol.OTLP_HTTP, "", ""),
                         new ObservabilityConfig.TracingConfig(ObservabilityConfig.TracingProtocol.NONE, "", 0F)));
         assertThat(metricsOptions.isEnabled()).isTrue();
     }
@@ -136,9 +128,7 @@ public class MetricsTest {
                 new BaseEnv(s -> "1"),
                 new ObservabilityConfig(
                         new ObservabilityConfig.MetricsConfig(
-                                ObservabilityConfig.MetricsProtocol.OTLP_HTTP,
-                                null,
-                                null),
+                                ObservabilityConfig.MetricsProtocol.OTLP_HTTP, null, null),
                         new ObservabilityConfig.TracingConfig(ObservabilityConfig.TracingProtocol.NONE, "", 0F)));
         assertThat(metricsOptions.isEnabled()).isTrue();
     }
@@ -149,9 +139,7 @@ public class MetricsTest {
                 new BaseEnv(s -> "1"),
                 new ObservabilityConfig(
                         new ObservabilityConfig.MetricsConfig(
-                                ObservabilityConfig.MetricsProtocol.OTLP_HTTP,
-                                "   ",
-                                "60s"),
+                                ObservabilityConfig.MetricsProtocol.OTLP_HTTP, "   ", "60s"),
                         new ObservabilityConfig.TracingConfig(ObservabilityConfig.TracingProtocol.NONE, "", 0F)));
         assertThat(metricsOptions.isEnabled()).isTrue();
     }
@@ -191,12 +179,12 @@ public class MetricsTest {
     @Test
     public void getWithOtlpHttpProtocolVariousEndpointFormats() {
         String[] endpoints = {
-                "http://localhost:4318/v1/metrics",
-                "http://otel-collector:4318/v1/metrics",
-                "http://otel-collector.otel-collector.svc:4318/v1/metrics",
-                "http://otel-collector.otel-collector.svc.cluster.local:4318/v1/metrics",
-                "https://otel-collector:4318/v1/metrics",
-                "http://127.0.0.1:4318/v1/metrics"
+            "http://localhost:4318/v1/metrics",
+            "http://otel-collector:4318/v1/metrics",
+            "http://otel-collector.otel-collector.svc:4318/v1/metrics",
+            "http://otel-collector.otel-collector.svc.cluster.local:4318/v1/metrics",
+            "https://otel-collector:4318/v1/metrics",
+            "http://127.0.0.1:4318/v1/metrics"
         };
 
         for (String endpoint : endpoints) {
@@ -204,9 +192,7 @@ public class MetricsTest {
                     new BaseEnv(s -> "1"),
                     new ObservabilityConfig(
                             new ObservabilityConfig.MetricsConfig(
-                                    ObservabilityConfig.MetricsProtocol.OTLP_HTTP,
-                                    endpoint,
-                                    "60s"),
+                                    ObservabilityConfig.MetricsProtocol.OTLP_HTTP, endpoint, "60s"),
                             new ObservabilityConfig.TracingConfig(ObservabilityConfig.TracingProtocol.NONE, "", 0F)));
             assertThat(metricsOptions.isEnabled())
                     .as("Endpoint '%s' should work", endpoint)
@@ -220,9 +206,7 @@ public class MetricsTest {
                 new BaseEnv(s -> "1"),
                 new ObservabilityConfig(
                         new ObservabilityConfig.MetricsConfig(
-                                ObservabilityConfig.MetricsProtocol.OTLP_GRPC,
-                                "http://otel-collector:4317",
-                                "60s"),
+                                ObservabilityConfig.MetricsProtocol.OTLP_GRPC, "http://otel-collector:4317", "60s"),
                         new ObservabilityConfig.TracingConfig(ObservabilityConfig.TracingProtocol.NONE, "", 0F)));
         assertThat(metricsOptions.isEnabled()).isTrue();
     }
@@ -233,9 +217,7 @@ public class MetricsTest {
                 new BaseEnv(s -> "1"),
                 new ObservabilityConfig(
                         new ObservabilityConfig.MetricsConfig(
-                                ObservabilityConfig.MetricsProtocol.PROMETHEUS,
-                                "http://localhost:9090/metrics",
-                                "60s"),
+                                ObservabilityConfig.MetricsProtocol.PROMETHEUS, "http://localhost:9090/metrics", "60s"),
                         new ObservabilityConfig.TracingConfig(ObservabilityConfig.TracingProtocol.NONE, "", 0F)));
         assertThat(metricsOptions.isEnabled()).isTrue();
     }
@@ -245,10 +227,7 @@ public class MetricsTest {
         final var metricsOptions = Metrics.getOptions(
                 new BaseEnv(s -> "1"),
                 new ObservabilityConfig(
-                        new ObservabilityConfig.MetricsConfig(
-                                ObservabilityConfig.MetricsProtocol.PROMETHEUS,
-                                "",
-                                ""),
+                        new ObservabilityConfig.MetricsConfig(ObservabilityConfig.MetricsProtocol.PROMETHEUS, "", ""),
                         new ObservabilityConfig.TracingConfig(ObservabilityConfig.TracingProtocol.NONE, "", 0F)));
         assertThat(metricsOptions.isEnabled()).isTrue();
     }


### PR DESCRIPTION
This pull request improves the robustness and flexibility of the metrics configuration logic in the observability module. It enhances how OTLP (OpenTelemetry Protocol) metrics endpoints and export intervals are handled, ensuring that empty or whitespace values are treated appropriately, and adds comprehensive tests to cover various configuration scenarios.

**Enhancements to metrics configuration handling:**

* Updated the `getRegistryFromConfig` method in `Metrics.java` to handle OTLP endpoint and export interval keys (`otlp.url` and `otlp.step`), returning `null` for empty or whitespace values so that Micrometer uses its built-in defaults. Also, changed the default return to `null` instead of an empty string for unrecognized keys.
* Added utility methods `isNullOrBlank` and `convertToMicrometerDuration` in `Metrics.java` to standardize the handling and conversion of configuration values for endpoints and intervals.

**Expanded test coverage:**

* Added multiple new test cases in `MetricsTest.java` to verify correct handling of various OTLP and Prometheus protocol configurations, including empty, null, and whitespace values for endpoints and export intervals, as well as different duration and endpoint formats.This pull request enhances the handling and validation of metrics configuration for observability, with a focus on supporting OTLP (OpenTelemetry Protocol) HTTP endpoints and intervals. It introduces utility methods for input validation, improves key handling for Micrometer integration, and significantly expands test coverage to ensure robust behavior across various input scenarios.

**Metrics configuration improvements:**

* Updated the `getRegistryFromConfig` method in `Metrics.java` to handle OTLP-specific keys (`otlp.url`, `otlp.step`) and to return `null` for missing values, allowing Micrometer to use its built-in defaults. Added trimming and null/blank checks for endpoint and interval values.
* Introduced two utility methods: `isNullOrBlank` for robust blank/null string checking, and `convertToMicrometerDuration` for normalizing interval formats or defaulting to Micrometer's behavior.

**Test coverage enhancements:**

* Added comprehensive tests in `MetricsTest.java` to verify correct behavior of metrics configuration with various OTLP HTTP endpoint and interval values (including null, empty, whitespace, and multiple valid formats), as well as coverage for OTLP gRPC and Prometheus protocols.<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
