### PR TITLE
Align tag names for resource name and namespace with eventing-core

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/observability/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/observability/metrics/Metrics.java
@@ -148,8 +148,8 @@ public class Metrics {
         public static final String RESPONSE_CODE = "http.response.status_code";
         public static final String EVENT_TYPE = "cloudevents.type";
 
-        public static final String RESOURCE_NAME_TEMPLATE = "kn.eventing.%s.name";
-        public static final String RESOURCE_NAMESPACE_TEMPLATE = "kn.eventing.%s.namespace";
+        public static final String RESOURCE_NAME_TEMPLATE = "kn.%s.name";
+        public static final String RESOURCE_NAMESPACE_TEMPLATE = "kn.%s.namespace";
         public static final String CONSUMER_NAME = "messaging.consumer.group.name";
         public static final String PARTITION_ID = "messaging.destination.partition.id";
         public static final String DESTINATION_NAME = "messaging.destination.name";


### PR DESCRIPTION
Aligning the tag names for the resource name and namspace with eventing-core.

https://github.com/knative/eventing/blob/37dd673eef41ae2493d1d58e503f316b516f3745/pkg/observability/key.go#L40-L46

Feature track document: https://docs.google.com/document/d/1QQ_ubc0RjeZbRHdN4rQR85Z7RZfTSjz4GoKsE0dZ2Z0/edit?tab=t.0