### PR TITLE
ci: Update dependabot config to group, skip major, include gh-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,29 @@ updates:
     schedule:
       interval: "daily"
     assignees:
-      - "pierDipi"
+      - "knative-extensions/eventing-kafka-broker-approvers"
     commit-message:
       prefix: "[data-plane]"
     target-branch: "main"
+    groups:
+      maven-all:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "knative-extensions/eventing-kafka-broker-approvers"
+    commit-message:
+      prefix: "[github-actions]"
+    target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "knative/actions/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     directory: "/data-plane" # Location of package manifests
     schedule:
       interval: "daily"
-    assignees:
-      - "knative-extensions/eventing-kafka-broker-approvers"
     commit-message:
       prefix: "[data-plane]"
     target-branch: "main"
@@ -21,12 +19,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
-    assignees:
-      - "knative-extensions/eventing-kafka-broker-approvers"
     commit-message:
       prefix: "[github-actions]"
     target-branch: "main"


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- ci: Update dependabot config to group, skip major, include gh-action

```release-note
ci: Update dependabot config to group, skip major, include gh-action
```

/cc @gauron99 