### PR TITLE
[Release-1.22] Update netty, logback-core, vertx-core, and jackson-core to resolve vulnerabilities

### DIFF
--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -42,15 +42,15 @@
     <spotless.plugin.version>2.46.1</spotless.plugin.version>
 
     <!-- dependencies version -->
-    <vertx.version>4.5.16</vertx.version>
+    <vertx.version>4.5.24</vertx.version>
     <cloudevents.sdk.version>4.0.1</cloudevents.sdk.version>
     <micrometer.version>1.15.4</micrometer.version>
     <opentelemetry.version>1.60.1</opentelemetry.version>
-    <jackson.version>2.18.3</jackson.version>
+    <jackson.version>2.18.6</jackson.version>
     <protobuf.version>3.25.5</protobuf.version>
     <bucket4j.version>7.6.0</bucket4j.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <ch.qos.logback.version>1.5.18</ch.qos.logback.version>
+    <ch.qos.logback.version>1.5.25</ch.qos.logback.version>
     <net.logstash.logback.encoder.version>8.0</net.logstash.logback.encoder.version>
     <assertj.version>3.27.3</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
@@ -60,7 +60,7 @@
     <kafka.version>3.9.1</kafka.version>
     <debezium.version>3.0.7.Final</debezium.version>
     <jib.version>3.4.6</jib.version>
-    <quarkus.version>3.28.0</quarkus.version>
+    <quarkus.version>3.36.3</quarkus.version>
     <antlr.version>4.9.2
     </antlr.version> <!-- Overwritting quarkus's antlr version. Reminder: antlr4-maven-plugin,antlr4-runtime, antlr4 need to have the same version -->
     <palantirJavaFormat.version>2.81.0</palantirJavaFormat.version>

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -42,7 +42,7 @@
     <spotless.plugin.version>2.46.1</spotless.plugin.version>
 
     <!-- dependencies version -->
-    <vertx.version>4.5.27</vertx.version>
+    <vertx.version>4.5.16</vertx.version>
     <cloudevents.sdk.version>4.0.1</cloudevents.sdk.version>
     <micrometer.version>1.15.4</micrometer.version>
     <opentelemetry.version>1.60.1</opentelemetry.version>

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -42,7 +42,7 @@
     <spotless.plugin.version>2.46.1</spotless.plugin.version>
 
     <!-- dependencies version -->
-    <vertx.version>4.5.16</vertx.version>
+    <vertx.version>4.5.27</vertx.version>
     <cloudevents.sdk.version>4.0.1</cloudevents.sdk.version>
     <micrometer.version>1.15.4</micrometer.version>
     <opentelemetry.version>1.60.1</opentelemetry.version>
@@ -60,7 +60,7 @@
     <kafka.version>3.9.1</kafka.version>
     <debezium.version>3.0.7.Final</debezium.version>
     <jib.version>3.4.6</jib.version>
-    <quarkus.version>3.36.3</quarkus.version>
+    <quarkus.version>3.28.0</quarkus.version>
     <antlr.version>4.9.2
     </antlr.version> <!-- Overwritting quarkus's antlr version. Reminder: antlr4-maven-plugin,antlr4-runtime, antlr4 need to have the same version -->
     <palantirJavaFormat.version>2.81.0</palantirJavaFormat.version>

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -61,6 +61,7 @@
     <debezium.version>3.0.7.Final</debezium.version>
     <jib.version>3.4.6</jib.version>
     <quarkus.version>3.28.0</quarkus.version>
+    <netty.version>4.1.135.Final</netty.version> <!-- Overwritting quarkus's netty version.-->
     <antlr.version>4.9.2
     </antlr.version> <!-- Overwritting quarkus's antlr version. Reminder: antlr4-maven-plugin,antlr4-runtime, antlr4 need to have the same version -->
     <palantirJavaFormat.version>2.81.0</palantirJavaFormat.version>
@@ -116,6 +117,16 @@
 
   <dependencyManagement>
     <dependencies>
+
+      <!-- Netty -->
+      <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-bom</artifactId>
+          <version>${netty.version}</version>
+          <type>pom</type>
+          <scope>import</scope>
+      </dependency>
+
       <!-- Vertx -->
       <dependency>
         <groupId>io.quarkus</groupId>

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -42,7 +42,7 @@
     <spotless.plugin.version>2.46.1</spotless.plugin.version>
 
     <!-- dependencies version -->
-    <vertx.version>4.5.24</vertx.version>
+    <vertx.version>4.5.27</vertx.version>
     <cloudevents.sdk.version>4.0.1</cloudevents.sdk.version>
     <micrometer.version>1.15.4</micrometer.version>
     <opentelemetry.version>1.60.1</opentelemetry.version>


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes several open CVEs picked up by security scanners

Logback-core `1.5.18` to `1.5.25`
https://github.com/advisories/GHSA-25qh-j22f-pwp8
https://github.com/advisories/GHSA-qqpg-mvqg-649v

Vertx-core `4.5.16` to `4.5.27`
https://github.com/advisories/GHSA-cphf-4846-3xx9 
https://github.com/advisories/GHSA-3g76-f9xq-8vp6

Jackson-core `2.18.3` to `2.18.6`
https://github.com/advisories/GHSA-72hv-8253-57qq 

Netty (overriding Quarkus `3.28.0`'s netty version `4.1.127.Final`)  to `4.1.135.Final`
https://github.com/advisories/GHSA-84h7-rjj3-6jx4 
https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 
https://github.com/advisories/GHSA-w9fj-cfpg-grvv 
https://github.com/advisories/GHSA-v8h7-rr48-vmmv 
https://github.com/advisories/GHSA-45q3-82m4-75jr 
https://github.com/advisories/GHSA-cm33-6792-r9fm 
https://github.com/advisories/GHSA-m4cv-j2px-7723 
https://github.com/advisories/GHSA-xxqh-mfjm-7mv9
https://github.com/advisories/GHSA-mj4r-2hfc-f8p6
https://github.com/advisories/GHSA-57rv-r2g8-2cj3 
https://github.com/advisories/GHSA-38f8-5428-x5cv
https://github.com/advisories/GHSA-f6hv-jmp6-3vwv 
https://github.com/advisories/GHSA-3qp7-7mw8-wx86 
https://github.com/advisories/GHSA-cc37-9q2j-3hfv 
https://github.com/advisories/GHSA-x4gw-5cx5-pgmh 
https://github.com/advisories/GHSA-xmv7-r254-6q78 
https://github.com/advisories/GHSA-676x-f7gg-47vc 
https://github.com/advisories/GHSA-5x3r-wrvg-rp6q 
https://github.com/advisories/GHSA-5pvg-856g-cp85 
https://github.com/advisories/GHSA-c2gf-v879-257j 
https://github.com/advisories/GHSA-h2qv-fj59-j46j 
https://github.com/advisories/GHSA-c653-97m9-rcg9 
https://github.com/advisories/GHSA-hvcg-qmg6-jm4c
https://github.com/advisories/GHSA-563q-j3cm-6jxm

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Upgrade pom packages to resolve open CVEs, with a particular focus on netty issues in the kafka-broker-dispatcher and kafka-broker-receiver pods

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
