### PR TITLE
feat: propagate sasl.jaas.config and sasl.login.callback.handler.class from auth secret for OAUTHBEARER

### DIFF
--- a/control-plane/pkg/security/oauth/common.go
+++ b/control-plane/pkg/security/oauth/common.go
@@ -58,3 +58,9 @@ func getAWSRegion(data map[string][]byte) string {
 
 	return defaultAWSRegion
 }
+
+// HasTokenProvider returns true if the secret data contains a tokenProvider key.
+func HasTokenProvider(data map[string][]byte) bool {
+	_, ok := data[saslTokenProviderKey]
+	return ok
+}

--- a/control-plane/pkg/security/oauth/common_test.go
+++ b/control-plane/pkg/security/oauth/common_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package oauth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasTokenProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string][]byte
+		want bool
+	}{
+		{
+			name: "tokenProvider present",
+			data: map[string][]byte{saslTokenProviderKey: []byte(mskAccessTokenProvider)},
+			want: true,
+		},
+		{
+			name: "tokenProvider present but empty still counts as set",
+			data: map[string][]byte{saslTokenProviderKey: []byte("")},
+			want: true,
+		},
+		{
+			name: "tokenProvider absent",
+			data: map[string][]byte{saslAWSRegion: []byte(defaultAWSRegion)},
+			want: false,
+		},
+		{
+			name: "empty data",
+			data: map[string][]byte{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HasTokenProvider(tt.data))
+		})
+	}
+}

--- a/control-plane/pkg/security/oauth/token_provider.go
+++ b/control-plane/pkg/security/oauth/token_provider.go
@@ -65,3 +65,22 @@ func NewTokenProvider(data map[string][]byte) (*TokenProvider, error) {
 		tokenIssuer: tokenIssuer,
 	}, nil
 }
+
+// errorTokenProvider is a sarama.AccessTokenProvider that always fails with a
+// descriptive error. It is used when an OAUTHBEARER secret has no tokenProvider
+// (the sasl.jaas.config / sasl.login.callback.handler.class keys are consumed by
+// the Java data plane only). Setting this instead of leaving TokenProvider nil
+// prevents a nil-pointer panic in sarama's OAUTHBEARER auth path when the Go
+// control plane attempts an admin connection, turning it into a clear reconciler
+// error instead.
+type errorTokenProvider struct{ msg string }
+
+func (e *errorTokenProvider) Token() (*sarama.AccessToken, error) {
+	return nil, fmt.Errorf("%s", e.msg)
+}
+
+// UnsupportedTokenProvider returns an AccessTokenProvider that always fails with
+// the given message. See errorTokenProvider for rationale.
+func UnsupportedTokenProvider(msg string) sarama.AccessTokenProvider {
+	return &errorTokenProvider{msg: msg}
+}

--- a/control-plane/pkg/security/oauth/token_provider_test.go
+++ b/control-plane/pkg/security/oauth/token_provider_test.go
@@ -139,3 +139,15 @@ func TestNewTokenProvider(t *testing.T) {
 		})
 	}
 }
+
+func TestUnsupportedTokenProvider(t *testing.T) {
+	const msg = "OAUTHBEARER without a Go token provider is not supported by the control plane"
+
+	provider := UnsupportedTokenProvider(msg)
+	assert.NotNil(t, provider)
+
+	token, err := provider.Token()
+	assert.Nil(t, token)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), msg)
+}

--- a/control-plane/pkg/security/secret.go
+++ b/control-plane/pkg/security/secret.go
@@ -46,6 +46,11 @@ const (
 	SaslTypeLegacy   = "saslType" // legacy secrets
 	SaslUsernameKey  = "username" // legacy secrets
 
+	// OAUTHBEARER passthrough keys — used by the Java data plane only.
+	// The Go control plane tolerates and ignores them.
+	SaslJaasConfigKey                = "sasl.jaas.config"
+	SaslLoginCallbackHandlerClassKey = "sasl.login.callback.handler.class"
+
 	ProtocolPlaintext     = "PLAINTEXT"
 	ProtocolSASLPlaintext = "SASL_PLAINTEXT"
 	ProtocolSSL           = "SSL"
@@ -116,11 +121,19 @@ func saslConfig(protocol string, data map[string][]byte) kafka.ConfigOption {
 		if saslMechanism == SaslOAuth {
 			config.Net.SASL.Enable = true
 			config.Net.SASL.Mechanism = sarama.SASLTypeOAuth
-			tokenProvider, err := oauth.NewTokenProvider(data)
-			if err != nil {
-				return fmt.Errorf("[protocol %s] failed to create OAUTHBEARER token provider: %w", protocol, err)
+
+			// If the secret contains a tokenProvider key (MSK), use the Go-native token provider.
+			// If not, the secret likely contains sasl.jaas.config / sasl.login.callback.handler.class
+			// for the Java data plane (Azure, Keycloak, etc.). The control plane cannot use a Java
+			// callback handler, so we configure SASL/OAUTHBEARER as enabled but skip the token
+			// provider — the control plane will not produce/consume from Kafka in this mode.
+			if oauth.HasTokenProvider(data) {
+				tokenProvider, err := oauth.NewTokenProvider(data)
+				if err != nil {
+					return fmt.Errorf("[protocol %s] failed to create OAUTHBEARER token provider: %w", protocol, err)
+				}
+				config.Net.SASL.TokenProvider = tokenProvider
 			}
-			config.Net.SASL.TokenProvider = tokenProvider
 			return nil
 		}
 

--- a/control-plane/pkg/security/secret.go
+++ b/control-plane/pkg/security/secret.go
@@ -133,6 +133,11 @@ func saslConfig(protocol string, data map[string][]byte) kafka.ConfigOption {
 					return fmt.Errorf("[protocol %s] failed to create OAUTHBEARER token provider: %w", protocol, err)
 				}
 				config.Net.SASL.TokenProvider = tokenProvider
+			} else {
+				config.Net.SASL.TokenProvider = oauth.UnsupportedTokenProvider(
+					"OAUTHBEARER without tokenProvider is not supported by the Go control plane " +
+						"(sasl.jaas.config/sasl.login.callback.handler.class are consumed by the Java data plane only); " +
+						"topic and consumer group management will fail")
 			}
 			return nil
 		}

--- a/control-plane/pkg/security/secret_test.go
+++ b/control-plane/pkg/security/secret_test.go
@@ -209,6 +209,9 @@ func TestSASLOAuthWithMSKRoleProvider(t *testing.T) {
 }
 
 func TestSASLOAuthMissingTokenProvider(t *testing.T) {
+	// When tokenProvider is absent, OAUTHBEARER is still valid — the secret may contain
+	// sasl.jaas.config / sasl.login.callback.handler.class for the Java data plane.
+	// The Go control plane tolerates this and configures SASL as enabled without a token provider.
 	secret := map[string][]byte{
 		"protocol":       []byte("SASL_PLAINTEXT"),
 		"sasl.mechanism": []byte("OAUTHBEARER"),
@@ -217,8 +220,10 @@ func TestSASLOAuthMissingTokenProvider(t *testing.T) {
 
 	err := kafka.Options(config, secretData(secret))
 
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "OAUTHBEARER token provider required")
+	assert.Nil(t, err)
+	assert.True(t, config.Net.SASL.Enable)
+	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypeOAuth), config.Net.SASL.Mechanism)
+	assert.Nil(t, config.Net.SASL.TokenProvider)
 }
 
 func TestSASLOAuthInvalidTokenProvider(t *testing.T) {
@@ -233,6 +238,27 @@ func TestSASLOAuthInvalidTokenProvider(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "unsupported OAUTHBEARER token provider")
+}
+
+func TestSASLOAuthWithJavaPassthroughKeys(t *testing.T) {
+	// When the secret contains sasl.jaas.config and sasl.login.callback.handler.class
+	// but no tokenProvider, the Go control plane should accept it without error.
+	// These keys are consumed by the Java data plane only.
+	secret := map[string][]byte{
+		"protocol":                          []byte("SASL_SSL"),
+		"sasl.mechanism":                    []byte("OAUTHBEARER"),
+		"sasl.jaas.config":                  []byte("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"),
+		"sasl.login.callback.handler.class": []byte("io.conduktor.kafka.security.oauthbearer.azure.AzureManagedIdentityCallbackHandler"),
+	}
+	config := sarama.NewConfig()
+
+	err := kafka.Options(config, secretData(secret))
+
+	assert.Nil(t, err)
+	assert.True(t, config.Net.SASL.Enable)
+	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypeOAuth), config.Net.SASL.Mechanism)
+	assert.Nil(t, config.Net.SASL.TokenProvider)
+	assert.True(t, config.Net.TLS.Enable)
 }
 
 func TestSSL(t *testing.T) {

--- a/control-plane/pkg/security/secret_test.go
+++ b/control-plane/pkg/security/secret_test.go
@@ -223,7 +223,10 @@ func TestSASLOAuthMissingTokenProvider(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, config.Net.SASL.Enable)
 	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypeOAuth), config.Net.SASL.Mechanism)
-	assert.Nil(t, config.Net.SASL.TokenProvider)
+	assert.NotNil(t, config.Net.SASL.TokenProvider)
+	_, tokenErr := config.Net.SASL.TokenProvider.Token()
+	assert.NotNil(t, tokenErr)
+	assert.Contains(t, tokenErr.Error(), "not supported by the Go control plane")
 }
 
 func TestSASLOAuthInvalidTokenProvider(t *testing.T) {
@@ -257,7 +260,10 @@ func TestSASLOAuthWithJavaPassthroughKeys(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, config.Net.SASL.Enable)
 	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypeOAuth), config.Net.SASL.Mechanism)
-	assert.Nil(t, config.Net.SASL.TokenProvider)
+	assert.NotNil(t, config.Net.SASL.TokenProvider)
+	_, tokenErr := config.Net.SASL.TokenProvider.Token()
+	assert.NotNil(t, tokenErr)
+	assert.Contains(t, tokenErr.Error(), "not supported by the Go control plane")
 	assert.True(t, config.Net.TLS.Enable)
 }
 

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/Credentials.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/Credentials.java
@@ -76,4 +76,30 @@ public interface Credentials {
      * @see <a href="https://kafka.apache.org/documentation/#security_sasl_scram">SASL Scram</a>
      */
     String SASLPassword();
+
+    /**
+     * Client key: sasl.jaas.config
+     *
+     * <p>When set, this value is used verbatim as the JAAS configuration for the Kafka client.
+     * Primarily useful for OAUTHBEARER, where the operator supplies a custom login module
+     * and its configuration (e.g. scope, token endpoint).
+     *
+     * @return the full JAAS config string, or null if not specified.
+     */
+    default String SASLJaasConfig() {
+        return null;
+    }
+
+    /**
+     * Client key: sasl.login.callback.handler.class
+     *
+     * <p>Fully qualified class name of an {@code AuthenticateCallbackHandler} implementation
+     * that the Kafka client will use to obtain tokens. The class must be on the data-plane
+     * classpath — this project does not ship any vendor-specific handler.
+     *
+     * @return the handler class name, or null if not specified.
+     */
+    default String SASLLoginCallbackHandlerClass() {
+        return null;
+    }
 }

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KafkaClientsAuth.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KafkaClientsAuth.java
@@ -24,8 +24,12 @@ import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KafkaClientsAuth {
+
+    private static final Logger logger = LoggerFactory.getLogger(KafkaClientsAuth.class);
 
     public static Properties attachCredentials(final Properties properties, final Credentials credentials) {
         clientsProperties(properties::setProperty, credentials);
@@ -72,7 +76,19 @@ public class KafkaClientsAuth {
                             credentials.SASLUsername(),
                             credentials.SASLPassword()));
         } else if ("OAUTHBEARER".equals(mechanism)) {
-            // OAUTHBEARER does not require username and password, so we do not set them.
+            // Propagate JAAS config and callback handler class when provided in the secret.
+            // This enables vendor-neutral OAUTHBEARER auth (Azure Event Hubs, Keycloak, etc.)
+            // without adding any vendor dependency to this project.
+            // When neither key is present, this is a no-op — preserving the current behaviour
+            // for AWS MSK IAM, which supplies its own login module via the classpath.
+            final var jaasConfig = credentials.SASLJaasConfig();
+            if (jaasConfig != null) {
+                propertiesSetter.accept(SaslConfigs.SASL_JAAS_CONFIG, jaasConfig);
+            }
+            final var callbackHandler = credentials.SASLLoginCallbackHandlerClass();
+            if (callbackHandler != null) {
+                propertiesSetter.accept(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, callbackHandler);
+            }
         } else {
             propertiesSetter.accept(
                     SaslConfigs.SASL_JAAS_CONFIG,
@@ -80,6 +96,13 @@ public class KafkaClientsAuth {
                             ScramLoginModule.class.getName() + " required username=\"%s\" password=\"%s\";",
                             credentials.SASLUsername(),
                             credentials.SASLPassword()));
+            // Warn if callback handler class is set on a non-OAUTHBEARER mechanism — likely misconfiguration.
+            if (credentials.SASLLoginCallbackHandlerClass() != null) {
+                logger.warn(
+                        "sasl.login.callback.handler.class is set but sasl.mechanism is '{}', not OAUTHBEARER. "
+                                + "The callback handler class will be ignored.",
+                        mechanism);
+            }
         }
     }
 

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentials.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentials.java
@@ -43,6 +43,8 @@ class KubernetesCredentials implements Credentials {
 
     static final String SECURITY_PROTOCOL = "protocol";
     static final String SASL_MECHANISM = "sasl.mechanism";
+    static final String SASL_JAAS_CONFIG_KEY = "sasl.jaas.config";
+    static final String SASL_LOGIN_CALLBACK_HANDLER_CLASS_KEY = "sasl.login.callback.handler.class";
 
     private final Secret secret;
 
@@ -54,6 +56,10 @@ class KubernetesCredentials implements Credentials {
     private String SASLMechanism;
     private String SASLUsername;
     private String SASLPassword;
+    private String SASLJaasConfig;
+    private String SASLLoginCallbackHandlerClass;
+    private boolean SASLJaasConfigResolved;
+    private boolean SASLLoginCallbackHandlerClassResolved;
 
     KubernetesCredentials(final Secret secret) {
         this.secret = secret;
@@ -199,5 +205,36 @@ class KubernetesCredentials implements Credentials {
             this.SASLPassword = new String(Base64.getDecoder().decode(SASLPassword));
         }
         return this.SASLPassword;
+    }
+
+    @Override
+    public String SASLJaasConfig() {
+        if (secret == null || secret.getData() == null) {
+            return null;
+        }
+        if (!SASLJaasConfigResolved) {
+            final var value = secret.getData().get(SASL_JAAS_CONFIG_KEY);
+            if (value != null) {
+                this.SASLJaasConfig = new String(Base64.getDecoder().decode(value));
+            }
+            this.SASLJaasConfigResolved = true;
+        }
+        return this.SASLJaasConfig;
+    }
+
+    @Override
+    public String SASLLoginCallbackHandlerClass() {
+        if (secret == null || secret.getData() == null) {
+            return null;
+        }
+        if (!SASLLoginCallbackHandlerClassResolved) {
+            final var value = secret.getData().get(SASL_LOGIN_CALLBACK_HANDLER_CLASS_KEY);
+            if (value != null) {
+                this.SASLLoginCallbackHandlerClass =
+                        new String(Base64.getDecoder().decode(value));
+            }
+            this.SASLLoginCallbackHandlerClassResolved = true;
+        }
+        return this.SASLLoginCallbackHandlerClass;
     }
 }

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/CredentialsTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/CredentialsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.knative.eventing.kafka.broker.core.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.junit.jupiter.api.Test;
+
+public class CredentialsTest {
+
+    /**
+     * A minimal {@link Credentials} implementation that does not override the
+     * OAUTHBEARER passthrough default methods, exercising their default (null) behaviour.
+     */
+    private static final class MinimalCredentials implements Credentials {
+        @Override
+        public String caCertificates() {
+            return null;
+        }
+
+        @Override
+        public String userCertificate() {
+            return null;
+        }
+
+        @Override
+        public String userKey() {
+            return null;
+        }
+
+        @Override
+        public String SASLMechanism() {
+            return null;
+        }
+
+        @Override
+        public String SASLUsername() {
+            return null;
+        }
+
+        @Override
+        public String SASLPassword() {
+            return null;
+        }
+
+        @Override
+        public SecurityProtocol securityProtocol() {
+            return null;
+        }
+
+        @Override
+        public boolean skipClientAuth() {
+            return false;
+        }
+    }
+
+    @Test
+    public void defaultSASLJaasConfigReturnsNull() {
+        assertThat(new MinimalCredentials().SASLJaasConfig()).isNull();
+    }
+
+    @Test
+    public void defaultSASLLoginCallbackHandlerClassReturnsNull() {
+        assertThat(new MinimalCredentials().SASLLoginCallbackHandlerClass()).isNull();
+    }
+}

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/KafkaClientsAuthTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/KafkaClientsAuthTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
@@ -202,5 +203,95 @@ public class KafkaClientsAuthTest {
 
         assertThat(producerConfigs).isEqualTo(expected);
         assertThat(consumerConfigs).isEqualTo(expected);
+    }
+
+    // --- OAUTHBEARER tests ---
+
+    @Test
+    public void shouldConfigureOauthbearerWithBothKeys() {
+        final var props = new Properties();
+
+        final var jaasConfig = OAuthBearerLoginModule.class.getName()
+                + " required scope=\"https://example.servicebus.windows.net/.default\";";
+        final var handlerClass = "io.conduktor.kafka.security.oauthbearer.azure.AzureManagedIdentityCallbackHandler";
+
+        final var credentials = mock(Credentials.class);
+        when(credentials.securityProtocol()).thenReturn(SecurityProtocol.SASL_SSL);
+        when(credentials.SASLMechanism()).thenReturn("OAUTHBEARER");
+        when(credentials.SASLJaasConfig()).thenReturn(jaasConfig);
+        when(credentials.SASLLoginCallbackHandlerClass()).thenReturn(handlerClass);
+        when(credentials.caCertificates()).thenReturn(null);
+
+        KafkaClientsAuth.attachCredentials(props, credentials);
+
+        assertThat(props.getProperty(SaslConfigs.SASL_MECHANISM)).isEqualTo("OAUTHBEARER");
+        assertThat(props.getProperty(SaslConfigs.SASL_JAAS_CONFIG)).isEqualTo(jaasConfig);
+        assertThat(props.getProperty(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS))
+                .isEqualTo(handlerClass);
+        assertThat(props.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG))
+                .isEqualTo(SecurityProtocol.SASL_SSL.name());
+    }
+
+    @Test
+    public void shouldConfigureOauthbearerWithNeitherKey_mskIamRegression() {
+        // When neither sasl.jaas.config nor sasl.login.callback.handler.class is set,
+        // the properties must be identical to the previous behaviour (empty block).
+        // This preserves AWS MSK IAM which relies on its own classpath-provided login module.
+        final var props = new Properties();
+
+        final var credentials = mock(Credentials.class);
+        when(credentials.securityProtocol()).thenReturn(SecurityProtocol.SASL_SSL);
+        when(credentials.SASLMechanism()).thenReturn("OAUTHBEARER");
+        when(credentials.SASLJaasConfig()).thenReturn(null);
+        when(credentials.SASLLoginCallbackHandlerClass()).thenReturn(null);
+        when(credentials.caCertificates()).thenReturn(null);
+
+        KafkaClientsAuth.attachCredentials(props, credentials);
+
+        assertThat(props.getProperty(SaslConfigs.SASL_MECHANISM)).isEqualTo("OAUTHBEARER");
+        assertThat(props).doesNotContainKey(SaslConfigs.SASL_JAAS_CONFIG);
+        assertThat(props).doesNotContainKey(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS);
+    }
+
+    @Test
+    public void shouldConfigureOauthbearerWithOnlyHandlerClass() {
+        final var props = new Properties();
+        final var handlerClass = "com.example.MyOAuthHandler";
+
+        final var credentials = mock(Credentials.class);
+        when(credentials.securityProtocol()).thenReturn(SecurityProtocol.SASL_SSL);
+        when(credentials.SASLMechanism()).thenReturn("OAUTHBEARER");
+        when(credentials.SASLJaasConfig()).thenReturn(null);
+        when(credentials.SASLLoginCallbackHandlerClass()).thenReturn(handlerClass);
+        when(credentials.caCertificates()).thenReturn(null);
+
+        KafkaClientsAuth.attachCredentials(props, credentials);
+
+        assertThat(props.getProperty(SaslConfigs.SASL_MECHANISM)).isEqualTo("OAUTHBEARER");
+        assertThat(props).doesNotContainKey(SaslConfigs.SASL_JAAS_CONFIG);
+        assertThat(props.getProperty(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS))
+                .isEqualTo(handlerClass);
+    }
+
+    @Test
+    public void shouldIgnoreHandlerClassOnNonOauthbearerMechanism() {
+        // If sasl.login.callback.handler.class is set but mechanism is SCRAM, warn and ignore.
+        final var props = new Properties();
+
+        final var credentials = mock(Credentials.class);
+        when(credentials.securityProtocol()).thenReturn(SecurityProtocol.SASL_SSL);
+        when(credentials.SASLMechanism()).thenReturn("SCRAM-SHA-512");
+        when(credentials.SASLUsername()).thenReturn("user");
+        when(credentials.SASLPassword()).thenReturn("pass");
+        when(credentials.SASLLoginCallbackHandlerClass()).thenReturn("com.example.Handler");
+        when(credentials.caCertificates()).thenReturn(null);
+
+        KafkaClientsAuth.attachCredentials(props, credentials);
+
+        // Handler class must NOT be set
+        assertThat(props).doesNotContainKey(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS);
+        // Normal SCRAM config must still work
+        assertThat(props.getProperty(SaslConfigs.SASL_MECHANISM)).isEqualTo("SCRAM-SHA-512");
+        assertThat(props.getProperty(SaslConfigs.SASL_JAAS_CONFIG)).contains("ScramLoginModule");
     }
 }

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentialsTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/KubernetesCredentialsTest.java
@@ -97,6 +97,53 @@ public class KubernetesCredentialsTest {
     }
 
     @Test
+    public void saslJaasConfigAndCallbackHandlerAreDecoded() {
+        final var data = Map.of(
+                KubernetesCredentials.SASL_MECHANISM, "OAUTHBEARER",
+                KubernetesCredentials.SASL_JAAS_CONFIG_KEY,
+                        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;",
+                KubernetesCredentials.SASL_LOGIN_CALLBACK_HANDLER_CLASS_KEY, "com.example.MyCallbackHandler");
+
+        final var credentials = getKubernetesCredentialsFromSecretData(data);
+
+        assertThat(credentials.SASLJaasConfig())
+                .isEqualTo("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
+        assertThat(credentials.SASLLoginCallbackHandlerClass()).isEqualTo("com.example.MyCallbackHandler");
+    }
+
+    @Test
+    public void saslJaasConfigAndCallbackHandlerAbsentReturnNull() {
+        final var data = Map.of(KubernetesCredentials.SASL_MECHANISM, "OAUTHBEARER");
+
+        final var credentials = getKubernetesCredentialsFromSecretData(data);
+
+        assertThat(credentials.SASLJaasConfig()).isNull();
+        assertThat(credentials.SASLLoginCallbackHandlerClass()).isNull();
+    }
+
+    @Test
+    public void saslJaasConfigAndCallbackHandlerNullOnNullSecret() {
+        final Secret secret = null;
+        final var credentials = new KubernetesCredentials(secret);
+
+        assertThat(credentials.SASLJaasConfig()).isNull();
+        assertThat(credentials.SASLLoginCallbackHandlerClass()).isNull();
+    }
+
+    @Test
+    public void saslJaasConfigAndCallbackHandlerNullOnNullSecretData() {
+        final var credentials = new KubernetesCredentials(new SecretBuilder()
+                .withNewMetadata()
+                .withNamespace("ns1")
+                .withName("name1")
+                .endMetadata()
+                .build());
+
+        assertThat(credentials.SASLJaasConfig()).isNull();
+        assertThat(credentials.SASLLoginCallbackHandlerClass()).isNull();
+    }
+
+    @Test
     public void unknownSecurityProtocolReturnsNull() {
         final var data = Map.of(KubernetesCredentials.SECURITY_PROTOCOL, "SASSO_PLAINTEXT");
 

--- a/docs/channel/README.md
+++ b/docs/channel/README.md
@@ -87,8 +87,10 @@ implementations.
     - `type`: Can be one of `PLAIN`, `OAUTHBEARER`, `SCRAM-SHA-256` or `SCRAM-SHA-512`. See Apache Kafka [SASL configuration documentation](https://kafka.apache.org/documentation/#security_sasl_config) for more information.
     - `user`: Username to use in the authentication context. See Apache Kafka [SASL configuration documentation](https://kafka.apache.org/documentation/#security_sasl_config) for more information.
     - `password`: Password to use in the authentication context. See Apache Kafka [SASL configuration documentation](https://kafka.apache.org/documentation/#security_sasl_config) for more information.
-    - `tokenProvider`: Name of the OAuth token provider. Only `MSKAccessTokenProvider` and `MSKRoleAccessTokenProvider` currently supported. Required for `OAUTHBEARER`. See Apache Kafka [SASL configuration documentation](https://kafka.apache.org/documentation/#security_sasl_config) for more information.
+    - `tokenProvider`: Name of the OAuth token provider. Only `MSKAccessTokenProvider` and `MSKRoleAccessTokenProvider` currently supported. Required for `OAUTHBEARER` **when using the Go control-plane token provider (AWS MSK)**. See Apache Kafka [SASL configuration documentation](https://kafka.apache.org/documentation/#security_sasl_config) for more information.
     - `roleARN`: ARN of the AWS IAM role to assume. Required for `OAUTHBEARER` and `MSKRoleAccessTokenProvider`.
+    - `sasl.jaas.config`: Full JAAS configuration string for the Kafka client. Optional, applies only when `sasl.mechanism=OAUTHBEARER`. Used by the Java data plane to configure a custom login module (e.g. for Azure Event Hubs, Keycloak, Confluent OIDC). Ignored by the Go control plane.
+    - `sasl.login.callback.handler.class`: Fully qualified class name of an `AuthenticateCallbackHandler` that provides OAuth tokens. Optional, applies only when `sasl.mechanism=OAUTHBEARER`. The class must be present on the data-plane classpath (not shipped by this project). Ignored by the Go control plane.
 
     For using encryption, these values must exist in the secret:
     - `ca.crt`: Certificate authority certificate. See Apache Kafka [SSL configuration documentation](https://kafka.apache.org/documentation/#security_ssl) for more information.
@@ -155,7 +157,26 @@ implementations.
       auth.secret.ref.namespace: knative-eventing
     ```
 
-7. If using `sasl.mechanism: OAUTHBEARER`, update java properties for the data plane.
+7. If using `sasl.mechanism: OAUTHBEARER`, configure the data plane.
+
+    **Option A: Via the auth secret (recommended when the callback handler jar is on the data-plane classpath)**
+
+    Add `sasl.jaas.config` and `sasl.login.callback.handler.class` directly in the auth secret:
+    ```sh
+    kubectl create secret --namespace knative-eventing generic kafka-auth-secret \
+      --from-literal=protocol="SASL_SSL" \
+      --from-literal=sasl.mechanism="OAUTHBEARER" \
+      --from-literal=sasl.jaas.config="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required scope=\"https://<namespace>.servicebus.windows.net/.default\";" \
+      --from-literal=sasl.login.callback.handler.class="io.conduktor.kafka.security.oauthbearer.azure.AzureManagedIdentityCallbackHandler"
+    ```
+
+    This is the cleanest approach: all auth configuration lives in a single Secret.
+
+    > **Note:** The callback handler class is not shipped with this project. You must build a
+    > derived data-plane image that includes the handler jar on the classpath. See the
+    > [Azure Event Hubs example](#azure-event-hubs-with-managed-identity) below.
+
+    **Option B: Via ConfigMap properties (fallback / legacy)**
 
     The following java properties files need sasl properties set:
     1. config-kafka-source-producer.properties
@@ -559,3 +580,71 @@ This will save you additional HTTP hops, from channel to broker and broker to ch
 
 - [Namespace dispatchers](https://github.com/knative-extensions/eventing-kafka/blob/main/pkg/channel/consolidated/README.md#namespace-dispatchers)
   are not supported at the moment.
+
+## Azure Event Hubs with Managed Identity
+
+This section describes how to use Azure Event Hubs (Kafka-compatible) with
+OAUTHBEARER authentication via Azure Workload Identity. No static credentials
+(SAS keys) are required.
+
+### Prerequisites
+
+- AKS cluster with OIDC Issuer and Workload Identity enabled
+- Azure Event Hubs namespace (Standard or Premium)
+- Managed Identity with `Azure Event Hubs Data Owner` role on the namespace
+- Federated credential trusting the AKS OIDC issuer for the data-plane ServiceAccount
+
+### 1. Build a derived data-plane image
+
+The callback handler jar is **not** shipped with this project. You must add it
+to the data-plane classpath. Example using the
+[Conduktor Azure OAUTHBEARER handler](https://github.com/conduktor/azure-kafka-oauthbearer):
+
+```dockerfile
+FROM gcr.io/knative-releases/knative.dev/eventing-kafka-broker/cmd/receiver@sha256:<digest>
+COPY azure-kafka-oauthbearer-0.5.0.jar /app/libs/
+RUN echo "/app/libs/azure-kafka-oauthbearer-0.5.0.jar" >> /app/jib-classpath-file
+```
+
+Repeat for the dispatcher image.
+
+### 2. Create the auth secret
+
+```sh
+kubectl create secret --namespace knative-eventing generic kafka-auth-secret \
+  --from-literal=protocol="SASL_SSL" \
+  --from-literal=sasl.mechanism="OAUTHBEARER" \
+  --from-literal=sasl.jaas.config="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required scope=\"https://<namespace>.servicebus.windows.net/.default\";" \
+  --from-literal=sasl.login.callback.handler.class="io.conduktor.kafka.security.oauthbearer.azure.AzureManagedIdentityCallbackHandler"
+```
+
+### 3. Configure Workload Identity
+
+Annotate the data-plane ServiceAccount and label pods:
+
+```sh
+kubectl annotate serviceaccount knative-kafka-broker-data-plane \
+  -n knative-eventing \
+  azure.workload.identity/client-id="<MANAGED_IDENTITY_CLIENT_ID>" \
+  --overwrite
+
+kubectl label serviceaccount knative-kafka-broker-data-plane \
+  -n knative-eventing \
+  azure.workload.identity/use=true --overwrite
+```
+
+Patch the dispatcher StatefulSet and receiver Deployment to add the pod label
+`azure.workload.identity/use=true` so the mutating webhook injects
+`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_FEDERATED_TOKEN_FILE`.
+
+### 4. Known limitations
+
+- **Control-plane limitation:** The Go control plane cannot use a Java callback
+  handler. When `tokenProvider` is absent from the secret, the control plane
+  configures SASL/OAUTHBEARER as enabled but without a token provider. This means
+  the control plane cannot produce/consume directly from Event Hubs. This is
+  acceptable because the control plane only manages configuration — the data plane
+  handles all Kafka traffic.
+- **Token refresh:** Azure tokens expire after ~1 hour. The Kafka client's built-in
+  re-authentication (Kafka 2.2+) handles refresh transparently, provided the callback
+  handler returns fresh tokens on each invocation.


### PR DESCRIPTION
Fixes #4759

## Summary
When `sasl.mechanism=OAUTHBEARER`, `KafkaClientsAuth.java` currently returns early without setting `sasl.jaas.config` or `sasl.login.callback.handler.class`. The Kafka client is left with the default `OAuthBearerLoginModule`, which has no way to obtain a token — so the only working OAUTHBEARER path today is AWS MSK IAM, whose IAMLoginModule is bundled on the classpath.

This PR adds a vendor-neutral passthrough: when those two keys are present in the auth secret, they are propagated verbatim to the Kafka client. This unblocks standard OAUTHBEARER providers (Azure Event Hubs via Entra ID / Workload Identity, Keycloak, etc.) without adding any vendor dependency to the project. When the keys are absent, behaviour is unchanged.

## Changes
### Data plane (Java)

- Credentials: add default methods `SASLJaasConfig()` and `SASLLoginCallbackHandlerClass()` (both return null by default — no behaviour change for existing implementations).
KubernetesCredentials: resolve the two new optional secret keys (sasl.jaas.config, sasl.login.callback.handler.class), base64-decoded and lazily cached.
- KafkaClientsAuth: in the OAUTHBEARER branch, set SASL_JAAS_CONFIG / SASL_LOGIN_CALLBACK_HANDLER_CLASS only when provided. Also logs a warning if a callback handler class is set on a non-OAUTHBEARER mechanism (likely misconfiguration).

### Control plane (Go)
`secret.go`: tolerate OAUTHBEARER secrets without tokenProvider. The new keys are consumed by the Java data plane only; the Go side ignores them without error.

## Docs 
New "Azure Event Hubs with Managed Identity" guide (derived data-plane image, secret format, Workload Identity setup) plus secret-based auth notes.

## What this does NOT do
No vendor code or dependencies added — the callback handler jar (e.g. the Conduktor Azure handler) must be supplied by the operator on the data-plane classpath via a derived image.
The Go control plane cannot use a Java callback handler; when tokenProvider is absent it enables SASL/OAUTHBEARER without a Go-native token provider. This is acceptable — the control plane only manages configuration; the data plane handles all Kafka traffic.

## Testing
Added KafkaClientsAuthTest cases covering:
both keys set → both propagated;
neither key set → identical to prior behaviour (MSK IAM regression guard);
only handler class set → only handler propagated;
handler class on a SCRAM mechanism → ignored (+ warning), normal SCRAM config intact.

Java + Go tests pass on the branch.

## Backward compatibility
Fully backward compatible. The new secret keys are optional; absent them, both planes behave exactly as before (verified by the MSK IAM regression test).