### PR TITLE
control-plane: avoid duplicate CreateTopics requests for existing topics

### DIFF
--- a/control-plane/pkg/kafka/topic_test.go
+++ b/control-plane/pkg/kafka/topic_test.go
@@ -50,6 +50,13 @@ func TestCreateTopic(t *testing.T) {
 			name: "Topic created no error",
 			args: args{
 				admin: &kafkatesting.MockKafkaClusterAdmin{
+					ExpectedTopics: []string{"topic-name-1"},
+					ExpectedTopicsMetadataOnDescribeTopics: []*sarama.TopicMetadata{
+						{
+							Name: "topic-name-1",
+							Err:  sarama.ErrUnknownTopicOrPartition,
+						},
+					},
 					ExpectedTopicName: "topic-name-1",
 					ExpectedTopicDetail: sarama.TopicDetail{
 						NumPartitions:     10,
@@ -74,15 +81,21 @@ func TestCreateTopic(t *testing.T) {
 			name: "Topic already exists",
 			args: args{
 				admin: &kafkatesting.MockKafkaClusterAdmin{
+					ExpectedTopics: []string{"topic-name-1"},
+					ExpectedTopicsMetadataOnDescribeTopics: []*sarama.TopicMetadata{
+						{
+							Name:       "topic-name-1",
+							IsInternal: false,
+							Partitions: []*sarama.PartitionMetadata{{}},
+							Err:        sarama.ErrNoError,
+						},
+					},
+
 					ExpectedTopicName: "topic-name-1",
 					ExpectedTopicDetail: sarama.TopicDetail{
 						NumPartitions:     10,
 						ReplicationFactor: 3,
 					},
-					ErrorOnCreateTopic: &sarama.TopicError{
-						Err: sarama.ErrTopicAlreadyExists,
-					},
-					T: t,
 				},
 				logger: zap.NewNop(),
 				topic:  "topic-name-1",
@@ -101,6 +114,13 @@ func TestCreateTopic(t *testing.T) {
 			name: "Create Topic error",
 			args: args{
 				admin: &kafkatesting.MockKafkaClusterAdmin{
+					ExpectedTopics: []string{"topic-name-1"},
+					ExpectedTopicsMetadataOnDescribeTopics: []*sarama.TopicMetadata{
+						{
+							Name: "topic-name-1",
+							Err:  sarama.ErrUnknownTopicOrPartition,
+						},
+					},
 					ExpectedTopicName: "topic-name-1",
 					ExpectedTopicDetail: sarama.TopicDetail{
 						NumPartitions:     10,
@@ -297,16 +317,20 @@ func TestCreateTopicTopicAlreadyExists(t *testing.T) {
 		},
 	}
 	topic := BrokerTopic("", b)
-	errMsg := "topic already exists"
 
 	ca := &kafkatesting.MockKafkaClusterAdmin{
+		ExpectedTopics: []string{topic},
+		ExpectedTopicsMetadataOnDescribeTopics: []*sarama.TopicMetadata{
+			{
+				Name:       topic,
+				IsInternal: false,
+				Partitions: []*sarama.PartitionMetadata{{}},
+				Err:        sarama.ErrNoError,
+			},
+		},
+
 		ExpectedTopicName:   topic,
 		ExpectedTopicDetail: sarama.TopicDetail{},
-		ErrorOnCreateTopic: &sarama.TopicError{
-			Err:    sarama.ErrTopicAlreadyExists,
-			ErrMsg: &errMsg,
-		},
-		T: t,
 	}
 
 	topicRet, err := CreateTopicIfDoesntExist(ca, zap.NewNop(), topic, &TopicConfig{})

--- a/control-plane/pkg/reconciler/channel/channel_test.go
+++ b/control-plane/pkg/reconciler/channel/channel_test.go
@@ -2344,6 +2344,15 @@ func TestReconcileKind(t *testing.T) {
 			Env: env,
 			GetKafkaClusterAdmin: func(_ context.Context, _ []string, _ *corev1.Secret) (sarama.ClusterAdmin, error) {
 				return &kafkatesting.MockKafkaClusterAdmin{
+					ExpectedTopics: []string{expectedTopicName},
+					ExpectedTopicsMetadataOnDescribeTopics: []*sarama.TopicMetadata{
+						{
+							Name:       expectedTopicName,
+							IsInternal: false,
+							Partitions: []*sarama.PartitionMetadata{{}},
+							Err:        sarama.ErrNoError,
+						},
+					},
 					ExpectedTopicName: expectedTopicName,
 					ExpectedTopicDetail: sarama.TopicDetail{
 						NumPartitions:     numPartitions,

--- a/control-plane/pkg/reconciler/sink/kafka_sink_test.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink_test.go
@@ -559,7 +559,8 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 				},
 			},
 			OtherTestData: map[string]interface{}{
-				wantTopicName: "my-topic-1",
+				wantTopicName:                  "my-topic-1",
+				ExpectedTopicsOnDescribeTopics: []string{"my-topic-1"},
 			},
 		},
 		{
@@ -598,6 +599,7 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 			},
 			OtherTestData: map[string]interface{}{
 				wantErrorOnCreateTopic: errCreateTopic,
+				ExpectedTopicIsPresent: false,
 			},
 		},
 		{
@@ -1891,9 +1893,10 @@ func sinkFinalization(t *testing.T, format string, env config.Env) {
 				}),
 			},
 			OtherTestData: map[string]interface{}{
-				wantErrorOnDeleteTopic: errDeleteTopic,
-				wantTopicName:          "topic-2",
-				testProber:             probertesting.MockNewProber(prober.StatusNotReady),
+				wantErrorOnDeleteTopic:         errDeleteTopic,
+				wantTopicName:                  "topic-2",
+				ExpectedTopicsOnDescribeTopics: []string{"topic-2"},
+				testProber:                     probertesting.MockNewProber(prober.StatusNotReady),
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #4406

<!-- Please include the 'why' behind your changes if no issue exists -->
### Proposed Changes
- Make `CreateTopicIfDoesntExist` idempotent by checking Kafka metadata before creating topics.
- Avoid repeated `CreateTopics` requests and error responses during steady-state reconciliation.
- Update unit tests and mocks to reflect the new `DescribeTopics` first behavior.
- This change avoids repeated mutating ``CreateTopics`` requests by checking topic existence via Kafka metadata before creating. 
- While this still involves a read call to Kafka, it removes unnecessary write requests and error responses in steady state reconciliation.