### PR TITLE
[release-1.22] Fix OpenTelemetry BOM ordering to ensure declared version takes precedence

### DIFF
--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -118,6 +118,17 @@
   <dependencyManagement>
     <dependencies>
 
+      <!-- OpenTelemetry BOM must be imported before quarkus-bom to ensure
+           the explicitly declared opentelemetry.version takes precedence
+           over the version transitively managed by Quarkus. -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- Netty -->
       <dependency>
           <groupId>io.netty</groupId>
@@ -170,14 +181,6 @@
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
         <version>${micrometer.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-bom</artifactId>
-        <version>${opentelemetry.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Summary

- Cherry-pick of #4752 to release-1.22
- The `quarkus-bom` was imported before the `opentelemetry-bom` in `data-plane/pom.xml` `<dependencyManagement>`. In Maven, when multiple BOMs manage the same artifact, the first declaration wins. This caused the Quarkus-managed OTel version (`1.44.x`) to silently override the explicitly declared `opentelemetry.version`, making the OTel version bump from #4633 / #4680 ineffective.
- Moves the `opentelemetry-bom` import to the top of `<dependencyManagement>` so the project's declared version is actually used.

Fixes #4677