### PR TITLE
chore: Refactor handling of stale lister cache

### DIFF
--- a/control-plane/pkg/reconciler/base/reconciler.go
+++ b/control-plane/pkg/reconciler/base/reconciler.go
@@ -140,6 +140,11 @@ func (r *Reconciler) GetOrCreateDataPlaneConfigMap(ctx context.Context) (*corev1
 
 	if apierrors.IsNotFound(err) {
 		cm, err = r.createDataPlaneConfigMap(ctx)
+		if apierrors.IsAlreadyExists(err) {
+			cm, err = r.KubeClient.CoreV1().
+				ConfigMaps(r.DataPlaneConfigMapNamespace).
+				Get(ctx, r.ContractConfigMapName, metav1.GetOptions{})
+		}
 	}
 
 	if r.DataPlaneConfigMapTransformer != nil {

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -363,6 +363,9 @@ func (r *Reconciler) reconcileChannelService(ctx context.Context, channel *messa
 		if apierrors.IsNotFound(err) {
 			_, err = r.KubeClient.CoreV1().Services(channel.Namespace).Create(ctx, expected, metav1.CreateOptions{})
 			if err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					return expected, nil
+				}
 				return expected, fmt.Errorf("failed to create the channel service object: %w", err)
 			}
 			return expected, nil
@@ -674,7 +677,10 @@ func (r *Reconciler) reconcileConsumerGroup(ctx context.Context, channel *messag
 	}
 	if apierrors.IsNotFound(err) {
 		cg, err = r.InternalsClient.InternalV1alpha1().ConsumerGroups(expectedCg.GetNamespace()).Create(ctx, expectedCg, metav1.CreateOptions{})
-		if err != nil && !apierrors.IsAlreadyExists(err) {
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return r.InternalsClient.InternalV1alpha1().ConsumerGroups(expectedCg.GetNamespace()).Get(ctx, expectedCg.GetName(), metav1.GetOptions{})
+			}
 			return nil, fmt.Errorf("failed to create consumer group %s/%s: %w", expectedCg.GetNamespace(), expectedCg.GetName(), err)
 		}
 		return cg, nil

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -673,6 +673,9 @@ func (r *Reconciler) reconcileScaledObject(ctx context.Context, expectedScaledOb
 	if apierrors.IsNotFound(err) {
 		_, err = r.KedaClient.KedaV1alpha1().ScaledObjects(expectedScaledObject.Namespace).Create(ctx, expectedScaledObject, metav1.CreateOptions{})
 		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
 			return fmt.Errorf("failed to create scaledobject %s/%s: %w", expectedScaledObject.Namespace, expectedScaledObject.Name, err)
 		}
 		return nil
@@ -697,6 +700,9 @@ func (r *Reconciler) reconcileTriggerAuthentication(ctx context.Context, expecte
 	if apierrors.IsNotFound(err) {
 		_, err = r.KedaClient.KedaV1alpha1().TriggerAuthentications(expectedTriggerAuth.Namespace).Create(ctx, expectedTriggerAuth, metav1.CreateOptions{})
 		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
 			return fmt.Errorf("failed to create triggerauthentication  object %s/%s: %w", expectedTriggerAuth.Namespace, expectedTriggerAuth.Name, err)
 		}
 		return nil
@@ -721,6 +727,9 @@ func (r *Reconciler) reconcileSecret(ctx context.Context, expectedSecret *corev1
 	if apierrors.IsNotFound(err) {
 		_, err = r.KubeClient.CoreV1().Secrets(expectedSecret.Namespace).Create(ctx, expectedSecret, metav1.CreateOptions{})
 		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
 			return fmt.Errorf("failed to create secret %s/%s: %w", expectedSecret.Namespace, expectedSecret.Name, err)
 		}
 		return nil

--- a/control-plane/pkg/reconciler/source/source.go
+++ b/control-plane/pkg/reconciler/source/source.go
@@ -218,8 +218,11 @@ func (r Reconciler) reconcileConsumerGroup(ctx context.Context, ks *sources.Kafk
 		return nil, err
 	}
 	if apierrors.IsNotFound(err) {
-		cg, err := r.InternalsClient.InternalV1alpha1().ConsumerGroups(expectedCg.GetNamespace()).Create(ctx, expectedCg, metav1.CreateOptions{})
-		if err != nil && !apierrors.IsAlreadyExists(err) {
+		cg, err = r.InternalsClient.InternalV1alpha1().ConsumerGroups(expectedCg.GetNamespace()).Create(ctx, expectedCg, metav1.CreateOptions{})
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return r.InternalsClient.InternalV1alpha1().ConsumerGroups(expectedCg.GetNamespace()).Get(ctx, expectedCg.GetName(), metav1.GetOptions{})
+			}
 			return nil, fmt.Errorf("failed to create consumer group %s/%s: %w", expectedCg.GetNamespace(), expectedCg.GetName(), err)
 		}
 		return cg, nil

--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
@@ -262,8 +262,11 @@ func (r *Reconciler) reconcileConsumerGroup(ctx context.Context, broker *eventin
 		return nil, err
 	}
 	if apierrors.IsNotFound(err) {
-		cg, err := r.InternalsClient.InternalV1alpha1().ConsumerGroups(expectedCg.GetNamespace()).Create(ctx, expectedCg, metav1.CreateOptions{})
-		if err != nil && !apierrors.IsAlreadyExists(err) {
+		cg, err = r.InternalsClient.InternalV1alpha1().ConsumerGroups(expectedCg.GetNamespace()).Create(ctx, expectedCg, metav1.CreateOptions{})
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return r.InternalsClient.InternalV1alpha1().ConsumerGroups(expectedCg.GetNamespace()).Get(ctx, expectedCg.GetName(), metav1.GetOptions{})
+			}
 			return nil, fmt.Errorf("failed to create consumer group %s/%s: %w", expectedCg.GetNamespace(), expectedCg.GetName(), err)
 		}
 		return cg, nil


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- chore: Refactor handling of stale lister cache

Added GetOrCreateResource[T] — a generic function that safely handles the get-or-create pattern with AlreadyExists race protection. On the initial Get returning NotFound, it creates the resource; if Create returns
  AlreadyExists (concurrent reconciler created it first), it re-fetches from the API server instead of failing. It should address multiple flake occurring in E2E test runs when tests are failing prematurely on expected state diff.

/cc @gauron99 