### PR TITLE
fix(test): fix flaky upgrade tests

### DIFF
--- a/test/rekt/features/kafka_source.go
+++ b/test/rekt/features/kafka_source.go
@@ -348,7 +348,7 @@ func KafkaSourceFeatureSetup(f *feature.Feature,
 	return kafkaSinkCfg.sinkName, kafkaSourceCfg.sourceName, receiver
 }
 
-func KafkaSourceFeatureAssert(f *feature.Feature, kafkaSink, receiver string, customizeFunc CustomizeEventFunc) {
+func KafkaSourceFeatureAssert(f *feature.Feature, kafkaSink, receiver string, customizeFunc CustomizeEventFunc, extraOpts ...eventshub.EventsHubOption) {
 	sender := feature.MakeRandomK8sName("eventshub-sender")
 	options := []eventshub.EventsHubOption{
 		eventshub.StartSenderToResource(kafkasink.GVR(), kafkaSink),
@@ -357,6 +357,7 @@ func KafkaSourceFeatureAssert(f *feature.Feature, kafkaSink, receiver string, cu
 	senderOpts, matcher := customizeFunc()
 
 	options = append(options, senderOpts...)
+	options = append(options, extraOpts...)
 
 	f.Requirement("install eventshub sender", eventshub.Install(sender, options...))
 

--- a/test/rekt/features/kafka_source.go
+++ b/test/rekt/features/kafka_source.go
@@ -283,7 +283,7 @@ type kafkaSinkConfig struct {
 
 func KafkaSourceFeatureSetup(f *feature.Feature,
 	kafkaSourceCfg kafkaSourceConfig,
-	kafkaSinkCfg kafkaSinkConfig) (string, string) {
+	kafkaSinkCfg kafkaSinkConfig) (string, string, string) {
 
 	if kafkaSourceCfg.topic == "" {
 		kafkaSourceCfg.topic = feature.MakeRandomK8sName("topic")
@@ -345,7 +345,7 @@ func KafkaSourceFeatureSetup(f *feature.Feature,
 	f.Setup("install kafka source", kafkasource.Install(kafkaSourceCfg.sourceName, kafkaSourceOpts...))
 	f.Requirement("kafka source is ready", kafkasource.IsReady(kafkaSourceCfg.sourceName))
 
-	return kafkaSinkCfg.sinkName, receiver
+	return kafkaSinkCfg.sinkName, kafkaSourceCfg.sourceName, receiver
 }
 
 func KafkaSourceFeatureAssert(f *feature.Feature, kafkaSink, receiver string, customizeFunc CustomizeEventFunc) {
@@ -407,13 +407,13 @@ func KafkaSourceBinaryEventCustomizeFunc() CustomizeEventFunc {
 func KafkaSourceBinaryEvent() *feature.Feature {
 	f := feature.NewFeatureNamed("KafkaSourceBinaryEvent")
 
-	kafkaSink, receiver := KafkaSourceBinaryEventFeatureSetup(f)
+	kafkaSink, _, receiver := KafkaSourceBinaryEventFeatureSetup(f)
 	KafkaSourceFeatureAssert(f, kafkaSink, receiver, KafkaSourceBinaryEventCustomizeFunc())
 
 	return f
 }
 
-func KafkaSourceBinaryEventFeatureSetup(f *feature.Feature) (string, string) {
+func KafkaSourceBinaryEventFeatureSetup(f *feature.Feature) (string, string, string) {
 	return KafkaSourceFeatureSetup(f,
 		kafkaSourceConfig{
 			authMech: PlainMech,
@@ -448,7 +448,7 @@ func KafkaSourceBinaryEventWithExtensions() *feature.Feature {
 
 	f := feature.NewFeatureNamed("KafkaSourceBinaryEventWithExtensions")
 
-	kafkaSink, receiver := KafkaSourceFeatureSetup(f,
+	kafkaSink, _, receiver := KafkaSourceFeatureSetup(f,
 		kafkaSourceConfig{
 			authMech: PlainMech,
 			opts: []manifest.CfgFn{
@@ -504,13 +504,13 @@ func KafkaSourceStructuredEventCustomizeFunc() CustomizeEventFunc {
 func KafkaSourceStructuredEvent() *feature.Feature {
 	f := feature.NewFeatureNamed("KafkaSourceStructuredEvent")
 
-	kafkaSink, receiver := KafkaSourceBinaryEventFeatureSetup(f)
+	kafkaSink, _, receiver := KafkaSourceBinaryEventFeatureSetup(f)
 	KafkaSourceFeatureAssert(f, kafkaSink, receiver, KafkaSourceStructuredEventCustomizeFunc())
 
 	return f
 }
 
-func KafkaSourceStructuredEventFeatureSetup(f *feature.Feature) (string, string) {
+func KafkaSourceStructuredEventFeatureSetup(f *feature.Feature) (string, string, string) {
 	return KafkaSourceFeatureSetup(f,
 		kafkaSourceConfig{
 			authMech: PlainMech,
@@ -544,7 +544,7 @@ func KafkaSourceWithExtensions() *feature.Feature {
 
 	f := feature.NewFeatureNamed("KafkaSourceWithExtensions")
 
-	kafkaSink, receiver := KafkaSourceFeatureSetup(f,
+	kafkaSink, _, receiver := KafkaSourceFeatureSetup(f,
 		kafkaSourceConfig{
 			authMech: PlainMech,
 			opts: []manifest.CfgFn{
@@ -579,7 +579,7 @@ func KafkaSourceTLS(kafkaSource, kafkaSink, topic string) *feature.Feature {
 
 	f := feature.NewFeatureNamed("KafkaSourceTLS")
 
-	kafkaSink, receiver := KafkaSourceFeatureSetup(f,
+	kafkaSink, _, receiver := KafkaSourceFeatureSetup(f,
 		kafkaSourceConfig{
 			authMech:   TLSMech,
 			topic:      topic,
@@ -719,7 +719,7 @@ func KafkaSourceSASL() *feature.Feature {
 
 	f := feature.NewFeatureNamed("KafkaSourceSASL")
 
-	kafkaSink, receiver := KafkaSourceFeatureSetup(f,
+	kafkaSink, _, receiver := KafkaSourceFeatureSetup(f,
 		kafkaSourceConfig{
 			authMech: SASLMech,
 		},

--- a/test/rekt/features/keda_scaling.go
+++ b/test/rekt/features/keda_scaling.go
@@ -155,7 +155,7 @@ func KafkaSourceSASLScalesToZeroWithKeda() *feature.Feature {
 	sinkCfg := kafkaSinkConfig{
 		sinkName: feature.MakeRandomK8sName("kafka-sink"),
 	}
-	sinkName, receiver := KafkaSourceFeatureSetup(f, sourceCfg, sinkCfg)
+	sinkName, _, receiver := KafkaSourceFeatureSetup(f, sourceCfg, sinkCfg)
 
 	sender := feature.MakeRandomK8sName("eventshub-sender")
 

--- a/test/upgrade/smoke.go
+++ b/test/upgrade/smoke.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/uuid"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/test/rekt/features"
+	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkasink"
+	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkasource"
 	brokerfeatures "knative.dev/eventing/test/rekt/features/broker"
 	channelfeatures "knative.dev/eventing/test/rekt/features/channel"
 	"knative.dev/eventing/test/rekt/features/knconf"
@@ -77,10 +79,12 @@ func KafkaChannelFeature(glob environment.GlobalEnvironment) *eventingupgrade.Du
 func KafkaSinkSourceBinaryEventFeature(glob environment.GlobalEnvironment,
 ) *eventingupgrade.DurableFeature {
 	setupF := feature.NewFeature()
-	kafkaSink, receiver := features.KafkaSourceBinaryEventFeatureSetup(setupF)
+	kafkaSink, kafkaSource, receiver := features.KafkaSourceBinaryEventFeatureSetup(setupF)
 
 	verifyF := func() *feature.Feature {
 		f := feature.NewFeatureNamed(setupF.Name)
+		f.Requirement("kafkasink is ready", kafkasink.IsReady(kafkaSink))
+		f.Requirement("kafkasource is ready", kafkasource.IsReady(kafkaSource))
 		features.KafkaSourceFeatureAssert(f, kafkaSink, receiver, features.KafkaSourceBinaryEventCustomizeFunc())
 		return f
 	}
@@ -91,9 +95,11 @@ func KafkaSinkSourceBinaryEventFeature(glob environment.GlobalEnvironment,
 func KafkaSinkSourceStructuredEventFeature(glob environment.GlobalEnvironment,
 ) *eventingupgrade.DurableFeature {
 	setupF := feature.NewFeature()
-	kafkaSink, receiver := features.KafkaSourceStructuredEventFeatureSetup(setupF)
+	kafkaSink, kafkaSource, receiver := features.KafkaSourceStructuredEventFeatureSetup(setupF)
 	verifyF := func() *feature.Feature {
 		f := feature.NewFeatureNamed(setupF.Name)
+		f.Requirement("kafkasink is ready", kafkasink.IsReady(kafkaSink))
+		f.Requirement("kafkasource is ready", kafkasource.IsReady(kafkaSource))
 		features.KafkaSourceFeatureAssert(f, kafkaSink, receiver, features.KafkaSourceStructuredEventCustomizeFunc())
 		return f
 	}
@@ -113,6 +119,8 @@ func BrokerEventTransformationForTrigger(glob environment.GlobalEnvironment,
 
 	verifyF := func() *feature.Feature {
 		f := feature.NewFeatureNamed(setupF.Name)
+		f.Requirement("broker is ready", brokerresources.IsReady(cfg.Broker))
+		f.Requirement("broker is addressable", brokerresources.IsAddressable(cfg.Broker))
 		brokerfeatures.BrokerEventTransformationForTriggerAssert(f, cfg)
 		return f
 	}
@@ -134,6 +142,8 @@ func NamespacedBrokerEventTransformationForTrigger(glob environment.GlobalEnviro
 
 	verifyF := func() *feature.Feature {
 		f := feature.NewFeatureNamed(setupF.Name)
+		f.Requirement("broker is ready", brokerresources.IsReady(broker))
+		f.Requirement("broker is addressable", brokerresources.IsAddressable(broker))
 		brokerAcceptsBinaryContentModeAssert(f, broker)
 		return f
 	}

--- a/test/upgrade/smoke.go
+++ b/test/upgrade/smoke.go
@@ -19,6 +19,7 @@ package upgrade
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
@@ -85,7 +86,7 @@ func KafkaSinkSourceBinaryEventFeature(glob environment.GlobalEnvironment,
 		f := feature.NewFeatureNamed(setupF.Name)
 		f.Requirement("kafkasink is ready", kafkasink.IsReady(kafkaSink))
 		f.Requirement("kafkasource is ready", kafkasource.IsReady(kafkaSource))
-		features.KafkaSourceFeatureAssert(f, kafkaSink, receiver, features.KafkaSourceBinaryEventCustomizeFunc())
+		features.KafkaSourceFeatureAssert(f, kafkaSink, receiver, features.KafkaSourceBinaryEventCustomizeFunc(), eventshub.SendMultipleEvents(10, 3*time.Second))
 		return f
 	}
 
@@ -100,7 +101,7 @@ func KafkaSinkSourceStructuredEventFeature(glob environment.GlobalEnvironment,
 		f := feature.NewFeatureNamed(setupF.Name)
 		f.Requirement("kafkasink is ready", kafkasink.IsReady(kafkaSink))
 		f.Requirement("kafkasource is ready", kafkasource.IsReady(kafkaSource))
-		features.KafkaSourceFeatureAssert(f, kafkaSink, receiver, features.KafkaSourceStructuredEventCustomizeFunc())
+		features.KafkaSourceFeatureAssert(f, kafkaSink, receiver, features.KafkaSourceStructuredEventCustomizeFunc(), eventshub.SendMultipleEvents(10, 3*time.Second))
 		return f
 	}
 


### PR DESCRIPTION
The upgrade tests are flaky across multiple PRs (e.g. #4724, #4716) with different tests failing each run.

## Root Cause

Two issues cause the flakes:

1. **Missing readiness checks**: After upgrade/downgrade, the verify phases immediately send events without waiting for resources to become ready again. The `kafka-source-dispatcher` pod restarts during upgrade and the KafkaSource CR temporarily goes NotReady (`BindInProgress`).

2. **Consumer subscription race**: Even after the KafkaSource CR reports Ready (dispatcher pod is running), the Kafka consumer inside the pod may not have joined the consumer group yet. Since no events are produced during pre-upgrade setup, there are no committed offsets. With `auto.offset.reset=latest`, the consumer starts at the end of the topic. The sender sends exactly 1 event — if it is produced before the consumer subscribes, the event is missed permanently and the test times out.

## Proposed Changes

- Add `kafkasink.IsReady()` and `kafkasource.IsReady()` requirements to `KafkaSinkSourceBinaryEventFeature` and `KafkaSinkSourceStructuredEventFeature` verify phases
- Add `broker.IsReady()` and `broker.IsAddressable()` requirements to `BrokerEventTransformationForTrigger` and `NamespacedBrokerEventTransformationForTrigger` verify phases
- Return the KafkaSource name from `KafkaSourceFeatureSetup` so callers can check its readiness
- Add `extraOpts` variadic parameter to `KafkaSourceFeatureAssert` for backward-compatible sender customization
- Send 10 events over ~27s in upgrade verify phases (via `SendMultipleEvents`) so at least some events arrive after the consumer subscribes