### PR TITLE
fix: Fix timer drift in cache impl

### DIFF
--- a/control-plane/pkg/counter/counter.go
+++ b/control-plane/pkg/counter/counter.go
@@ -18,12 +18,14 @@ package counter
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 )
 
 type Counter struct {
+	mu    sync.Mutex
 	cache prober.Cache[string, int, struct{}]
 }
 
@@ -35,11 +37,17 @@ func NewExpiringCounter(ctx context.Context) *Counter {
 }
 
 func (c *Counter) Inc(uuid string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	value, _ := c.cache.Get(uuid)
 	c.cache.UpsertStatus(uuid, value+1, struct{}{}, func(key string, value int, arg struct{}) {})
 	return value + 1
 }
 
 func (c *Counter) Del(uuid string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.cache.Expire(uuid)
 }

--- a/control-plane/pkg/counter/counter_test.go
+++ b/control-plane/pkg/counter/counter_test.go
@@ -18,6 +18,7 @@ package counter_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,4 +41,27 @@ func TestCounter(t *testing.T) {
 	c.Del(key)
 	v3 := c.Inc(key)
 	assert.Equal(t, 1, v3)
+}
+
+func TestCounterConcurrentInc(t *testing.T) {
+	ctx := context.Background()
+	c := counter.NewExpiringCounter(ctx)
+
+	const goroutines = 100
+	const key = "concurrent-key"
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			c.Inc(key)
+		}()
+	}
+
+	wg.Wait()
+
+	final := c.Inc(key)
+	assert.Equal(t, goroutines+1, final)
 }

--- a/control-plane/pkg/prober/cache.go
+++ b/control-plane/pkg/prober/cache.go
@@ -102,11 +102,13 @@ func NewLocalExpiringCacheWithDefault[K comparable, V, A interface{}](ctx contex
 		defaultValue: defaultValue,
 	}
 	go func() {
+		ticker := time.NewTicker(expiration)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(expiration):
+			case <-ticker.C:
 				c.removeExpiredEntries(time.Now())
 			}
 		}

--- a/control-plane/pkg/prober/cache.go
+++ b/control-plane/pkg/prober/cache.go
@@ -19,6 +19,8 @@ package prober
 import (
 	"container/list"
 	"context"
+	"fmt"
+	"os"
 	"sync"
 	"time"
 )
@@ -143,33 +145,45 @@ func (c *localExpiringCache[K, V, A]) UpsertStatus(key K, val V, arg A, onExpire
 
 func (c *localExpiringCache[K, V, A]) Expire(key K) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	element, ok := c.targets[key]
 	if !ok {
+		c.mu.Unlock()
 		return
 	}
 	c.entries.Remove(element)
 	delete(c.targets, key)
+	c.mu.Unlock()
 
 	v := element.Value.(*value[K, V, A])
-
 	v.onExpired(v.key, v.value, v.arg)
 }
 
 func (c *localExpiringCache[K, V, A]) removeExpiredEntries(now time.Time) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	var expiredEntries []*value[K, V, A]
 
+	c.mu.Lock()
 	for curr := c.entries.Front(); curr != nil && c.isExpired(curr.Value.(*value[K, V, A]), now); {
 		v := curr.Value.(*value[K, V, A])
 		delete(c.targets, v.key)
 		prev := curr
 		curr = curr.Next()
 		c.entries.Remove(prev)
-
-		v.onExpired(v.key, v.value, v.arg)
+		expiredEntries = append(expiredEntries, v)
 	}
+	c.mu.Unlock()
+
+	for _, v := range expiredEntries {
+		callOnExpired(v)
+	}
+}
+
+func callOnExpired[K comparable, V, A interface{}](v *value[K, V, A]) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "recovered panic in cache expiration callback: %v\n", r)
+		}
+	}()
+	v.onExpired(v.key, v.value, v.arg)
 }
 
 func (c *localExpiringCache[K, V, A]) isExpired(v *value[K, V, A], now time.Time) bool {

--- a/control-plane/pkg/prober/cache_test.go
+++ b/control-plane/pkg/prober/cache_test.go
@@ -104,3 +104,76 @@ func verifyOnExpired(expectedKey string, expectedArg int, wg *sync.WaitGroup, er
 		wg.Done()
 	}
 }
+
+func TestExpireCallbackDoesNotDeadlock(t *testing.T) {
+	d := 200 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c := NewLocalExpiringCache[string, int, int](ctx, d)
+
+	done := make(chan struct{})
+	go func() {
+		c.UpsertStatus("k1", 1, 1, func(key string, val int, arg int) {
+			// Callback that touches the cache — would deadlock if called under lock.
+			c.Get("k1")
+			c.UpsertStatus("k2", 2, 2, func(string, int, int) {})
+		})
+		c.Expire("k1")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("deadlock: Expire callback that touches cache did not complete in time")
+	}
+}
+
+func TestRemoveExpiredEntriesCallbackDoesNotDeadlock(t *testing.T) {
+	d := 200 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c := NewLocalExpiringCache[string, int, int](ctx, d)
+
+	callbackCalled := make(chan struct{})
+	c.UpsertStatus("k1", 1, 1, func(key string, val int, arg int) {
+		// Callback that touches the cache — would deadlock if called under lock.
+		c.Get("k1")
+		close(callbackCalled)
+	})
+
+	select {
+	case <-callbackCalled:
+	case <-ctx.Done():
+		t.Fatal("deadlock: removeExpiredEntries callback that touches cache did not complete in time")
+	}
+}
+
+func TestPanicInCallbackDoesNotKillGoroutine(t *testing.T) {
+	d := 200 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c := NewLocalExpiringCache[string, int, int](ctx, d)
+
+	secondExpired := make(chan struct{})
+
+	c.UpsertStatus("k1", 1, 1, func(string, int, int) {
+		panic("test panic")
+	})
+
+	// Wait for the panicking callback to fire, then insert a second entry
+	time.Sleep(d + 100*time.Millisecond)
+
+	c.UpsertStatus("k2", 2, 2, func(string, int, int) {
+		close(secondExpired)
+	})
+
+	select {
+	case <-secondExpired:
+	case <-ctx.Done():
+		t.Fatal("background goroutine died after panic in onExpired callback")
+	}
+}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- fix: Fix timer drift in cache impl

The background goroutine in cache.go:108-113 uses time.After(expiration) which creates a new timer each iteration, introducing cumulative drift. A time.NewTicker would fire at more consistent intervals and avoid the drift that causes entries to miss their expiration window under load. This results in unstable unit tests execution that fail intermittently. 

/cc @gauron99 