### PR TITLE
test : add explicit spotless check to presubmit build tests

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -33,6 +33,11 @@ function fail_test() {
 }
 
 function build_tests() {
+  header "Running Spotless format check"
+  pushd "$(dirname "$0")/../data-plane" >/dev/null || exit 1
+  ./mvnw spotless:check || fail_test "Spotless formatting failed"
+  popd >/dev/null || exit 1
+
   header "Running control plane build tests"
   default_build_test_runner || fail_test "Control plane build tests failed"
 }


### PR DESCRIPTION
Fixes #3349
#### Spotless formatting is configured in the data-plane modules, but formatting violations are currently only detected indirectly during the build phase.

This results in:
- unclear failure messages (e.g. generic build failure)
- delayed feedback (failure occurs later in the pipeline)
#### This PR adds an explicit `spotless:check` step to the presubmit build tests.
With this change:
- formatting issues are detected early
- failures are clearly surfaced with a dedicated message

NOTE : As Spotless support was introduced in #3171, the check was already enforced indirectly via the build ; it is now made explicit to improve failure visibility.