### PR TITLE
fix: use configured system namespace for KafkaChannel subscriber SA check

### DIFF
--- a/control-plane/pkg/apis/messaging/v1/kafka_channel_validation.go
+++ b/control-plane/pkg/apis/messaging/v1/kafka_channel_validation.go
@@ -26,9 +26,10 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
+	"knative.dev/pkg/system"
 )
 
-const eventingControllerSAName = "system:serviceaccount:knative-eventing:eventing-controller"
+var eventingControllerSAName = fmt.Sprintf("system:serviceaccount:%s:eventing-controller", system.Namespace())
 
 func (kc *KafkaChannel) Validate(ctx context.Context) *apis.FieldError {
 	errs := kc.Spec.Validate(ctx).ViaField("spec")

--- a/control-plane/pkg/apis/messaging/v1/kafka_channel_validation_test.go
+++ b/control-plane/pkg/apis/messaging/v1/kafka_channel_validation_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing"
+)
+
+func TestCheckSubscribersChangeAllowed(t *testing.T) {
+	subscriberURI := apis.HTTP("example.com")
+
+	original := &KafkaChannel{
+		Spec: KafkaChannelSpec{},
+	}
+	updated := &KafkaChannel{
+		Spec: KafkaChannelSpec{
+			ChannelableSpec: eventingduck.ChannelableSpec{
+				SubscribableSpec: eventingduck.SubscribableSpec{
+					Subscribers: []eventingduck.SubscriberSpec{{SubscriberURI: subscriberURI}},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		username string
+		wantErr  bool
+	}{{
+		name:     "allowed for the eventing-controller in the configured system namespace",
+		username: fmt.Sprintf("system:serviceaccount:%s:eventing-controller", system.Namespace()),
+		wantErr:  false,
+	}, {
+		name:     "denied for the eventing-controller in a different namespace",
+		username: "system:serviceaccount:some-other-namespace:eventing-controller",
+		wantErr:  true,
+	}, {
+		name:     "denied for an arbitrary user",
+		username: "system:serviceaccount:some-other-namespace:some-other-controller",
+		wantErr:  true,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := apis.WithUserInfo(context.Background(), &authenticationv1.UserInfo{Username: test.username})
+
+			err := updated.CheckSubscribersChangeAllowed(ctx, original)
+			if test.wantErr && err == nil {
+				t.Errorf("expected an error, got none")
+			}
+			if !test.wantErr && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/control-plane/pkg/apis/messaging/v1/kafka_channel_validation_test.go
+++ b/control-plane/pkg/apis/messaging/v1/kafka_channel_validation_test.go
@@ -1,18 +1,18 @@
 /*
-Copyright 2026 The Knative Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2026 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package v1
 

--- a/control-plane/pkg/apis/messaging/v1beta1/kafka_channel_validation.go
+++ b/control-plane/pkg/apis/messaging/v1beta1/kafka_channel_validation.go
@@ -26,9 +26,10 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
+	"knative.dev/pkg/system"
 )
 
-const eventingControllerSAName = "system:serviceaccount:knative-eventing:eventing-controller"
+var eventingControllerSAName = fmt.Sprintf("system:serviceaccount:%s:eventing-controller", system.Namespace())
 
 func (kc *KafkaChannel) Validate(ctx context.Context) *apis.FieldError {
 	errs := kc.Spec.Validate(ctx).ViaField("spec")

--- a/control-plane/pkg/apis/messaging/v1beta1/kafka_channel_validation_test.go
+++ b/control-plane/pkg/apis/messaging/v1beta1/kafka_channel_validation_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing"
+)
+
+func TestCheckSubscribersChangeAllowed(t *testing.T) {
+	subscriberURI := apis.HTTP("example.com")
+
+	original := &KafkaChannel{
+		Spec: KafkaChannelSpec{},
+	}
+	updated := &KafkaChannel{
+		Spec: KafkaChannelSpec{
+			ChannelableSpec: eventingduck.ChannelableSpec{
+				SubscribableSpec: eventingduck.SubscribableSpec{
+					Subscribers: []eventingduck.SubscriberSpec{{SubscriberURI: subscriberURI}},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		username string
+		wantErr  bool
+	}{{
+		name:     "allowed for the eventing-controller in the configured system namespace",
+		username: fmt.Sprintf("system:serviceaccount:%s:eventing-controller", system.Namespace()),
+		wantErr:  false,
+	}, {
+		name:     "denied for the eventing-controller in a different namespace",
+		username: "system:serviceaccount:some-other-namespace:eventing-controller",
+		wantErr:  true,
+	}, {
+		name:     "denied for an arbitrary user",
+		username: "system:serviceaccount:some-other-namespace:some-other-controller",
+		wantErr:  true,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := apis.WithUserInfo(context.Background(), &authenticationv1.UserInfo{Username: test.username})
+
+			err := updated.CheckSubscribersChangeAllowed(ctx, original)
+			if test.wantErr && err == nil {
+				t.Errorf("expected an error, got none")
+			}
+			if !test.wantErr && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/control-plane/pkg/apis/messaging/v1beta1/kafka_channel_validation_test.go
+++ b/control-plane/pkg/apis/messaging/v1beta1/kafka_channel_validation_test.go
@@ -1,18 +1,18 @@
 /*
-Copyright 2026 The Knative Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2026 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package v1beta1
 


### PR DESCRIPTION
Motivation:

KafkaChannel validation only allowed spec.subscribers to be changed by
system:serviceaccount:knative-eventing:eventing-controller, with the
namespace hardcoded. When Knative Eventing is installed into a custom
system namespace, the real subscription-controller runs as
system:serviceaccount:<custom-namespace>:eventing-controller, so the
webhook rejects its updates and Subscriptions targeting a KafkaChannel
never become Ready (PhysicalChannelSyncFailed), leaving
spec.subscribers empty. Setting SYSTEM_NAMESPACE on the webhook
deployment had no effect because the validation code never read it.

Approach:

Replace the hardcoded eventingControllerSAName constant in
control-plane/pkg/apis/messaging/v1/kafka_channel_validation.go and
control-plane/pkg/apis/messaging/v1beta1/kafka_channel_validation.go
with a package-level var built from knative.dev/pkg/system.Namespace(),
which resolves SYSTEM_NAMESPACE at process start. This mirrors the
existing pattern already used by knative/eventing's own
InMemoryChannel validation
(vendor/knative.dev/eventing/pkg/apis/messaging/v1/in_memory_channel_validation.go)
for the same problem. Both the webhook's storage (v1beta1) and served
(v1) KafkaChannel types are updated so the check is consistent across
API versions.

This only changes which service account is treated as the trusted
subscription-controller; behavior for the default "knative-eventing"
namespace is unchanged.

Validation:

Ran `go build ./control-plane/...` (passes) and
`go test ./control-plane/pkg/apis/messaging/...` (passes), which is
the unit-test path documented in DEVELOPMENT.md
(./hack/run.sh unit-tests-control-plane) and does not require a
running cluster. Added kafka_channel_validation_test.go to both
packages exercising CheckSubscribersChangeAllowed against the
configured system-namespace service account, a same-named service
account in a different namespace, and an arbitrary user. Confirmed
these tests reproduce the reported failure: reverting only the two
validation.go changes and rerunning the tests fails with the exact
error from the issue ("... which was not the
system:serviceaccount:knative-eventing:eventing-controller service
account"), and reapplying the fix makes them pass.

Report: https://github.com/knative-extensions/eventing-kafka-broker/issues/4742
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #4742

```release-note
fix: use configured system namespace for KafkaChannel subscriber SA check
```