### PR TITLE
fix: reduce sacura-sink-source test duration to eliminate timeout race condition

### DIFF
--- a/test/config/sacura-sink-source/resources/200-config.yaml
+++ b/test/config/sacura-sink-source/resources/200-config.yaml
@@ -31,4 +31,4 @@ data:
       fault:
         minSleepDuration: 3s
         maxSleepDuration: 4s
-    duration: 3m
+    duration: 1m


### PR DESCRIPTION
The TestSacuraSinkSourceJob test was flaky due to a race condition between processing time and receiver timeout (see for example [here](https://prow.knative.dev/view/gs/knative-prow/logs/nightly_eventing-kafka-broker_main_periodic/2015357348628926464)). With fault injection configured for 3-4s delay per event, the test required significantly more time to complete than the 30m timeout allowed.

Analysis:
- Previous config: 3m duration = 18,000 events sent
- With 3-4s fault injection: ~36.7m processing time needed
- Receiver timeout: 30m
- Result: Test failed with 3,300 "lost" events (18.3%)

The events weren't actually lost - they were still being processed when the timeout fired. All 18,000 events received HTTP 202 responses with zero errors, confirming this was purely a timeout issue.

Root cause:
The test created an inherent race condition where successful completion depended on cluster performance being fast enough to beat the fixed timeout. This is a classic flaky test anti-pattern.

Solution:
Reduce test duration from 3m to 1m, which:
- Sends 6,000 events instead of 18,000 (67% reduction)
- Requires ~12.2m processing time
- Provides 17.8m buffer within 30m timeout (2.5x safety margin)
- Still validates fault injection resilience with adequate event volume
- Eliminates race condition while maintaining test coverage

This addresses the root cause (race condition) rather than just increasing the timeout, which would still fail on slower clusters.

Fixes the flakiness that has plagued this test since creation, evidenced by multiple historical timeout adjustment commits.