### PR TITLE
fix(consumergroup): prevent orphaned Kafka group on delete

### DIFF
--- a/control-plane/pkg/reconciler/consumer/consumer.go
+++ b/control-plane/pkg/reconciler/consumer/consumer.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/apis"
@@ -102,11 +103,60 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, c *kafkainternals.Consume
 
 	logger := logging.FromContext(ctx).Desugar()
 
-	if _, err := r.schedule(ctx, logger, c, removeResource, FalseAnyStatus); err != nil {
+	scheduled, err := r.schedule(ctx, logger, c, removeResource, FalseAnyStatus)
+	if err != nil {
 		return c.MarkBindFailed(err)
+	}
+	if !scheduled && c.Spec.PodBind != nil {
+		// The pod is gone but its contract ConfigMap (named after the pod) may outlive it
+		// and be re-mounted by a same-named StatefulSet pod, resurrecting the egress.
+		if err := r.removeResourceFromLeftoverConfigMap(ctx, logger, c); err != nil {
+			return c.MarkBindFailed(err)
+		}
 	}
 
 	return nil
+}
+
+// removeResourceFromLeftoverConfigMap removes the consumer's resource from the contract
+// ConfigMap bound to a pod that no longer exists.
+func (r *Reconciler) removeResourceFromLeftoverConfigMap(ctx context.Context, logger *zap.Logger, c *kafkainternals.Consumer) error {
+	ns := c.Spec.PodBind.PodNamespace
+	// The contract ConfigMap of a StatefulSet dispatcher pod is named after the pod,
+	// see core.DispatcherPodsDefaulting.
+	cmName := c.Spec.PodBind.PodName
+
+	cm, err := r.KubeClient.CoreV1().ConfigMaps(ns).Get(ctx, cmName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get data plane ConfigMap %s/%s: %w", ns, cmName, err)
+	}
+
+	b := base.Reconciler{
+		KubeClient:                  r.KubeClient,
+		PodLister:                   r.PodLister,
+		SecretLister:                r.SecretLister,
+		Tracker:                     r.Tracker,
+		DataPlaneConfigMapNamespace: ns,
+		ContractConfigMapName:       cmName,
+		ContractConfigMapFormat:     string(r.SerDe.Format),
+		DataPlaneNamespace:          ns,
+	}
+
+	ct, err := b.GetDataPlaneConfigMapData(logger, cm)
+	if err != nil {
+		return fmt.Errorf("failed to get contract from ConfigMap %s/%s: %w", ns, cmName, err)
+	}
+
+	if coreconfig.FindResource(ct, c.GetUID()) == coreconfig.NoResource {
+		return nil
+	}
+
+	removeResource(logger, ct, c)
+
+	return b.UpdateDataPlaneConfigMap(ctx, ct, cm)
 }
 
 func (r *Reconciler) reconcileContractResource(ctx context.Context, c *kafkainternals.Consumer) (*contract.Resource, error) {

--- a/control-plane/pkg/reconciler/consumer/consumer_test.go
+++ b/control-plane/pkg/reconciler/consumer/consumer_test.go
@@ -826,6 +826,116 @@ func TestReconcileKind(t *testing.T) {
 			},
 		},
 		{
+			Name: "Finalized normal - pod gone, leftover ConfigMap cleaned up",
+			Objects: []runtime.Object{
+				NewService(),
+				NewConsumerGroup(ConsumerGroupOwnerRef(SourceAsOwnerReference())),
+				NewConsumer(1,
+					ConsumerDeletedTimeStamp(),
+					ConsumerUID(ConsumerUUID),
+					ConsumerSpec(NewConsumerSpec(
+						ConsumerTopics(SourceTopics...),
+						ConsumerConfigs(
+							ConsumerBootstrapServersConfig(SourceBootstrapServers),
+							ConsumerGroupIDConfig(SourceConsumerGroup),
+						),
+						ConsumerSubscriber(NewSourceSinkReference()),
+						ConsumerVReplicas(1),
+						ConsumerPlacement(kafkainternals.PodBind{PodName: "p1", PodNamespace: SystemNamespace}),
+					)),
+					ConsumerOwnerRef(ConsumerGroupAsOwnerRef()),
+				),
+				NewConfigMapFromContract(
+					&contract.Contract{
+						Generation: 1,
+						Resources: []*contract.Resource{
+							{
+								Uid:              ConsumerUUID,
+								Topics:           SourceTopics,
+								BootstrapServers: SourceBootstrapServers,
+								Egresses: []*contract.Egress{{
+									ConsumerGroup: SourceConsumerGroup,
+									Destination:   ServiceURL,
+									Uid:           ConsumerUUID,
+									DeliveryOrder: contract.DeliveryOrder_UNORDERED,
+									VReplicas:     1,
+									Reference: &contract.Reference{
+										Uuid:      SourceUUID,
+										Namespace: ConsumerNamespace,
+										Name:      SourceName,
+									},
+									FeatureFlags: defaultContractFeatureFlags,
+								}},
+								Reference: &contract.Reference{
+									Uuid:      SourceUUID,
+									Namespace: ConsumerNamespace,
+									Name:      SourceName,
+								},
+							},
+							{
+								Uid:              ConsumerUUID + "a",
+								Topics:           SourceTopics,
+								BootstrapServers: SourceBootstrapServers,
+								Egresses: []*contract.Egress{{
+									ConsumerGroup: SourceConsumerGroup,
+									Destination:   ServiceURL,
+									Uid:           ConsumerUUID + "a",
+									DeliveryOrder: contract.DeliveryOrder_UNORDERED,
+									VReplicas:     1,
+									Reference: &contract.Reference{
+										Uuid:      SourceUUID,
+										Namespace: ConsumerNamespace,
+										Name:      SourceName,
+									},
+									FeatureFlags: defaultContractFeatureFlags,
+								}},
+								Reference: &contract.Reference{
+									Uuid:      SourceUUID,
+									Namespace: ConsumerNamespace,
+									Name:      SourceName,
+								},
+							},
+						},
+					},
+					SystemNamespace,
+					"p1",
+					base.JSON,
+				),
+			},
+			Key:                     testKey,
+			SkipNamespaceValidation: true, // WantCreates compare the broker namespace with configmap namespace, so skip it
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapUpdate(SystemNamespace, "p1", base.JSON, &contract.Contract{
+					Generation: 2,
+					Resources: []*contract.Resource{
+						{
+							Uid:              ConsumerUUID + "a",
+							Topics:           SourceTopics,
+							BootstrapServers: SourceBootstrapServers,
+							Egresses: []*contract.Egress{{
+								ConsumerGroup: SourceConsumerGroup,
+								Destination:   ServiceURL,
+								Uid:           ConsumerUUID + "a",
+								DeliveryOrder: contract.DeliveryOrder_UNORDERED,
+								VReplicas:     1,
+								Reference: &contract.Reference{
+									Uuid:      SourceUUID,
+									Namespace: ConsumerNamespace,
+									Name:      SourceName,
+								},
+								FeatureFlags: defaultContractFeatureFlags,
+							}},
+							Reference: &contract.Reference{
+								Uuid:      SourceUUID,
+								Namespace: ConsumerNamespace,
+								Name:      SourceName,
+							},
+						},
+					},
+				}),
+			},
+		},
+		{
 			Name: "Reconciled normal - With CA Cert",
 			Objects: []runtime.Object{
 				NewService(),

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -243,8 +243,22 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, cg *kafkainternals.Consum
 		}
 	}
 
+	// Deleting the consumer group from Kafka while consumers are still being finalized fails
+	// with GROUP_NOT_EMPTY, since dispatchers only leave the group once consumer finalization
+	// has removed their egresses from the contract. Wait for consumers to be gone; consumer
+	// deletion events re-enqueue this ConsumerGroup.
+	if len(existingConsumers) > 0 {
+		return cg.MarkReconcileConsumersFailed("FinalizeConsumers", fmt.Errorf("waiting for %d consumer(s) to be finalized", len(existingConsumers)))
+	}
+
 	logger.Debugw("Deleteing consumergroup metadata from Kafka cluster")
 	if err := r.deleteConsumerGroupMetadata(ctx, cg); err != nil {
+		// The group still has active members (dispatchers that haven't observed the contract
+		// update yet), so retry without consuming the bounded retry budget used for
+		// unreachable clusters.
+		if errorIsOneOf(err, sarama.ErrNonEmptyGroup) {
+			return cg.MarkDeleteOffsetFailed("DeleteConsumerGroupOffset", err)
+		}
 		// We retry a few times to delete Consumer group metadata from Kafka before giving up.
 		if v := r.DeleteConsumerGroupMetadataCounter.Inc(string(cg.GetUID())); v <= 5 {
 			return cg.MarkDeleteOffsetFailed("DeleteConsumerGroupOffset", fmt.Errorf("%w (retry num %d)", err, v))

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
@@ -2205,6 +2205,68 @@ func TestFinalizeKind(t *testing.T) {
 					Name: fmt.Sprintf("%s-%d", ConsumerNamePrefix, 1),
 				},
 			},
+			WantErr: true,
+			WantEvents: []string{
+				Eventf(
+					corev1.EventTypeWarning,
+					"InternalError",
+					"failed to reconcile consumers: waiting for 1 consumer(s) to be finalized",
+				),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: func() runtime.Object {
+						cg := NewDeletedConsumeGroup(
+							ConsumerGroupReplicas(1),
+							ConsumerGroupOwnerRef(SourceAsOwnerReference()),
+							ConsumerGroupConsumerSpec(NewConsumerSpec(
+								ConsumerConfigs(
+									ConsumerBootstrapServersConfig(ChannelBootstrapServers),
+									ConsumerGroupIDConfig("my.group.id"),
+								),
+								ConsumerAuth(&kafkainternals.Auth{
+									NetSpec: &bindings.KafkaNetSpec{
+										SASL: bindings.KafkaSASLSpec{
+											Enable: true,
+											User: bindings.SecretValueFromSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: SecretName,
+													},
+													Key: "user",
+												},
+											},
+											Password: bindings.SecretValueFromSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: SecretName,
+													},
+													Key: "password",
+												},
+											},
+											Type: bindings.SecretValueFromSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: SecretName,
+													},
+													Key: "type",
+												},
+											},
+										},
+										TLS: bindings.KafkaTLSSpec{
+											Enable: true,
+										},
+									},
+								}),
+							)),
+						)
+
+						_ = cg.MarkReconcileConsumersFailed("FinalizeConsumers", fmt.Errorf("waiting for 1 consumer(s) to be finalized"))
+
+						return cg
+					}(),
+				},
+			},
 			SkipNamespaceValidation: true, // WantCreates compare the source namespace with configmap namespace, so skip it
 		},
 		{
@@ -2285,6 +2347,68 @@ func TestFinalizeKind(t *testing.T) {
 					Name: fmt.Sprintf("%s-%d", ConsumerNamePrefix, 1),
 				},
 			},
+			WantErr: true,
+			WantEvents: []string{
+				Eventf(
+					corev1.EventTypeWarning,
+					"InternalError",
+					"failed to reconcile consumers: waiting for 1 consumer(s) to be finalized",
+				),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: func() runtime.Object {
+						cg := NewDeletedConsumeGroup(
+							ConsumerGroupReplicas(1),
+							ConsumerGroupOwnerRef(SourceAsOwnerReference()),
+							ConsumerGroupConsumerSpec(NewConsumerSpec(
+								ConsumerConfigs(
+									ConsumerBootstrapServersConfig(ChannelBootstrapServers),
+									ConsumerGroupIDConfig("my.group.id"),
+								),
+								ConsumerAuth(&kafkainternals.Auth{
+									NetSpec: &bindings.KafkaNetSpec{
+										SASL: bindings.KafkaSASLSpec{
+											Enable: true,
+											User: bindings.SecretValueFromSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: SecretName,
+													},
+													Key: "user",
+												},
+											},
+											Password: bindings.SecretValueFromSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: SecretName,
+													},
+													Key: "password",
+												},
+											},
+											Type: bindings.SecretValueFromSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: SecretName,
+													},
+													Key: "type",
+												},
+											},
+										},
+										TLS: bindings.KafkaTLSSpec{
+											Enable: true,
+										},
+									},
+								}),
+							)),
+						)
+
+						_ = cg.MarkReconcileConsumersFailed("FinalizeConsumers", fmt.Errorf("waiting for 1 consumer(s) to be finalized"))
+
+						return cg
+					}(),
+				},
+			},
 			SkipNamespaceValidation: true, // WantCreates compare the source namespace with configmap namespace, so skip it
 		},
 		{
@@ -2331,23 +2455,38 @@ func TestFinalizeKind(t *testing.T) {
 					Name: fmt.Sprintf("%s-%d", ConsumerNamePrefix, 1),
 				},
 			},
+			WantErr: true,
+			WantEvents: []string{
+				Eventf(
+					corev1.EventTypeWarning,
+					"InternalError",
+					"failed to reconcile consumers: waiting for 1 consumer(s) to be finalized",
+				),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: func() runtime.Object {
+						cg := NewDeletedConsumeGroup(
+							ConsumerGroupOwnerRef(SourceAsOwnerReference()),
+							ConsumerGroupConsumerSpec(NewConsumerSpec(
+								ConsumerConfigs(
+									ConsumerBootstrapServersConfig(ChannelBootstrapServers),
+									ConsumerGroupIDConfig("my.group.id"),
+								),
+							)),
+						)
+
+						_ = cg.MarkReconcileConsumersFailed("FinalizeConsumers", fmt.Errorf("waiting for 1 consumer(s) to be finalized"))
+
+						return cg
+					}(),
+				},
+			},
 			SkipNamespaceValidation: true, // WantCreates compare the source namespace with configmap namespace, so skip it
 		},
 		{
 			Name: "Finalize normal - failed consumer group deletion with " + sarama.ErrUnknownTopicOrPartition.Error(),
 			Objects: []runtime.Object{
-				NewConsumer(1,
-					ConsumerSpec(NewConsumerSpec(
-						ConsumerTopics("t1", "t2"),
-						ConsumerConfigs(
-							ConsumerBootstrapServersConfig(ChannelBootstrapServers),
-							ConsumerGroupIDConfig("my.group.id"),
-						),
-						ConsumerVReplicas(1),
-						ConsumerPlacement(kafkainternals.PodBind{PodName: "p1", PodNamespace: systemNamespace}),
-						ConsumerSubscriber(NewSourceSinkReference()),
-					)),
-				),
 				NewDeletedConsumeGroup(
 					ConsumerGroupOwnerRef(SourceAsOwnerReference()),
 					ConsumerGroupConsumerSpec(NewConsumerSpec(
@@ -2365,36 +2504,11 @@ func TestFinalizeKind(t *testing.T) {
 				}),
 				kafkatesting.ErrorOnDeleteConsumerGroupTestKey: sarama.ErrUnknownTopicOrPartition,
 			},
-			WantDeletes: []clientgotesting.DeleteActionImpl{
-				{
-					ActionImpl: clientgotesting.ActionImpl{
-						Namespace: ConsumerGroupNamespace,
-						Resource: schema.GroupVersionResource{
-							Group:    kafkainternals.SchemeGroupVersion.Group,
-							Version:  kafkainternals.SchemeGroupVersion.Version,
-							Resource: "consumers",
-						},
-					},
-					Name: fmt.Sprintf("%s-%d", ConsumerNamePrefix, 1),
-				},
-			},
 			SkipNamespaceValidation: true, // WantCreates compare the source namespace with configmap namespace, so skip it
 		},
 		{
 			Name: "Finalize normal - failed consumer group deletion with " + sarama.ErrGroupIDNotFound.Error(),
 			Objects: []runtime.Object{
-				NewConsumer(1,
-					ConsumerSpec(NewConsumerSpec(
-						ConsumerTopics("t1", "t2"),
-						ConsumerConfigs(
-							ConsumerBootstrapServersConfig(ChannelBootstrapServers),
-							ConsumerGroupIDConfig("my.group.id"),
-						),
-						ConsumerVReplicas(1),
-						ConsumerPlacement(kafkainternals.PodBind{PodName: "p1", PodNamespace: systemNamespace}),
-						ConsumerSubscriber(NewSourceSinkReference()),
-					)),
-				),
 				NewDeletedConsumeGroup(
 					ConsumerGroupOwnerRef(SourceAsOwnerReference()),
 					ConsumerGroupConsumerSpec(NewConsumerSpec(
@@ -2412,36 +2526,11 @@ func TestFinalizeKind(t *testing.T) {
 				}),
 				kafkatesting.ErrorOnDeleteConsumerGroupTestKey: sarama.ErrGroupIDNotFound,
 			},
-			WantDeletes: []clientgotesting.DeleteActionImpl{
-				{
-					ActionImpl: clientgotesting.ActionImpl{
-						Namespace: ConsumerGroupNamespace,
-						Resource: schema.GroupVersionResource{
-							Group:    kafkainternals.SchemeGroupVersion.Group,
-							Version:  kafkainternals.SchemeGroupVersion.Version,
-							Resource: "consumers",
-						},
-					},
-					Name: fmt.Sprintf("%s-%d", ConsumerNamePrefix, 1),
-				},
-			},
 			SkipNamespaceValidation: true, // WantCreates compare the source namespace with configmap namespace, so skip it
 		},
 		{
 			Name: "Finalize error - failed consumer group deletion with " + sarama.ErrClusterAuthorizationFailed.Error(),
 			Objects: []runtime.Object{
-				NewConsumer(1,
-					ConsumerSpec(NewConsumerSpec(
-						ConsumerTopics("t1", "t2"),
-						ConsumerConfigs(
-							ConsumerBootstrapServersConfig(ChannelBootstrapServers),
-							ConsumerGroupIDConfig("my.group.id"),
-						),
-						ConsumerVReplicas(1),
-						ConsumerPlacement(kafkainternals.PodBind{PodName: "p1", PodNamespace: systemNamespace}),
-						ConsumerSubscriber(NewSourceSinkReference()),
-					)),
-				),
 				NewDeletedConsumeGroup(
 					ConsumerGroupOwnerRef(SourceAsOwnerReference()),
 					ConsumerGroupConsumerSpec(NewConsumerSpec(
@@ -2459,19 +2548,6 @@ func TestFinalizeKind(t *testing.T) {
 					return nil, nil
 				}),
 				kafkatesting.ErrorOnDeleteConsumerGroupTestKey: sarama.ErrClusterAuthorizationFailed,
-			},
-			WantDeletes: []clientgotesting.DeleteActionImpl{
-				{
-					ActionImpl: clientgotesting.ActionImpl{
-						Namespace: ConsumerGroupNamespace,
-						Resource: schema.GroupVersionResource{
-							Group:    kafkainternals.SchemeGroupVersion.Group,
-							Version:  kafkainternals.SchemeGroupVersion.Version,
-							Resource: "consumers",
-						},
-					},
-					Name: fmt.Sprintf("%s-%d", ConsumerNamePrefix, 1),
-				},
 			},
 			WantEvents: []string{
 				Eventf(
@@ -2494,6 +2570,55 @@ func TestFinalizeKind(t *testing.T) {
 						)
 
 						_ = cg.MarkDeleteOffsetFailed("DeleteConsumerGroupOffset", fmt.Errorf("unable to delete the consumer group my.group.id: kafka server: The client is not authorized to send this request type (retry num 1)"))
+
+						return cg
+					}(),
+				},
+			},
+			SkipNamespaceValidation: true, // WantCreates compare the source namespace with configmap namespace, so skip it
+		},
+		{
+			Name: "Finalize error - failed consumer group deletion with " + sarama.ErrNonEmptyGroup.Error(),
+			Objects: []runtime.Object{
+				NewDeletedConsumeGroup(
+					ConsumerGroupOwnerRef(SourceAsOwnerReference()),
+					ConsumerGroupConsumerSpec(NewConsumerSpec(
+						ConsumerConfigs(
+							ConsumerBootstrapServersConfig(ChannelBootstrapServers),
+							ConsumerGroupIDConfig("my.group.id"),
+						),
+					)),
+				),
+			},
+			WantErr: true,
+			Key:     testKey,
+			OtherTestData: map[string]interface{}{
+				testSchedulerKey: SchedulerFunc(func(_ context.Context, vpod scheduler.VPod) ([]eventingduckv1alpha1.Placement, error) {
+					return nil, nil
+				}),
+				kafkatesting.ErrorOnDeleteConsumerGroupTestKey: sarama.ErrNonEmptyGroup,
+			},
+			WantEvents: []string{
+				Eventf(
+					corev1.EventTypeWarning,
+					"InternalError",
+					"failed to delete consumer group offset: unable to delete the consumer group my.group.id: "+sarama.ErrNonEmptyGroup.Error(),
+				),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: func() runtime.Object {
+						cg := NewDeletedConsumeGroup(
+							ConsumerGroupOwnerRef(SourceAsOwnerReference()),
+							ConsumerGroupConsumerSpec(NewConsumerSpec(
+								ConsumerConfigs(
+									ConsumerBootstrapServersConfig(ChannelBootstrapServers),
+									ConsumerGroupIDConfig("my.group.id"),
+								),
+							)),
+						)
+
+						_ = cg.MarkDeleteOffsetFailed("DeleteConsumerGroupOffset", fmt.Errorf("unable to delete the consumer group my.group.id: %w", sarama.ErrNonEmptyGroup))
 
 						return cg
 					}(),


### PR DESCRIPTION
Fixes #4784

/kind bug

## Changes
- Wait for Consumer finalization before Kafka `DeleteConsumerGroup`:
  deleting while dispatchers still hold group membership fails with
  GROUP_NOT_EMPTY, and the error was silently dropped after 5 retries,
  clearing the finalizer and orphaning the group.
- Retry GROUP_NOT_EMPTY without the bounded retry budget (budget stays
  for unreachable clusters).
- On Consumer finalization with the bound pod gone, remove the egress
  from the pod-named contract ConfigMap so a recreated StatefulSet pod
  cannot resurrect it.

## Release Note
```release-note
Fixed: deleting a Trigger/Subscription while its consumer group lag exceeded the KEDA autoscaler threshold could orphan the Kafka consumer group and leave a stale egress in the dispatcher contract.