### PR TITLE
fix(control-plane): kafkasink reconciler cluster admin error

### DIFF
--- a/control-plane/pkg/reconciler/base/receiver_condition_set.go
+++ b/control-plane/pkg/reconciler/base/receiver_condition_set.go
@@ -23,14 +23,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	sources "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/reconciler"
-
-	sources "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1"
-
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 )
 
 const (
@@ -182,6 +180,18 @@ func (manager *StatusConditionManager) TopicReady(topic string) {
 		fmt.Sprintf("Topic %s created", topic),
 		"",
 	)
+}
+
+func (manager *StatusConditionManager) FailedToGetKafkaClusterAdmin(err error) reconciler.Event {
+
+	manager.Object.GetConditionSet().Manage(manager.Object.GetStatus()).MarkFalse(
+		ConditionTopicReady,
+		"Failed to obtain Kafka cluster admin",
+		"%v",
+		err,
+	)
+
+	return fmt.Errorf("cannot obtain Kafka cluster admin: %w", err)
 }
 
 func (manager *StatusConditionManager) FailedToGetBrokerAuthSecret(err error) reconciler.Event {

--- a/control-plane/pkg/reconciler/sink/kafka_sink.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink.go
@@ -21,41 +21,34 @@ import (
 	"fmt"
 	"time"
 
-	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
-
-	corev1 "k8s.io/api/core/v1"
-	eventingv1alpha1listers "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
-
-	"k8s.io/utils/ptr"
-	"knative.dev/eventing/pkg/auth"
-	"knative.dev/pkg/logging"
-
 	"github.com/IBM/sarama"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/retry"
-	"knative.dev/pkg/controller"
-	pointer "knative.dev/pkg/ptr"
-	"knative.dev/pkg/reconciler"
-	"knative.dev/pkg/resolver"
-
-	"knative.dev/eventing/pkg/apis/feature"
-
+	"k8s.io/utils/ptr"
+	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/clientpool"
-
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-
-	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 	coreconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/core/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/clientpool"
 	kafkalogging "knative.dev/eventing-kafka-broker/control-plane/pkg/logging"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/receiver"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
+	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing/pkg/apis/feature"
+	"knative.dev/eventing/pkg/auth"
+	eventingv1alpha1listers "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	pointer "knative.dev/pkg/ptr"
+	"knative.dev/pkg/reconciler"
+	"knative.dev/pkg/resolver"
 )
 
 const (
@@ -127,7 +120,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, ks *eventingv1alpha1.Kaf
 
 	kafkaClusterAdminClient, err := r.GetKafkaClusterAdmin(ctx, ks.Spec.BootstrapServers, secret)
 	if err != nil {
-		return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)
+		return statusConditionManager.FailedToGetKafkaClusterAdmin(err)
 	}
 	defer kafkaClusterAdminClient.Close()
 

--- a/control-plane/pkg/reconciler/sink/kafka_sink_test.go
+++ b/control-plane/pkg/reconciler/sink/kafka_sink_test.go
@@ -22,45 +22,36 @@ import (
 	"io"
 	"testing"
 
-	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
-
-	"knative.dev/eventing/pkg/auth"
-
-	pointer "knative.dev/pkg/ptr"
-
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"knative.dev/pkg/network"
-
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
-	kafkatesting "knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/testing"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober/probertesting"
-
 	"github.com/IBM/sarama"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
-	"knative.dev/pkg/apis"
-	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
-
-	. "knative.dev/pkg/reconciler/testing"
-
-	"knative.dev/eventing/pkg/apis/feature"
-
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing"
 	kafkaeventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 	fakeeventingkafkaclient "knative.dev/eventing-kafka-broker/control-plane/pkg/client/injection/client/fake"
 	sinkreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/client/injection/reconciler/eventing/v1alpha1/kafkasink"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
+	kafkatesting "knative.dev/eventing-kafka-broker/control-plane/pkg/kafka/testing"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober/probertesting"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/receiver"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/sink"
 	. "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/testing"
-
+	"knative.dev/eventing/pkg/apis/feature"
+	"knative.dev/eventing/pkg/auth"
 	eventingtlstesting "knative.dev/eventing/pkg/eventingtls/eventingtlstesting"
+	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/network"
+	pointer "knative.dev/pkg/ptr"
+	. "knative.dev/pkg/reconciler/testing"
 )
 
 var (
@@ -75,6 +66,7 @@ const (
 	wantTopicName                  = "wantTopicName"
 	wantErrorOnCreateTopic         = "wantErrorOnCreateTopic"
 	wantErrorOnDeleteTopic         = "wantErrorOnDeleteTopic"
+	wantErrorOnGetClusterAdmin     = "wantErrorOnGetClusterAdmin"
 	ExpectedTopicDetail            = "expectedTopicDetail"
 	ExpectedTopicsOnDescribeTopics = "expectedTopicsOnDescribeTopics"
 	ExpectedTopicIsPresent         = "expectedTopicIsPresent"
@@ -116,6 +108,8 @@ var (
 	errCreateTopic = fmt.Errorf("failed to create topic")
 
 	errDeleteTopic = fmt.Errorf("failed to delete topic")
+
+	errGetClusterAdmin = fmt.Errorf("failed to get cluster admin")
 )
 
 var DefaultEnv = &config.Env{
@@ -598,6 +592,44 @@ func sinkReconciliation(t *testing.T, format string, env config.Env) {
 			},
 			OtherTestData: map[string]interface{}{
 				wantErrorOnCreateTopic: errCreateTopic,
+			},
+		},
+		{
+			Name: "Failed to get Kafka cluster admin",
+			Objects: []runtime.Object{
+				NewSink(
+					StatusControllerOwnsTopic(sink.ControllerTopicOwner),
+					BootstrapServers(bootstrapServersArr),
+				),
+				SinkReceiverPod(env.SystemNamespace, nil),
+			},
+			Key:     testKey,
+			WantErr: true,
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+				Eventf(
+					corev1.EventTypeWarning,
+					"InternalError",
+					"cannot obtain Kafka cluster admin: %v",
+					errGetClusterAdmin,
+				),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: NewSink(
+						StatusControllerOwnsTopic(sink.ControllerTopicOwner),
+						InitSinkConditions,
+						StatusDataPlaneAvailable,
+						BootstrapServers(bootstrapServersArr),
+						StatusFailedToGetKafkaClusterAdmin(errGetClusterAdmin),
+					),
+				},
+			},
+			OtherTestData: map[string]interface{}{
+				wantErrorOnGetClusterAdmin: errGetClusterAdmin,
 			},
 		},
 		{
@@ -1978,6 +2010,9 @@ func useTable(t *testing.T, table TableTest, env *config.Env) {
 			ConfigMapLister:   listers.GetConfigMapLister(),
 			EventPolicyLister: listers.GetEventPolicyLister(),
 			GetKafkaClusterAdmin: func(_ context.Context, _ []string, _ *corev1.Secret) (sarama.ClusterAdmin, error) {
+				if errClusterAdmin, ok := row.OtherTestData[wantErrorOnGetClusterAdmin]; ok {
+					return nil, errClusterAdmin.(error)
+				}
 				return &kafkatesting.MockKafkaClusterAdmin{
 					ExpectedTopicName:                      expectedTopicName,
 					ExpectedTopicDetail:                    expectedTopicDetail,

--- a/control-plane/pkg/reconciler/testing/objects_common.go
+++ b/control-plane/pkg/reconciler/testing/objects_common.go
@@ -22,32 +22,28 @@ import (
 	"time"
 
 	"github.com/magiconair/properties"
-	appsv1 "k8s.io/api/apps/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/types"
-	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
-
-	sources "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1"
-
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
+	kafkaeventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internalskafkaeventing"
+	sources "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
+	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	pointer "knative.dev/pkg/ptr"
-
-	kafkaeventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/internalskafkaeventing"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
-
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 )
 
 const (
@@ -532,6 +528,17 @@ func StatusFailedToCreateTopic(topicName string) func(obj duckv1.KRShaped) {
 			fmt.Sprintf("Failed to create topic: %s", topicName),
 			"%v",
 			fmt.Errorf("failed to create topic"),
+		)
+	}
+}
+
+func StatusFailedToGetKafkaClusterAdmin(err error) func(obj duckv1.KRShaped) {
+	return func(obj duckv1.KRShaped) {
+		obj.GetConditionSet().Manage(obj.GetStatus()).MarkFalse(
+			base.ConditionTopicReady,
+			"Failed to obtain Kafka cluster admin",
+			"%v",
+			err,
 		)
 	}
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Fixes
This fixes an issue where the ready state of a KafkaSink resource is not updated when a reconciliation fails. Specifically this error came about by updating a KafkaSink bootstrapServers field to invalid IPs. When Knative attempts to reconcile the KafkaSink it fails to do so and then requeues the reconciliation. What it should do though is change the ready status to false and then continue to requeue the reconciliation. 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- Sets the KafkaSink object ready condition to false if the reconciler fails to obtain Kafka cluster admin.
