### PR TITLE
Added null check to ExactFilter to handle case where FilterAttributes…

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/ExactFilter.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/ExactFilter.java
@@ -26,6 +26,6 @@ public class ExactFilter extends AttributesFilter {
 
     @Override
     public boolean match(String given, String wanted) {
-        return given.equals(wanted);
+        return given != null && given.equals(wanted);
     }
 }

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/ExactFilterTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/filter/subscriptionsapi/ExactFilterTest.java
@@ -109,6 +109,29 @@ public class ExactFilterTest {
     }
 
     @Test
+    public void shouldNotPassOnNonExistentAttributes() {
+
+        final var event = CloudEventBuilder.v1()
+                .withId("123")
+                .withType("type")
+                .withSource(URI.create("/api/source"))
+                .withExtension("extension2", "valueExtension2")
+                .build();
+
+        final var attributes = Map.of(
+                "source", "/api/source",
+                "extension1", "",
+                "extension2", "valueExtension2",
+                "subject", "someSubject"); // CloudEvent::getSubject == null on test
+
+        final var filter = new ExactFilter(attributes);
+
+        final boolean match = filter.test(event);
+
+        assertThat(match).isFalse();
+    }
+
+    @Test
     public void test() {
 
         final var event = CloudEventBuilder.v1()


### PR DESCRIPTION
… may be missing from CloudEvent and are nullable functions in attributeMapper.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

We intended to upgrade our Knative Eventing stack from 1.13 to 1.20 recently. However the CloudEvents our system utilizes the "subject" optional attribute of the CloudEvent spec. The ExactFilter which underpins the default Trigger implementation on the kafka-broker-dispatcher attempts to evaluate the CloudEvent::getSubject attribute expression during the filter.test(). In the case where Trigger has "subject" as a filter attribute, but a CloudEvent does not contain a "subject" field, the "given" variable of the match() function in the ExactFilter, and possibly other AttributeFilters, will be Null and result in a NullPointerException. 

This NullPointerException has existed since our version of Knative (1.13) but the ConsumerVerticles in the kafka-broker-dispatchers were able function despite throwing this error.

This line in the [RecordDispatcherImpl](https://github.com/knative-extensions/eventing-kafka-broker/blob/main/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java#L225) is where the test would throw the NullPointerException. 

However, upon upgrade to Knative 1.20 we noticed that the NullPointerException would launch our system into a Kafka Rebalance Storm. Below is what we think is occurring:

Whenever a CloudEvent produced the NullPointerException, the number of [inFlightEvents](https://github.com/knative-extensions/eventing-kafka-broker/blob/main/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java#L89C33-L89C47) had been increased. However this exception is caught in the [fatal catch block](https://github.com/knative-extensions/eventing-kafka-broker/blob/main/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java#L190) and although the record is summarily discarded, the inFlightEvents counter is never decremented. 

Since the inFlightEvents is never decremented to 0, upon manual Trigger deletion in the cluster, the ConsumerVerticle would hang and not [close](https://github.com/knative-extensions/eventing-kafka-broker/blob/4acacc2fc1bd9feb8dd174ae059e8a822b20d5c2/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/RecordDispatcherImpl.java#L516). 

This was evidenced by the existence of the Consumer in the the Trigger's ConsumerGroup on Kafka after deletion of the Trigger. The Consumer would also persist beyond the `session.timeout`. 

Whenever a subsequent Trigger was deployed to the system. The Kafka brokers would attempt to rebalance the partitions of the Knative Eventing Broker Topic amongst the new Consumer and the old (hung) Consumer which would leave the Kafka system in Rebalance permanently. 

We proposed this change to the ExactFilter since it was able to replicate our NullPointerException via a test and if an Exact Match of all attributes is not possible due to a null member, then the filter itself should not pass.


**Release Note**
-


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->


<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug:  Fix bug in ExactFilter When Given Is Null
```

**Docs**

