### PR TITLE
fix(data-plane): fetch k8s secrets on separate thread from main vertx instance to prevent contention

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesAuthProvider.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesAuthProvider.java
@@ -19,54 +19,63 @@ import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 
 class KubernetesAuthProvider implements AuthProvider {
 
     private final Vertx vertx;
     private final KubernetesClient kubernetesClient;
+    private final ExecutorService secretFetchExecutor;
 
     KubernetesAuthProvider(final Vertx vertx, final KubernetesClient client) {
         this.vertx = vertx;
         this.kubernetesClient = client;
+        this.secretFetchExecutor = Executors.newVirtualThreadPerTaskExecutor();
     }
 
     private Future<Credentials> getCredentials(final DataPlaneContract.Reference secretReference) {
-        return this.vertx.executeBlocking(p -> {
+        final Promise<Credentials> promise = Promise.promise();
+        secretFetchExecutor.execute(() -> {
             try {
                 final Secret secret = getSecretFromKubernetes(secretReference);
                 final var credentials = new KubernetesCredentials(secret);
                 final var error = CredentialsValidator.validate(credentials);
                 if (error != null) {
-                    p.fail(error);
+                    vertx.runOnContext(v -> promise.fail(error));
                     return;
                 }
-                p.complete(credentials);
+                vertx.runOnContext(v -> promise.complete(credentials));
             } catch (final Exception ex) {
-                p.fail(ex);
+                vertx.runOnContext(v -> promise.fail(ex));
             }
         });
+        return promise.future();
     }
 
     private Future<Credentials> getCredentials(final DataPlaneContract.MultiSecretReference secretReferences) {
-        return this.vertx.executeBlocking(p -> {
+        final Promise<Credentials> promise = Promise.promise();
+        secretFetchExecutor.execute(() -> {
             try {
                 final var credentials = new KubernetesCredentials(secretDataOf(secretReferences));
                 final var error = CredentialsValidator.validate(credentials);
                 if (error != null) {
-                    p.fail(error);
+                    vertx.runOnContext(v -> promise.fail(error));
                     return;
                 }
-                p.complete(credentials);
+                vertx.runOnContext(v -> promise.complete(credentials));
             } catch (final Exception ex) {
-                p.fail(ex);
+                vertx.runOnContext(v -> promise.fail(ex));
             }
         });
+        return promise.future();
     }
 
     private Map<String, String> secretDataOf(final DataPlaneContract.MultiSecretReference secretReferences) {


### PR DESCRIPTION


<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This should fix a bug where dispatcher pods sometimes fail to start by timing out while fetching a secret in the egress reconciliation. As far as I can tell, this is happening because we switched to using the default vert.x http client for these requests, so the execute blocking calls + all the fetch requests contend on the same thread.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use a separate executor for the auth instead of the default vert.x thread

```release-note
fix(data-plane): resolve issue where dispatcher pods sometimes fail at startup while trying to fetch secrets
```
