### PR TITLE
[WIP] Speed up channel integration tests with parallel execution

### DIFF
--- a/test/channel-e2e-tests.sh
+++ b/test/channel-e2e-tests.sh
@@ -2,6 +2,8 @@
 
 source $(dirname $0)/e2e-common.sh
 
+# Enable parallel execution for first-event-delay test (100 channels in parallel vs sequential)
+export PARALLEL=1
 $(dirname $0)/scripts/first-event-delay.sh || fail_test "Failed"
 
-go_test_e2e -timeout=1h ./test/e2e_channel/... -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test "E2E suite (KafkaChannel) failed"
+go_test_e2e -timeout=1h -parallel=8 ./test/e2e_channel/... -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test "E2E suite (KafkaChannel) failed"

--- a/test/channel-reconciler-tests.sh
+++ b/test/channel-reconciler-tests.sh
@@ -2,10 +2,10 @@
 
 source $(dirname $0)/e2e-common.sh
 
-go_test_e2e -tags=e2e,cloudevents -timeout=1h ./test/e2e_new_channel/... || fail_test "E2E (new - KafkaChannel) suite failed"
+go_test_e2e -tags=e2e,cloudevents -timeout=1h -parallel=8 ./test/e2e_new_channel/... || fail_test "E2E (new - KafkaChannel) suite failed"
 
 echo "Running E2E Channel Reconciler Tests with OIDC authentication enabled"
 
 kubectl apply -Rf "$(dirname "$0")/config-oidc-authentication"
 
-go_test_e2e -timeout=1h ./test/e2e_new_channel/... -run OIDC || fail_test
+go_test_e2e -timeout=1h -parallel=8 ./test/e2e_new_channel/... -run OIDC || fail_test


### PR DESCRIPTION
Enable parallel test execution to reduce channel test runtime:

1. Set `PARALLEL=1` for `first-event-delay.sh` to run 100 channel creations in parallel instead of sequentially
2. Add `-parallel` flag to go_test_e2e calls to increase concurrent test execution (tests already use t.Parallel())